### PR TITLE
Adds a source-term to SWE.

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -31,10 +31,11 @@ int main(int argc, char *argv[]) {
     // allocate arrays for inspecting simulation data
     PetscInt n;
     PetscCall(RDyGetNumLocalCells(rdy, &n));
-    PetscReal *h, *vx, *vy;
+    PetscReal *h, *vx, *vy, *rain;
     PetscCalloc1(n * sizeof(PetscReal), &h);
     PetscCalloc1(n * sizeof(PetscReal), &vx);
     PetscCalloc1(n * sizeof(PetscReal), &vy);
+    PetscCalloc1(n * sizeof(PetscReal), &rain);
 
     // run the simulation to completion using the time parameters in the
     // config file
@@ -42,6 +43,11 @@ int main(int argc, char *argv[]) {
     RDyGetTime(rdy, &prev_time);
     RDyGetCouplingInterval(rdy, &coupling_interval);
     while (!RDyFinished(rdy)) { // returns true based on stopping criteria
+
+      // apply a 1 mm/hr rain over the entire domain
+      for (PetscInt icell=0; icell < n; icell++) rain[icell] = 1.0/3600.0/1000.0; // mm/hr --> m/s
+      PetscCall(RDySetWaterSource(rdy, rain));
+
       // advance the solution by the coupling interval specified in the config file
       PetscCall(RDyAdvance(rdy));
 
@@ -70,6 +76,7 @@ int main(int argc, char *argv[]) {
     PetscFree(h);
     PetscFree(vx);
     PetscFree(vy);
+    PetscFree(rain);
     PetscCall(RDyDestroy(&rdy));
   }
 

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -122,7 +122,7 @@ struct _p_RDy {
   Vec R;
 
   // source-sink vector
-  Vec S;
+  Vec WaterSrc;
 
   //-------------------
   // Simulatіon output

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -122,7 +122,7 @@ struct _p_RDy {
   Vec R;
 
   // source-sink vector
-  Vec WaterSrc;
+  Vec water_src;
 
   //-------------------
   // Simulatіon output

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -121,6 +121,9 @@ struct _p_RDy {
   // residual vector
   Vec R;
 
+  // source-sink vector
+  Vec S;
+
   //-------------------
   // Simulatіon output
   //-------------------

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -45,5 +45,6 @@ PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDySetWaterSource(RDy, PetscReal*);
 
 #endif

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -95,6 +95,12 @@ module rdycore
       type(c_ptr), value, intent(in) :: vy
     end function
 
+    integer(c_int) function rdysetwatersource_(rdy, watsrc) bind(c, name="RDySetWaterSource")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr), value, intent(in) :: rdy
+      type(c_ptr), value, intent(in) :: watsrc
+    end function
+
     integer(c_int) function rdyadvance_(rdy) bind(c, name="RDyAdvance")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
@@ -207,6 +213,13 @@ contains
     real(RDyDouble), pointer, intent(inout) :: vy(:)
     integer,         intent(out)            :: ierr
     ierr = rdygetyvelocity_(rdy_%c_rdy, c_loc(vy))
+  end subroutine
+
+  subroutine RDySetWaterSource(rdy_, watsrc, ierr)
+    type(RDy),       intent(inout)       :: rdy_
+    real(RDyDouble), pointer, intent(in) :: watsrc(:)
+    integer,         intent(out)         :: ierr
+    ierr = rdysetwatersource_(rdy_%c_rdy, c_loc(watsrc))
   end subroutine
 
   subroutine RDyAdvance(rdy_, ierr)

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -47,10 +47,10 @@ PetscErrorCode RDySetWaterSource(RDy rdy, PetscReal *watsrc) {
   PetscFunctionBegin;
 
   PetscReal *s;
-  PetscCall(VecGetArray(rdy->WaterSrc, &s));
+  PetscCall(VecGetArray(rdy->water_src, &s));
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
     s[i] = watsrc[i];
   }
-  PetscCall(VecRestoreArray(rdy->WaterSrc, &s));
+  PetscCall(VecRestoreArray(rdy->water_src, &s));
   PetscFunctionReturn(0);
 }

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -47,10 +47,10 @@ PetscErrorCode RDySetWaterSource(RDy rdy, PetscReal *watsrc) {
   PetscFunctionBegin;
 
   PetscReal *s;
-  PetscCall(VecGetArray(rdy->S, &s));
+  PetscCall(VecGetArray(rdy->WaterSrc, &s));
   for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
-    s[3 * i] = watsrc[i];
+    s[i] = watsrc[i];
   }
-  PetscCall(VecRestoreArray(rdy->S, &s));
+  PetscCall(VecRestoreArray(rdy->WaterSrc, &s));
   PetscFunctionReturn(0);
 }

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -42,3 +42,15 @@ PetscErrorCode RDyGetYVelocity(RDy rdy, PetscReal *vy) {
   PetscCall(VecRestoreArray(rdy->X, &x));
   PetscFunctionReturn(0);
 }
+
+PetscErrorCode RDySetWaterSource(RDy rdy, PetscReal *watsrc) {
+  PetscFunctionBegin;
+
+  PetscReal *s;
+  PetscCall(VecGetArray(rdy->S, &s));
+  for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
+    s[3 * i] = watsrc[i];
+  }
+  PetscCall(VecRestoreArray(rdy->S, &s));
+  PetscFunctionReturn(0);
+}

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -833,6 +833,7 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   // set up vectors
   PetscCall(DMCreateGlobalVector(rdy->dm, &rdy->X));
   PetscCall(VecDuplicate(rdy->X, &rdy->R));
+  PetscCall(VecDuplicate(rdy->X, &rdy->S));
   PetscCall(VecViewFromOptions(rdy->X, NULL, "-vec_view"));
   PetscCall(DMCreateLocalVector(rdy->dm, &rdy->X_local));
 

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -833,9 +833,10 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   // set up vectors
   PetscCall(DMCreateGlobalVector(rdy->dm, &rdy->X));
   PetscCall(VecDuplicate(rdy->X, &rdy->R));
-  PetscCall(VecDuplicate(rdy->X, &rdy->S));
   PetscCall(VecViewFromOptions(rdy->X, NULL, "-vec_view"));
   PetscCall(DMCreateLocalVector(rdy->dm, &rdy->X_local));
+
+  PetscCall(DMCreateGlobalVector(rdy->aux_dm, &rdy->WaterSrc));
 
   PetscInt n_dof;
   PetscCall(VecGetSize(rdy->X, &n_dof));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -836,7 +836,7 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   PetscCall(VecViewFromOptions(rdy->X, NULL, "-vec_view"));
   PetscCall(DMCreateLocalVector(rdy->dm, &rdy->X_local));
 
-  PetscCall(DMCreateGlobalVector(rdy->aux_dm, &rdy->WaterSrc));
+  PetscCall(DMCreateGlobalVector(rdy->aux_dm, &rdy->water_src));
 
   PetscInt n_dof;
   PetscCall(VecGetSize(rdy->X, &n_dof));

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -495,9 +495,9 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
   RDyCells *cells = &mesh->cells;
 
   // Get access to Vec
-  PetscScalar *x_ptr, *f_ptr, *s_ptr;
+  PetscScalar *x_ptr, *f_ptr, *watersrc_ptr;
   PetscCall(VecGetArray(rdy->X_local, &x_ptr));
-  PetscCall(VecGetArray(rdy->S, &s_ptr));
+  PetscCall(VecGetArray(rdy->WaterSrc, &watersrc_ptr));
   PetscCall(VecGetArray(F, &f_ptr));
 
   PetscInt ndof;
@@ -558,7 +558,7 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
         tby = (hv + dt * Fsum_y - dt * bedy) * factor;
       }
 
-      f_ptr[icell * ndof + 0] += s_ptr[icell * ndof];
+      f_ptr[icell * ndof + 0] += watersrc_ptr[icell];
       f_ptr[icell * ndof + 1] += -bedx - tbx;
       f_ptr[icell * ndof + 2] += -bedy - tby;
     }
