### PR TITLE
Minor updates to support verification runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+build/
+*.code-workspace
+

--- a/driver/tests/swe_roe/ex2b_ic_file.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file.yaml
@@ -14,7 +14,7 @@ logging:
   level: debug
 
 time:
-  final_time: 0.005
+  dtime: 0.005
   unit: hours
   max_step: 1000
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -188,6 +188,8 @@ typedef struct {
   RDyTimeUnit time_unit;
   // Maximum number of time steps
   PetscInt max_step;
+  // Time step
+  PetscReal dtime;
 
   //----------
   // Restarts

--- a/src/physics_swe.c
+++ b/src/physics_swe.c
@@ -674,9 +674,11 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
   // write out debugging info for maximum courant number
   if (rdy->config.log_level >= LOG_DEBUG) {
     MPI_Allreduce(MPI_IN_PLACE, &courant_num_diags, 1, courant_num_diags_type, courant_num_diags_op, rdy->comm);
-    PetscReal dt;
-    PetscCall(TSGetTimeStep(ts, &dt));
-    RDyLogDebug(rdy, "Max courant number %g encountered at edge %d of cell %d is %f", courant_num_diags.max_courant_num,
+    PetscReal time;
+    PetscInt  stepnum;
+    PetscCall(TSGetTime(ts, &time));
+    PetscCall(TSGetStepNumber(ts, &stepnum));
+    RDyLogDebug(rdy, "[%d] Time = %f Max courant number %g encountered at edge %d of cell %d is %f", stepnum, time, courant_num_diags.max_courant_num,
                 courant_num_diags.global_edge_id, courant_num_diags.global_cell_id, courant_num_diags.max_courant_num);
   }
   rdy->step++;

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -722,7 +722,7 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   PetscReal final_time_in_sec = ConvertTimeToSeconds(rdy->config.final_time, rdy->config.time_unit);
   PetscCall(TSSetMaxTime(rdy->ts, final_time_in_sec));
   PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.max_step));
-  PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_STEPOVER));
+  PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
   PetscCall(TSSetSolution(rdy->ts, rdy->X));
   PetscCall(TSSetTimeStep(rdy->ts, rdy->dt));
 

--- a/src/read_config_file.c
+++ b/src/read_config_file.c
@@ -1041,7 +1041,7 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config) {
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Can only specify time.final_time or time.max_step in the .yaml file");
     }
     if (config->max_step == UNINITIALIZED_INT && config->dtime == UNINITIALIZED_REAL) {
-      PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Need to spcicify time.final_time or time.max_step in the .yaml file");
+      PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Need to specify time.final_time or time.max_step in the .yaml file");
     }
     if (config->max_step == UNINITIALIZED_INT) config->max_step = (PetscInt)(config->final_time / config->dtime);
     if (config->dtime == UNINITIALIZED_REAL) config->dtime = config->final_time / config->max_step;

