### PR TITLE
Adds an interface for coupling with a client application (ELM)

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -53,8 +53,8 @@ int main(int argc, char *argv[]) {
       PetscCheck(time > prev_time, comm, PETSC_ERR_USER, "Non-increasing time!");
       PetscCheck(time_step > 0.0, comm, PETSC_ERR_USER, "Non-positive time step!");
 
-      PetscCheck(fabs(time - prev_time + coupling_interval) < 1e-12, comm, PETSC_ERR_USER,
-        "RDyAdvance advanced time improperly!");
+      PetscCheck(fabs(time - prev_time - coupling_interval) < 1e-12, comm, PETSC_ERR_USER,
+        "RDyAdvance advanced time improperly (%g, %g, %g)!", prev_time, time, fabs(time - prev_time + coupling_interval));
       prev_time += coupling_interval;
 
       PetscInt step;

--- a/driver/tests/swe_roe/ex2b_ic_file.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file.yaml
@@ -14,7 +14,7 @@ logging:
   level: detail
 
 time:
-  dtime: 0.005
+  time_step: 0.005
   unit: hours
   max_step: 1000
 

--- a/driver/tests/swe_roe/four_mounds_60x24.yaml
+++ b/driver/tests/swe_roe/four_mounds_60x24.yaml
@@ -16,7 +16,7 @@ logging:
 time:
   final_time: 0.5
   unit: seconds
-  dtime: 0.020
+  time_step: 0.020
 
 grid:
   file: four_mounds_60x24.exo

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -101,10 +101,11 @@ typedef enum { TIME_SECONDS = 0, TIME_MINUTES, TIME_HOURS, TIME_DAYS, TIME_MONTH
 
 // all time parameters
 typedef struct {
-  PetscReal   final_time;  // final simulation time [unit]
-  RDyTimeUnit unit;        // unit in which time is expressed
-  PetscInt    max_step;    // maximum number of simulation time steps
-  PetscReal   dtime;       // time step [unit]
+  PetscReal   final_time;        // final simulation time [unit]
+  RDyTimeUnit unit;              // unit in which time is expressed
+  PetscInt    max_step;          // maximum number of simulation time steps
+  PetscReal   time_step;         // minimum internal time step [unit]
+  PetscReal   coupling_interval; // time interval spanned by RDyAdvance
 } RDyTimeSection;
 
 // ---------------

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -101,11 +101,11 @@ typedef enum { TIME_SECONDS = 0, TIME_MINUTES, TIME_HOURS, TIME_DAYS, TIME_MONTH
 
 // all time parameters
 typedef struct {
-  PetscReal   final_time;        // final simulation time [unit]
-  RDyTimeUnit unit;              // unit in which time is expressed
-  PetscInt    max_step;          // maximum number of simulation time steps
-  PetscReal   time_step;         // minimum internal time step [unit]
-  PetscReal   coupling_interval; // time interval spanned by RDyAdvance
+  PetscReal   final_time;         // final simulation time [unit]
+  RDyTimeUnit unit;               // unit in which time is expressed
+  PetscInt    max_step;           // maximum number of simulation time steps
+  PetscReal   time_step;          // minimum internal time step [unit]
+  PetscReal   coupling_interval;  // time interval spanned by RDyAdvance
 } RDyTimeSection;
 
 // ---------------

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -112,8 +112,9 @@ struct _p_RDy {
   // time step size
   PetscReal dt;
 
-  // index of current timestep
-  PetscInt step;
+  // time and index of current timestep
+  PetscReal t;
+  PetscInt  step;
 
   // time₋stepping solver
   TS ts;

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -33,9 +33,9 @@ PETSC_EXTERN PetscErrorCode RDyRun(RDy);
 PETSC_EXTERN PetscErrorCode RDyDestroy(RDy*);
 
 // Accessing data
-PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy*, PetscInt*);
-PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy*, PetscReal*);
-PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy*, PetscReal*);
-PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy*, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy, PetscReal*);
 
 #endif

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -26,13 +26,17 @@ PETSC_EXTERN PetscErrorCode RDyOnFinalize(void (*)(void));
 PETSC_EXTERN PetscErrorCode RDyFinalize(void);
 PETSC_EXTERN PetscBool RDyInitialized(void);
 
