### PR TITLE
Switching submodules to SSH clone method.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "external/cmocka"]
 	path = external/cmocka
-	url = https://git.cryptomilk.org/projects/cmocka.git
+	url = git@github.com:clibs/cmocka.git
 [submodule "external/libyaml"]
 	path = external/libyaml
-	url = https://github.com/yaml/libyaml.git
+	url = git@github.com:yaml/libyaml.git
 [submodule "external/libcyaml"]
 	path = external/libcyaml
 	url = git@github.com:tlsa/libcyaml.git


### PR DESCRIPTION
Because of a recent change to PNNL's IT security policy, cloning repos with the HTTPS method has become taboo. This PR switchs our submodules to use SSH instead.