### PR TITLE
Relaxes assumptions made about region and boundary IDs in mesh files

### DIFF
--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -200,5 +200,9 @@ typedef struct {
 
 } RDyConfig;
 
+PETSC_INTERN PetscErrorCode RDyConfigFindRegion(RDyConfig*, PetscInt, PetscInt*);
+PETSC_INTERN PetscErrorCode RDyConfigFindBoundary(RDyConfig*, PetscInt, PetscInt*);
+
+
 #endif
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -140,16 +140,24 @@ typedef struct {
   // initial conditions file (if given)
   char initial_conditions_file[PETSC_MAX_PATH_LEN];
 
-  // table of initial conditions mapping region IDs to names of conditions
+  // IDs of all regions mentioned in an input file
+  PetscInt num_regions;
+  PetscInt region_ids[MAX_NUM_REGIONS];
+
+  // IDs of all boundaries mentioned in an input file
+  PetscInt num_boundaries;
+  PetscInt boundary_ids[MAX_NUM_BOUNDARIES];
+
+  // table of initial conditions mapping regions to names of conditions
   // (unless file above is given)
   PetscInt         num_initial_conditions;
   RDyConditionSpec initial_conditions[MAX_NUM_REGIONS];
 
-  // table of sources/sinks mapping region IDs to names of conditions
+  // table of sources/sinks mapping regions to names of conditions
   PetscInt         num_sources;
   RDyConditionSpec sources[MAX_NUM_REGIONS];
 
-  // table of boundary conditions mapping boundary IDs to names of conditions
+  // table of boundary conditions mapping boundaries to names of conditions
   PetscInt         num_boundary_conditions;
   RDyConditionSpec boundary_conditions[MAX_NUM_BOUNDARIES];
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -9,15 +9,15 @@
 // https://rdycore.atlassian.net/wiki/spaces/PD/pages/24576001/RDycore+configuration+file
 //
 
-// the maximum region ID that can be defined on a domain
-#define MAX_REGION_ID 32
+// the maximum number of regions that can be defined on a domain
+#define MAX_NUM_REGIONS 32
 
-// the maximum boundary ID that can be defined on a domain
-#define MAX_BOUNDARY_ID 32
+// the maximum number of boundaries that can be defined on a domain
+#define MAX_NUM_BOUNDARIES 32
 
-// the maximum flow/sediment/salinity condition ID that can be defined for a
+// the maximum number of flow/sediment/salinity conditions that can be defined for a
 // simulation
-#define MAX_CONDITION_ID 32
+#define MAX_NUM_CONDITIONS 32
 
 // the maximum length of a string referring to a name in the config file
 #define MAX_NAME_LEN 128
@@ -143,23 +143,23 @@ typedef struct {
   // table of initial conditions mapping region IDs to names of conditions
   // (unless file above is given)
   PetscInt         num_initial_conditions;
-  RDyConditionSpec initial_conditions[1+MAX_REGION_ID];
+  RDyConditionSpec initial_conditions[MAX_NUM_REGIONS];
 
   // table of sources/sinks mapping region IDs to names of conditions
   PetscInt         num_sources;
-  RDyConditionSpec sources[1+MAX_REGION_ID];
+  RDyConditionSpec sources[MAX_NUM_REGIONS];
 
   // table of boundary conditions mapping boundary IDs to names of conditions
   PetscInt         num_boundary_conditions;
-  RDyConditionSpec boundary_conditions[1+MAX_BOUNDARY_ID];
+  RDyConditionSpec boundary_conditions[MAX_NUM_BOUNDARIES];
 
   // tables of named sets of flow, sediment, and salinity conditions
   PetscInt             num_flow_conditions;
-  RDyFlowCondition     flow_conditions[1+MAX_CONDITION_ID];
+  RDyFlowCondition     flow_conditions[MAX_NUM_CONDITIONS];
   PetscInt             num_sediment_conditions;
-  RDySedimentCondition sediment_conditions[1+MAX_CONDITION_ID];
+  RDySedimentCondition sediment_conditions[MAX_NUM_CONDITIONS];
   PetscInt             num_salinity_conditions;
-  RDySalinityCondition salinity_conditions[1+MAX_CONDITION_ID];
+  RDySalinityCondition salinity_conditions[MAX_NUM_CONDITIONS];
 
   //--------------
   // Timestepping

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -432,36 +432,6 @@ static PetscErrorCode InitBoundaries(RDy rdy) {
   PetscFunctionReturn(0);
 }
 
-// this helper finds the index of a region ID within a configuration, setting it
-// to -1 if not found
-static PetscErrorCode FindRegionIndex(MPI_Comm comm, RDyConfig *config, PetscInt id, PetscInt *index) {
-  PetscFunctionBegin;
-
-  *index = -1;
-  for (PetscInt r = 0; r < config->num_regions; ++r) {
-    if (config->region_ids[r] == id) {
-      *index = r;
-      break;
-    }
-  }
-  PetscFunctionReturn(0);
-}
-
-// this helper finds the index of a region ID within a configuration, setting it
-// to -1 if not found
-static PetscErrorCode FindBoundaryIndex(MPI_Comm comm, RDyConfig *config, PetscInt id, PetscInt *index) {
-  PetscFunctionBegin;
-
-  *index = -1;
-  for (PetscInt b = 0; b < config->num_boundaries; ++b) {
-    if (config->boundary_ids[b] == id) {
-      *index = b;
-      break;
-    }
-  }
-  PetscFunctionReturn(0);
-}
-
 // checks the validity of initial/boundary conditions and sources
 static PetscErrorCode InitConditionsAndSources(RDy rdy) {
   PetscFunctionBegin;
@@ -475,7 +445,7 @@ static PetscErrorCode InitConditionsAndSources(RDy rdy) {
       RDyCondition *ic        = &rdy->initial_conditions[r];
       PetscInt      region_id = rdy->region_ids[r];
       PetscInt      ic_region_index;
-      PetscCall(FindRegionIndex(rdy->comm, &rdy->config, region_id, &ic_region_index));
+      PetscCall(RDyConfigFindRegion(&rdy->config, region_id, &ic_region_index));
       PetscCheck(ic_region_index != -1, rdy->comm, PETSC_ERR_USER, "Region %d has no initial conditions!", region_id);
 
       RDyConditionSpec *ic_spec = &rdy->config.initial_conditions[ic_region_index];
@@ -517,7 +487,7 @@ static PetscErrorCode InitConditionsAndSources(RDy rdy) {
       RDyCondition *src       = &rdy->sources[r];
       PetscInt      region_id = rdy->region_ids[r];
       PetscInt      src_region_index;
-      PetscCall(FindRegionIndex(rdy->comm, &rdy->config, region_id, &src_region_index));
+      PetscCall(RDyConfigFindRegion(&rdy->config, region_id, &src_region_index));
       if (src_region_index != -1) {
         RDyConditionSpec *src_spec = &rdy->config.sources[src_region_index];
         if (strlen(src_spec->flow_name)) {
@@ -569,7 +539,7 @@ static PetscErrorCode InitConditionsAndSources(RDy rdy) {
     RDyCondition *bc          = &rdy->boundary_conditions[b];
     PetscInt      boundary_id = rdy->boundary_ids[b];
     PetscInt      bc_boundary_index;
-    PetscCall(FindBoundaryIndex(rdy->comm, &rdy->config, boundary_id, &bc_boundary_index));
+    PetscCall(RDyConfigFindBoundary(&rdy->config, boundary_id, &bc_boundary_index));
     if (bc_boundary_index != -1) {
       RDyConditionSpec *bc_spec = &rdy->config.boundary_conditions[bc_boundary_index];
 

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -331,7 +331,7 @@ static PetscErrorCode InitBoundaries(RDy rdy) {
   DMLabel label;
   PetscCall(DMGetLabel(rdy->dm, "Face Sets", &label));
   PetscInt        num_boundaries = 0;
-  IS              boundary_id_is;
+  IS              boundary_id_is = NULL;
   const PetscInt *boundary_ids;
   if (label) {  // found face sets!
     PetscCall(DMLabelGetNumValues(label, &num_boundaries));
@@ -403,7 +403,9 @@ static PetscErrorCode InitBoundaries(RDy rdy) {
         PetscInt num_edges;
         PetscCall(ISGetLocalSize(edge_is, &num_edges));
         if (num_edges > 0) {
-          RDyLogDebug(rdy, "  Found boundary %d (%d edges)", boundary_id, num_edges);
+          if (boundary_id != unassigned_edge_boundary_id) {
+            RDyLogDebug(rdy, "  Found boundary %d (%d edges)", boundary_id, num_edges);
+          }
           boundary->num_edges = num_edges;
           PetscCall(RDyAlloc(PetscInt, boundary->num_edges, &boundary->edge_ids));
         }
@@ -418,8 +420,10 @@ static PetscErrorCode InitBoundaries(RDy rdy) {
         PetscCall(ISDestroy(&edge_is));
       }
     }
-    PetscCall(ISRestoreIndices(boundary_id_is, &boundary_ids));
-    PetscCall(ISDestroy(&boundary_id_is));
+    if (boundary_id_is) {
+      PetscCall(ISRestoreIndices(boundary_id_is, &boundary_ids));
+      PetscCall(ISDestroy(&boundary_id_is));
+    }
   }
 
   // make sure we have at least one region and boundary

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -513,7 +513,7 @@ static PetscErrorCode InitConditionsAndSources(RDy rdy) {
 
   // Set up a reflecting flow boundary condition.
   RDyFlowCondition *reflecting_flow = NULL;
-  for (PetscInt c = 0; c <= MAX_NUM_CONDITIONS; ++c) {
+  for (PetscInt c = 0; c < MAX_NUM_CONDITIONS; ++c) {
     if (!strlen(rdy->config.flow_conditions[c].name)) {
       reflecting_flow = &rdy->config.flow_conditions[c];
       strcpy((char *)reflecting_flow->name, "reflecting");

--- a/src/read_config_file.c
+++ b/src/read_config_file.c
@@ -126,16 +126,16 @@ static PetscErrorCode CloseSection(YamlParserState *state, RDyConfig *config) {
     // handle some special cases in conditions sections first
     if (state->section == FLOW_CONDITIONS_SECTION) {
       config->num_flow_conditions++;
-      PetscCheck(config->num_flow_conditions <= MAX_CONDITION_ID, state->comm, PETSC_ERR_USER,
-                 "Maximum flow condition ID (%d) exceeded (increase MAX_CONDITION_ID)", MAX_CONDITION_ID);
+      PetscCheck(config->num_flow_conditions <= MAX_NUM_CONDITIONS, state->comm, PETSC_ERR_USER,
+                 "Maximum number of flow conditions (%d) exceeded (increase MAX_NUM_CONDITIONS)", MAX_NUM_CONDITIONS);
     } else if (state->section == SEDIMENT_CONDITIONS_SECTION) {
       config->num_sediment_conditions++;
-      PetscCheck(config->num_sediment_conditions <= MAX_CONDITION_ID, state->comm, PETSC_ERR_USER,
-                 "Maximum number of sediment condition ID (%d) exceeded (increase (MAX_CONDITION_ID)", MAX_CONDITION_ID);
+      PetscCheck(config->num_sediment_conditions <= MAX_NUM_CONDITIONS, state->comm, PETSC_ERR_USER,
+                 "Maximum number of sediment conditions (%d) exceeded (increase (MAX_NUM_CONDITIONS)", MAX_NUM_CONDITIONS);
     } else if (state->section == SALINITY_CONDITIONS_SECTION) {
       config->num_salinity_conditions++;
-      PetscCheck(config->num_salinity_conditions <= MAX_CONDITION_ID, state->comm, PETSC_ERR_USER,
-                 "Maximum number of salinity condition ID (%d) exceeded (increase MAX_CONDITION_ID)", MAX_CONDITION_ID);
+      PetscCheck(config->num_salinity_conditions <= MAX_NUM_CONDITIONS, state->comm, PETSC_ERR_USER,
+                 "Maximum number of salinity conditions (%d) exceeded (increase MAX_NUM_CONDITIONS)", MAX_NUM_CONDITIONS);
     }
     state->inside_subsection = PETSC_FALSE;
     state->subsection[0]     = 0;


### PR DESCRIPTION
Previously, I made some assumptions about region IDs ("values" in the "Cell Sets" label) and boundary IDs ("values" in the "Face Sets" label) that evidently didn't hold in general. This PR relaxes those assumptions and queries these labels for the proper IDs.

Also, because @bishtgautam and I discussed it in the same conversation, this PR includes a mild refactor of our enforcement of boundary conditions for the SWE Riemann solver, which makes it clear how to add new types of boundary conditions.