### PR TITLE
Updating PETSc Docker image tag.

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -14,7 +14,7 @@ jobs:
   # This job builds RDycore and runs our test suite.
   build:
     runs-on: ${{ matrix.os }}
-    container: coherellc/rdycore-petsc:v3.18.1
+    container: coherellc/rdycore-petsc:2291d37ff9f
 
     # A build matrix storing all desired configurations.
     strategy:


### PR DESCRIPTION
This updates our Docker image to use a very recent version of PETSc `main`, which includes some necessary fixes to DMPlex.

Closes #11