-// RDycore setup/run/breakdown
+// RDycore setup/step/breakdown
 PETSC_EXTERN PetscErrorCode RDyCreate(MPI_Comm, const char*, RDy*);
 PETSC_EXTERN PetscErrorCode RDySetup(RDy);
-PETSC_EXTERN PetscErrorCode RDyRun(RDy);
+PETSC_EXTERN PetscErrorCode RDyAdvance(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyDestroy(RDy*);
 
 // Accessing data
+PETSC_EXTERN PetscBool      RDyFinished(RDy);
+PETSC_EXTERN PetscErrorCode RDyGetTime(RDy, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetTimeStep(RDy, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetStep(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -32,4 +32,10 @@ PETSC_EXTERN PetscErrorCode RDySetup(RDy);
 PETSC_EXTERN PetscErrorCode RDyRun(RDy);
 PETSC_EXTERN PetscErrorCode RDyDestroy(RDy*);
 
+// Accessing data
+PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy*, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy*, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy*, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy*, PetscReal*);
+
 #endif

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -26,17 +26,20 @@ PETSC_EXTERN PetscErrorCode RDyOnFinalize(void (*)(void));
 PETSC_EXTERN PetscErrorCode RDyFinalize(void);
 PETSC_EXTERN PetscBool RDyInitialized(void);
 
-// RDycore setup/step/breakdown
+// RDycore setup/breakdown
 PETSC_EXTERN PetscErrorCode RDyCreate(MPI_Comm, const char*, RDy*);
 PETSC_EXTERN PetscErrorCode RDySetup(RDy);
-PETSC_EXTERN PetscErrorCode RDyAdvance(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyDestroy(RDy*);
+
+// time integration
+PETSC_EXTERN PetscErrorCode RDyAdvance(RDy);
 
 // Accessing data
 PETSC_EXTERN PetscBool      RDyFinished(RDy);
 PETSC_EXTERN PetscErrorCode RDyGetTime(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetTimeStep(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetStep(RDy, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(rdycore
   rdycore.c
   physics_swe.c
   print_config.c
+  rdydata.c
   rdymesh.c
   rdyrun.c
   rdysetup.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(rdycore
   print_config.c
   rdydata.c
   rdymesh.c
-  rdyrun.c
+  rdyadvance.c
   rdysetup.c
   write_xdmf_output.c
 )

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -8,7 +8,9 @@ module rdycore
   implicit none
 
   public :: RDy, RDyInit, RDyFinalize, RDyInitialized, &
-            RDyCreate, RDySetup, RDyRun, RDyDestroy
+            RDyCreate, RDySetup, RDyRun, RDyDestroy, &
+            RDyGetNumLocalCells, RDyGetHeight, &
+            RDyGetXVelocity, RDyGetYVelocity
 
   type :: RDy
     ! C pointer to RDy type
@@ -40,6 +42,30 @@ module rdycore
     integer(c_int) function rdysetup_(rdy) bind(c, name="RDySetup")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
+    end function
+
+    integer(c_int) function rdygetnumlocalcells_(rdy, num_cells) bind(c, name="RDyGetNumLocalCells")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr),    value, intent(in)  :: rdy
+      integer(c_int),        intent(out) :: num_cells
+    end function
+
+    integer(c_int) function rdygetheight(rdy, h) bind(c, name="RDyGetHeight")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr), value, intent(in)    :: rdy
+      type(c_ptr), value, intent(inout) :: h
+    end function
+
+    integer(c_int) function rdygetxvelocity(rdy, vx) bind(c, name="RDyGetXVelocity")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr), value, intent(in)    :: rdy
+      type(c_ptr), value, intent(inout) :: vx
+    end function
+
+    integer(c_int) function rdygetyvelocity(rdy, h) bind(c, name="RDyGetYVelocity")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr), value, intent(in)    :: rdy
+      type(c_ptr), value, intent(inout) :: vy
     end function
 
     integer(c_int) function rdyrun_(rdy) bind(c, name="RDyRun")
@@ -93,6 +119,34 @@ contains
     type(RDy), intent(inout) :: rdy_
     integer,   intent(out)   :: ierr
     ierr = rdysetup_(rdy_%c_rdy)
+  end subroutine
+
+  subroutine RDyGetNumLocalCells(rdy_, num_cells, ierr)
+    type(RDy), intent(inout) :: rdy_
+    integer,   intent(out)   :: num_cells
+    integer,   intent(out)   :: ierr
+    ierr = rdygetnumlocalcells_(rdy_%c_rdy, num_cells)
+  end subroutine
+
+  subroutine RDyGetHeight(rdy_, h, ierr)
+    type(RDy),          intent(inout) :: rdy_
+    real,      pointer, intent(inout) :: h
+    integer,            intent(out)   :: ierr
+    ierr = rdygetheight(rdy_%c_rdy, c_loc(h))
+  end subroutine
+
+  subroutine RDyGetXVelocity(rdy_, vx, ierr)
+    type(RDy),          intent(inout) :: rdy_
+    real,      pointer, intent(inout) :: vx
+    integer,            intent(out)   :: ierr
+    ierr = rdygetxvelocity(rdy_%c_rdy, c_loc(vx))
+  end subroutine
+
+  subroutine RDyGetYVelocity(rdy_, vy, ierr)
+    type(RDy),          intent(inout) :: rdy_
+    real,      pointer, intent(inout) :: vy
+    integer,            intent(out)   :: ierr
+    ierr = rdygetyvelocity(rdy_%c_rdy, c_loc(vy))
   end subroutine
 
   subroutine RDyRun(rdy_, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -50,22 +50,22 @@ module rdycore
       integer(c_int),        intent(out) :: num_cells
     end function
 
-    integer(c_int) function rdygetheight(rdy, h) bind(c, name="RDyGetHeight")
+    integer(c_int) function rdygetheight_(rdy, h) bind(c, name="RDyGetHeight")
       use iso_c_binding, only: c_int, c_ptr
-      type(c_ptr), value, intent(in)    :: rdy
-      type(c_ptr), value, intent(inout) :: h
+      type(c_ptr), value, intent(in) :: rdy
+      type(c_ptr), value, intent(in) :: h
     end function
 
-    integer(c_int) function rdygetxvelocity(rdy, vx) bind(c, name="RDyGetXVelocity")
+    integer(c_int) function rdygetxvelocity_(rdy, vx) bind(c, name="RDyGetXVelocity")
       use iso_c_binding, only: c_int, c_ptr
-      type(c_ptr), value, intent(in)    :: rdy
-      type(c_ptr), value, intent(inout) :: vx
+      type(c_ptr), value, intent(in) :: rdy
+      type(c_ptr), value, intent(in) :: vx
     end function
 
-    integer(c_int) function rdygetyvelocity(rdy, h) bind(c, name="RDyGetYVelocity")
+    integer(c_int) function rdygetyvelocity_(rdy, vy) bind(c, name="RDyGetYVelocity")
       use iso_c_binding, only: c_int, c_ptr
-      type(c_ptr), value, intent(in)    :: rdy
-      type(c_ptr), value, intent(inout) :: vy
+      type(c_ptr), value, intent(in) :: rdy
+      type(c_ptr), value, intent(in) :: vy
     end function
 
     integer(c_int) function rdyrun_(rdy) bind(c, name="RDyRun")
@@ -132,21 +132,21 @@ contains
     type(RDy),          intent(inout) :: rdy_
     real,      pointer, intent(inout) :: h
     integer,            intent(out)   :: ierr
-    ierr = rdygetheight(rdy_%c_rdy, c_loc(h))
+    ierr = rdygetheight_(rdy_%c_rdy, c_loc(h))
   end subroutine
 
   subroutine RDyGetXVelocity(rdy_, vx, ierr)
     type(RDy),          intent(inout) :: rdy_
     real,      pointer, intent(inout) :: vx
     integer,            intent(out)   :: ierr
-    ierr = rdygetxvelocity(rdy_%c_rdy, c_loc(vx))
+    ierr = rdygetxvelocity_(rdy_%c_rdy, c_loc(vx))
   end subroutine
 
   subroutine RDyGetYVelocity(rdy_, vy, ierr)
     type(RDy),          intent(inout) :: rdy_
     real,      pointer, intent(inout) :: vy
     integer,            intent(out)   :: ierr
-    ierr = rdygetyvelocity(rdy_%c_rdy, c_loc(vy))
+    ierr = rdygetyvelocity_(rdy_%c_rdy, c_loc(vy))
   end subroutine
 
   subroutine RDyRun(rdy_, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -8,7 +8,7 @@ module rdycore
   implicit none
 
   public :: RDy, RDyInit, RDyFinalize, RDyInitialized, &
-            RDyCreate, RDySetup, RDyRun, RDyDestroy, &
+            RDyCreate, RDySetup, RDyAdvance, RDyDestroy, &
             RDyGetNumLocalCells, RDyGetHeight, &
             RDyGetXVelocity, RDyGetYVelocity
 
@@ -50,6 +50,24 @@ module rdycore
       integer(c_int),        intent(out) :: num_cells
     end function
 
+    integer(c_int) function rdygettime_(rdy, time) bind(c, name="RDyGetTime")
+      use iso_c_binding, only: c_int, c_ptr, c_double
+      type(c_ptr),    value, intent(in)  :: rdy
+      real(c_double),        intent(out) :: time
+    end function
+
+    integer(c_int) function rdygettimestep_(rdy, dt) bind(c, name="RDyGetTimeStep")
+      use iso_c_binding, only: c_int, c_ptr, c_double
+      type(c_ptr),    value, intent(in)  :: rdy
+      real(c_double),        intent(out) :: dt
+    end function
+
+    integer(c_int) function rdygetstep_(rdy, step) bind(c, name="RDyGetStep")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr),    value, intent(in)  :: rdy
+      integer(c_int),        intent(out) :: step
+    end function
+
     integer(c_int) function rdygetheight_(rdy, h) bind(c, name="RDyGetHeight")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
@@ -68,7 +86,7 @@ module rdycore
       type(c_ptr), value, intent(in) :: vy
     end function
 
-    integer(c_int) function rdyrun_(rdy) bind(c, name="RDyRun")
+    integer(c_int) function rdyadvance_(rdy) bind(c, name="RDyAdvance")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
     end function
@@ -128,6 +146,27 @@ contains
     ierr = rdygetnumlocalcells_(rdy_%c_rdy, num_cells)
   end subroutine
 
+  subroutine RDyGetTime(rdy_, time, ierr)
+    type(RDy),      intent(inout) :: rdy_
+    real(c_double), intent(out)   :: time
+    integer,        intent(out)   :: ierr
+    ierr = rdygettime_(rdy_%c_rdy, time)
+  end subroutine
+
+  subroutine RDyGetTimeStep(rdy_, timestep, ierr)
+    type(RDy),      intent(inout) :: rdy_
+    real(c_double), intent(out)   :: timestep
+    integer,        intent(out)   :: ierr
+    ierr = rdygettimestep_(rdy_%c_rdy, timestep)
+  end subroutine
+
+  subroutine RDyGetStep(rdy_, step, ierr)
+    type(RDy), intent(inout) :: rdy_
+    integer,   intent(out)   :: step
+    integer,   intent(out)   :: ierr
+    ierr = rdygetstep_(rdy_%c_rdy, step)
+  end subroutine
+
   subroutine RDyGetHeight(rdy_, h, ierr)
     type(RDy),          intent(inout) :: rdy_
     real,      pointer, intent(inout) :: h
@@ -149,10 +188,10 @@ contains
     ierr = rdygetyvelocity_(rdy_%c_rdy, c_loc(vy))
   end subroutine
 
-  subroutine RDyRun(rdy_, ierr)
+  subroutine RDyAdvance(rdy_, ierr)
     type(RDy), intent(inout) :: rdy_
     integer,   intent(out)   :: ierr
-    ierr = rdyrun_(rdy_%c_rdy)
+    ierr = rdyadvance_(rdy_%c_rdy)
   end subroutine
 
   subroutine RDyDestroy(rdy_, ierr)

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -1,0 +1,44 @@
+#include <private/rdycoreimpl.h>
+#include <rdycore.h>
+
+PetscErrorCode RDyGetNumLocalCells(RDy *rdy, PetscInt *num_cells) {
+  PetscFunctionBegin;
+  *num_cells = rdy->mesh.num_cells_local;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode RDyGetHeight(RDy *rdy, PetscReal *h) {
+  PetscFunctionBegin;
+
+  PetscReal *x;
+  PetscCall(VecGetArray(rdy->X, &x));
+  for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
+    h[i] = x[3*i];
+  }
+  PetscCall(VecRestoreArray(rdy->X, &x);
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode RDyGetXVelocity(RDy *rdy, PetscReal *vx) {
+  PetscFunctionBegin;
+
+  PetscReal *x;
+  PetscCall(VecGetArray(rdy->X, &x));
+  for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
+    vx[i] = x[3*i+1];
+  }
+  PetscCall(VecRestoreArray(rdy->X, &x);
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode RDyGetYVelocity(RDy *rdy, PetscReal *vy) {
+  PetscFunctionBegin;
+
+  PetscReal *x;
+  PetscCall(VecGetArray(rdy->X, &x));
+  for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
+    vy[i] = x[3*i+2];
+  }
+  PetscCall(VecRestoreArray(rdy->X, &x);
+  PetscFunctionReturn(0);
+}

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -13,7 +13,7 @@ PetscErrorCode RDyGetHeight(RDy rdy, PetscReal *h) {
   PetscReal *x;
   PetscCall(VecGetArray(rdy->X, &x));
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
-    h[i] = x[3*i];
+    h[i] = x[3 * i];
   }
   PetscCall(VecRestoreArray(rdy->X, &x));
   PetscFunctionReturn(0);
@@ -25,7 +25,7 @@ PetscErrorCode RDyGetXVelocity(RDy rdy, PetscReal *vx) {
   PetscReal *x;
   PetscCall(VecGetArray(rdy->X, &x));
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
-    vx[i] = x[3*i+1];
+    vx[i] = x[3 * i + 1];
   }
   PetscCall(VecRestoreArray(rdy->X, &x));
   PetscFunctionReturn(0);
@@ -37,7 +37,7 @@ PetscErrorCode RDyGetYVelocity(RDy rdy, PetscReal *vy) {
   PetscReal *x;
   PetscCall(VecGetArray(rdy->X, &x));
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
-    vy[i] = x[3*i+2];
+    vy[i] = x[3 * i + 2];
   }
   PetscCall(VecRestoreArray(rdy->X, &x));
   PetscFunctionReturn(0);

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -1,13 +1,13 @@
 #include <private/rdycoreimpl.h>
 #include <rdycore.h>
 
-PetscErrorCode RDyGetNumLocalCells(RDy *rdy, PetscInt *num_cells) {
+PetscErrorCode RDyGetNumLocalCells(RDy rdy, PetscInt *num_cells) {
   PetscFunctionBegin;
   *num_cells = rdy->mesh.num_cells_local;
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode RDyGetHeight(RDy *rdy, PetscReal *h) {
+PetscErrorCode RDyGetHeight(RDy rdy, PetscReal *h) {
   PetscFunctionBegin;
 
   PetscReal *x;
@@ -15,11 +15,11 @@ PetscErrorCode RDyGetHeight(RDy *rdy, PetscReal *h) {
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
     h[i] = x[3*i];
   }
-  PetscCall(VecRestoreArray(rdy->X, &x);
+  PetscCall(VecRestoreArray(rdy->X, &x));
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode RDyGetXVelocity(RDy *rdy, PetscReal *vx) {
+PetscErrorCode RDyGetXVelocity(RDy rdy, PetscReal *vx) {
   PetscFunctionBegin;
 
   PetscReal *x;
@@ -27,11 +27,11 @@ PetscErrorCode RDyGetXVelocity(RDy *rdy, PetscReal *vx) {
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
     vx[i] = x[3*i+1];
   }
-  PetscCall(VecRestoreArray(rdy->X, &x);
+  PetscCall(VecRestoreArray(rdy->X, &x));
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode RDyGetYVelocity(RDy *rdy, PetscReal *vy) {
+PetscErrorCode RDyGetYVelocity(RDy rdy, PetscReal *vy) {
   PetscFunctionBegin;
 
   PetscReal *x;
@@ -39,6 +39,6 @@ PetscErrorCode RDyGetYVelocity(RDy *rdy, PetscReal *vy) {
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
     vy[i] = x[3*i+2];
   }
-  PetscCall(VecRestoreArray(rdy->X, &x);
+  PetscCall(VecRestoreArray(rdy->X, &x));
   PetscFunctionReturn(0);
 }

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -860,8 +860,6 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   PetscCall(InitSWE(rdy));  // initialize SWE physics
   PetscCall(TSSetRHSFunction(rdy->ts, rdy->R, RHSFunctionSWE, rdy));
 
-  PetscReal final_time_in_sec = ConvertTimeToSeconds(rdy->config.time.final_time, rdy->config.time.unit);
-  PetscCall(TSSetMaxTime(rdy->ts, final_time_in_sec));
   PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.time.max_step));
   PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
   PetscCall(TSSetSolution(rdy->ts, rdy->X));

--- a/src/read_config_file.c
+++ b/src/read_config_file.c
@@ -548,10 +548,9 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config) {
   if (config->time.coupling_interval == INVALID_REAL) {
     config->time.coupling_interval = config->time.final_time;
   } else {
-    PetscCheck(config->time.coupling_interval > 0.0,
-      comm, PETSC_ERR_USER, "time.coupling_interval must be positive");
-    PetscCheck(config->time.coupling_interval <= config->time.final_time,
-      comm, PETSC_ERR_USER, "time.coupling_interval must not exceed time.final_time");
+    PetscCheck(config->time.coupling_interval > 0.0, comm, PETSC_ERR_USER, "time.coupling_interval must be positive");
+    PetscCheck(config->time.coupling_interval <= config->time.final_time, comm, PETSC_ERR_USER,
+               "time.coupling_interval must not exceed time.final_time");
   }
 
   // we need either a domain initial condition or region-by-region conditions


### PR DESCRIPTION
This PR adds some functions and changes some existing ones to make it possible to couple with a client application (ELM, in our case) in a way that is specified in the input configuration file. The driver code and tests have been updated to reflect these changes.

## New features

A new parameter, `coupling_interval` has been added as a parameter to the `time` section of the config file. This parameter determines how often data exchanges occur between RDycore and the client. If no coupling interval is specified, this parameter is set to the final solution time, meaning no coupling is performed for the duration of the entire simulation.

The following functions have been added to allow a client to retrieve data from RDycore:

* `PetscBool RDyFinished(RDy)` - returns true if RDycore has completed its simulation according to the specified parameters
* `PetscErrorCode RDyGetTime(RDy, PetscReal*)` - returns the simulation time in units specified in the config file
* `PetscErrorCode RDyGetTimeStep(RDy, PetscReal*)` - returns the internal time step used by RDycore in units specified in the config file
* `PetscErrorCode RDyGetStep(RDy, PetscInt*)` - returns the index of RDycore's current (internal) time step
* `PetscErrorCode RDyGetCouplingInterval(RDy, PetscReal*)` - returns the specified coupling interval that determines how often the client and RDycore exchange data
* `PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*)` - returns the number of locally-owned cells on the current process for RDycore
* `PetscErrorCode RDyGetHeight(RDy, PetscReal*)` - fills a given array (capable of storing the number of locally-owned cells) with height solution data
* `PetscErrorCode RDyGetXVelocity(RDy, PetscReal*)` - fills a given array (capable of storing the number of locally-owned cells) with x velocity solution data
* `PetscErrorCode RDyGetYVelocity(RDy, PetscReal*)` - fills a given array (capable of storing the number of locally-owned cells) with y velocity solution data

Also, I've attempted to add [preloading](https://github.com/RDycore/RDycore/issues/57) to the time integrator. I'm not sure how best to test this.

## Changes to existing features

* `RDyRun` has been renamed to `RDyAdvance`, and now advances the solution by the coupling interval instead of running it to completion. If no coupling interval has been specified, `RDyAdvance` behaves the same way as `RDyRun` did.
* the `dtime` parameter in the `time` section has been renamed to `time_step`, and represents the maximum internal time step size used to integrate the solution.

Closes #57 
Closes #58 