@@ -566,7 +566,7 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
 
   // Restore vectors
   PetscCall(VecRestoreArray(rdy->X_local, &x_ptr));
-  PetscCall(VecRestoreArray(rdy->S, &s_ptr));
+  PetscCall(VecRestoreArray(rdy->WaterSrc, &watersrc_ptr));
   PetscCall(VecRestoreArray(F, &f_ptr));
 
   PetscCall(RiemannDataSWEDestroy(data));

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -495,8 +495,9 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
   RDyCells *cells = &mesh->cells;
 
   // Get access to Vec
-  PetscScalar *x_ptr, *f_ptr;
+  PetscScalar *x_ptr, *f_ptr, *s_ptr;
   PetscCall(VecGetArray(rdy->X_local, &x_ptr));
+  PetscCall(VecGetArray(rdy->S, &s_ptr));
   PetscCall(VecGetArray(F, &f_ptr));
 
   PetscInt ndof;
@@ -557,7 +558,7 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
         tby = (hv + dt * Fsum_y - dt * bedy) * factor;
       }
 
-      f_ptr[icell * ndof + 0] += 0.0;
+      f_ptr[icell * ndof + 0] += s_ptr[icell * ndof];
       f_ptr[icell * ndof + 1] += -bedx - tbx;
       f_ptr[icell * ndof + 2] += -bedy - tby;
     }
