### PR TITLE
Added libceed download option to PETSc Docker build.

### DIFF
--- a/tools/Dockerfile.petsc
+++ b/tools/Dockerfile.petsc
@@ -54,6 +54,7 @@ RUN git clone --branch=main https://gitlab.com/petsc/petsc && \
     --download-exodusii \
     --download-fblaslapack \
     --download-hdf5 \
+    --download-libceed \
     --download-metis \
     --download-netcdf \
     --download-parmetis \


### PR DESCRIPTION
This PR updates the Dockerfile used to build PETSc in our blessed configuration, adding the `--download-libceed` option. The new image has already been pushed, so this PR will actually test its viability.