--- a/src/read_config_file.c
+++ b/src/read_config_file.c
@@ -1038,7 +1038,7 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config) {
     config->final_time = config->max_step * config->dtime;
   } else {
     if (config->max_step != UNINITIALIZED_INT && config->dtime != UNINITIALIZED_REAL) {
-      PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Can only spcicify time.final_time or time.max_step in the .yaml file");
+      PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Can only specify time.final_time or time.max_step in the .yaml file");
     }
     if (config->max_step == UNINITIALIZED_INT && config->dtime == UNINITIALIZED_REAL) {
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Need to spcicify time.final_time or time.max_step in the .yaml file");

--- a/src/read_config_file.c
+++ b/src/read_config_file.c
@@ -20,6 +20,8 @@
 //
 // the maximum length of an identifier or value in the YAML file
 #define YAML_MAX_LEN 1024
+#define UNINITIALIZED_REAL -999.0
+#define UNINITIALIZED_INT -999
 
 // This enum defines the different sections in our configuration file.
 typedef enum {
@@ -363,7 +365,7 @@ static PetscErrorCode ParseTime(yaml_event_t *event, YamlParserState *state, RDy
 
   if (!strlen(state->parameter)) {  // parameter not set
     PetscInt selection;
-    SelectItem(value, 3, (const char *[3]){"final_time", "unit", "max_step"}, (PetscInt[3]){0, 1, 2}, &selection);
+    SelectItem(value, 4, (const char *[4]){"final_time", "unit", "max_step", "dtime"}, (PetscInt[4]){0, 1, 2, 3}, &selection);
     PetscCheck(selection != -1, state->comm, PETSC_ERR_USER, "Invalid parameter in time: %s", value);
     strncpy(state->parameter, value, YAML_MAX_LEN);
   } else {  // parameter set, get value
@@ -376,9 +378,12 @@ static PetscErrorCode ParseTime(yaml_event_t *event, YamlParserState *state, RDy
                  (PetscInt[6]){TIME_SECONDS, TIME_MINUTES, TIME_HOURS, TIME_DAYS, TIME_MONTHS, TIME_YEARS}, &selection);
       PetscCheck(selection != -1, state->comm, PETSC_ERR_USER, "Invalid time.unit: %s", value);
       config->time_unit = selection;
-    } else {  // max_step
+    } else if (!strcmp(state->parameter, "max_step")) {
       PetscCall(ConvertToInt(state->comm, state->parameter, value, &config->max_step));
       PetscCheck((config->max_step >= 0), state->comm, PETSC_ERR_USER, "invalid time.max_step: %d\n", config->max_step);
+    } else if (!strcmp(state->parameter, "dtime")) {
+      PetscCall(ConvertToReal(state->comm, state->parameter, value, &config->dtime));
+      PetscCheck((config->dtime > 0.0), state->comm, PETSC_ERR_USER, "invalid time.dtime: %g\n", config->dtime);
     }
     state->parameter[0] = 0;  // clear parameter name
   }
@@ -981,6 +986,10 @@ static PetscErrorCode InitConfig(RDyConfig *config) {
   // RDy struct. So all we need to do is initialize anything that shouldn't be
   // zero.
 
+  config->final_time = UNINITIALIZED_REAL;
+  config->dtime      = UNINITIALIZED_REAL;
+  config->max_step   = UNINITIALIZED_INT;
+
   // initialize boundary conditions so we can determine whether they are
   // properly set after parsing
   for (PetscInt i = 0; i < MAX_NUM_CONDITIONS; ++i) {
@@ -1002,10 +1011,10 @@ static PetscErrorCode InitConfig(RDyConfig *config) {
 }
 
 // checks config for any invalid or omitted parameters
-static PetscErrorCode ValidateConfig(MPI_Comm comm, const RDyConfig *config) {
+static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config) {
   PetscFunctionBegin;
 
-  // currently, only certain methods are implemented
+  // check 'Numerics' settings
   if (config->spatial != SPATIAL_FV) {
     PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Only the finite volume spatial method (FV) is currently implemented.");
   }
@@ -1017,6 +1026,26 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, const RDyConfig *config) {
   }
 
   PetscCheck(strlen(config->mesh_file), comm, PETSC_ERR_USER, "grid.file not specified!");
+
+  // check 'Timestepping' settings
+  // 'final_time', 'max_step', 'dtime': Only two of the three values can be specified in the .yaml file.
+  if (config->final_time == UNINITIALIZED_REAL) {
+    if (!(config->max_step != UNINITIALIZED_INT && config->dtime != UNINITIALIZED_REAL)) {
+      PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER,
+                 "time.final_time could be determined.\n  - time.final_time was not specified, and\n  - both time.final_time and time.max_step were "
+                 "also not specified");
+    }
+    config->final_time = config->max_step * config->dtime;
+  } else {
+    if (config->max_step != UNINITIALIZED_INT && config->dtime != UNINITIALIZED_REAL) {
+      PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Can only spcicify time.final_time or time.max_step in the .yaml file");
+    }
+    if (config->max_step == UNINITIALIZED_INT && config->dtime == UNINITIALIZED_REAL) {
+      PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Need to spcicify time.final_time or time.max_step in the .yaml file");
+    }
+    if (config->max_step == UNINITIALIZED_INT) config->max_step = (PetscInt)(config->final_time / config->dtime);
+    if (config->dtime == UNINITIALIZED_REAL) config->dtime = config->final_time / config->max_step;
+  }
 
   // we can accept an initial conditions file OR a set of initial conditions,
   // but not both

--- a/src/write_output.c
+++ b/src/write_output.c
@@ -49,7 +49,10 @@ PetscErrorCode DetermineOutputFile(RDy rdy, PetscInt step, PetscReal time, const
   // encode specific information into the filename based on its format
   char ending[PETSC_MAX_PATH_LEN];
   if (rdy->config.output_format == OUTPUT_BINARY) {  // PETSc native binary format
-    snprintf(ending, PETSC_MAX_PATH_LEN - 1, ".%s", suffix);
+    int  num_digits = (int)(log10((double)rdy->config.max_step)) + 1;
+    char fmt[16]    = {0};
+    snprintf(fmt, 15, "-%%0%dd.%%s", num_digits);
+    snprintf(ending, PETSC_MAX_PATH_LEN - 1, fmt, step, suffix);
   } else if (rdy->config.output_format == OUTPUT_XDMF) {
     if (!strcasecmp(suffix, "h5")) {  // XDMF "heavy" data
       // for now we assume all output data goes into a single HDF5 file


### PR DESCRIPTION
- Adds the option to specify `dtime`. Now, among the following three timestepping-related 
variables, two need to be specified in the yaml file and the third is computed as:
```
final_time = max_steps * dtime
max_steps = final_time / dtime
dtime = final_time / max_steps
```

- The binary output filename is modified to be like `DamBreak_grid250x500-*.dat` instead of 
`DamBreak_grid250x500.dat`. This would avoid overwriting the binary output.

- Changes the `TSSetExactFinalTime` from `TS_EXACTFINALTIME_STEPOVER` to 
`TS_EXACTFINALTIME_MATCHSTEP`.