@@ -565,6 +566,7 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
 
   // Restore vectors
   PetscCall(VecRestoreArray(rdy->X_local, &x_ptr));
+  PetscCall(VecRestoreArray(rdy->S, &s_ptr));
   PetscCall(VecRestoreArray(F, &f_ptr));
 
   PetscCall(RiemannDataSWEDestroy(data));

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -495,9 +495,9 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
   RDyCells *cells = &mesh->cells;
 
   // Get access to Vec
-  PetscScalar *x_ptr, *f_ptr, *watersrc_ptr;
+  PetscScalar *x_ptr, *f_ptr, *water_src_ptr;
   PetscCall(VecGetArray(rdy->X_local, &x_ptr));
-  PetscCall(VecGetArray(rdy->WaterSrc, &watersrc_ptr));
+  PetscCall(VecGetArray(rdy->water_src, &water_src_ptr));
   PetscCall(VecGetArray(F, &f_ptr));
 
   PetscInt ndof;
@@ -558,7 +558,7 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
         tby = (hv + dt * Fsum_y - dt * bedy) * factor;
       }
 
-      f_ptr[icell * ndof + 0] += watersrc_ptr[icell];
+      f_ptr[icell * ndof + 0] += water_src_ptr[icell];
       f_ptr[icell * ndof + 1] += -bedx - tbx;
       f_ptr[icell * ndof + 2] += -bedy - tby;
     }
@@ -566,7 +566,7 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
 
   // Restore vectors
   PetscCall(VecRestoreArray(rdy->X_local, &x_ptr));
-  PetscCall(VecRestoreArray(rdy->WaterSrc, &watersrc_ptr));
+  PetscCall(VecRestoreArray(rdy->water_src, &water_src_ptr));
   PetscCall(VecRestoreArray(F, &f_ptr));
 
   PetscCall(RiemannDataSWEDestroy(data));


### PR DESCRIPTION
- Adds a water source/sink term in the SWE. The Vec to hold the water source/sink
  is a 1-DOF Vec.
- Adds function/subroutine for an external model (e.g., E3SM) to specify the water source/sink term.
- The source/sink term is currently only added in the PETSc-version of the code.
- The two drivers are updated to call the new function/subroutine.