### PR TITLE
Implemented boundary flux output

### DIFF
--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -19,8 +19,10 @@ time:
 
 output:
   format: xdmf
-  frequency: 100
+  interval: 100
   batch_size: 20
+  time_series:
+    boundary_fluxes: 10
 
 grid:
   file: planar_dam_10x5.msh

--- a/driver/tests/swe_roe/ex2b_ic_file.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file.yaml
@@ -21,7 +21,7 @@ time:
 
 output:
   format: xdmf
-  frequency: 100
+  interval: 100
 
 grid:
   file: DamBreak_grid5x10.exo

--- a/driver/tests/swe_roe/four_mounds_60x24.yaml
+++ b/driver/tests/swe_roe/four_mounds_60x24.yaml
@@ -34,6 +34,6 @@ initial_conditions:
 
 output:
   format: xdmf
-  frequency: 10
+  interval: 10
 
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -124,8 +124,8 @@ typedef struct {
 
 // all restart parameters
 typedef struct {
-  PetscViewerFormat format;     // file format
-  PetscInt          frequency;  // number of steps between restart dumps
+  PetscViewerFormat format;    // file format
+  PetscInt          interval;  // number of steps between restart dumps [steps]
 } RDyRestartSection;
 
 // ---------------
@@ -135,11 +135,17 @@ typedef struct {
 // output file formats
 typedef enum { OUTPUT_BINARY = 0, OUTPUT_XDMF, OUTPUT_CGNS } RDyOutputFormat;
 
+// time series output interval parameters appended to files
+typedef struct {
+  PetscInt boundary_fluxes; // written to "boundary_fluxes.dat" [steps between outputs]
+} RDyTimeSeries;
+
 // all output parameters
 typedef struct {
   RDyOutputFormat format;      // file format
-  PetscInt        frequency;   // frequency of output [steps]
+  PetscInt        interval;    // output interval [steps between outputs]
   PetscInt        batch_size;  // number of timesteps per output file (if available)
+  RDyTimeSeries   time_series; // time series appended to text (.dat) files
 } RDyOutputSection;
 
 // ------------

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -137,15 +137,15 @@ typedef enum { OUTPUT_BINARY = 0, OUTPUT_XDMF, OUTPUT_CGNS } RDyOutputFormat;
 
 // time series output interval parameters appended to files
 typedef struct {
-  PetscInt boundary_fluxes; // written to "boundary_fluxes.dat" [steps between outputs]
+  PetscInt boundary_fluxes;  // written to "boundary_fluxes.dat" [steps between outputs]
 } RDyTimeSeries;
 
 // all output parameters
 typedef struct {
-  RDyOutputFormat format;      // file format
-  PetscInt        interval;    // output interval [steps between outputs]
-  PetscInt        batch_size;  // number of timesteps per output file (if available)
-  RDyTimeSeries   time_series; // time series appended to text (.dat) files
+  RDyOutputFormat format;       // file format
+  PetscInt        interval;     // output interval [steps between outputs]
+  PetscInt        batch_size;   // number of timesteps per output file (if available)
+  RDyTimeSeries   time_series;  // time series appended to text (.dat) files
 } RDyOutputSection;
 
 // ------------

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -33,7 +33,21 @@ typedef struct {
 
   // value(s) associated with the condition
   PetscReal value;
+
+  // was this boundary condition automatically generated and not explicitly
+  // requested in the config file?
+  PetscBool auto_generated;
 } RDyCondition;
+
+// This type keeps track of accumulated time series data appended periodically
+// to files.
+typedef struct {
+  struct {
+    PetscReal water_mass;
+    PetscReal x_momentum;
+    PetscReal y_momentum;
+  } * boundary_fluxes;
+} RDyTimeSeriesData;
 
 // This type serves as a "virtual table" containing function pointers that
 // define the behavior of the dycore.
@@ -124,12 +138,18 @@ struct _p_RDy {
   // source-sink vector
   Vec water_src;
 
+  // time series bookkeeping
+  RDyTimeSeriesData time_series;
+
   //-------------------
   // Simulatіon output
   //-------------------
   PetscViewer           output_viewer;
   PetscViewerAndFormat *output_vf;
 
+  //--------------
+  // CEED support
+  //--------------
   char ceed_resource[PETSC_MAX_PATH_LEN];
   // RHS operator (optional)
   struct {
@@ -147,8 +167,14 @@ PETSC_INTERN PetscErrorCode RHSFunctionSWE(TS, PetscReal, Vec, Vec, void *);
 
 // output functions
 PETSC_INTERN PetscErrorCode CreateOutputDir(RDy);
+PETSC_INTERN PetscErrorCode GetOutputDir(RDy, char dir[PETSC_MAX_PATH_LEN]);
 PETSC_INTERN PetscErrorCode DetermineOutputFile(RDy, PetscInt, PetscReal, const char *, char *);
 PETSC_INTERN PetscErrorCode WriteXDMFOutput(TS, PetscInt, PetscReal, Vec, void *);
+
+// time series
+PETSC_INTERN PetscErrorCode InitTimeSeries(RDy);
+PETSC_INTERN PetscErrorCode WriteTimeSeries(TS, PetscInt, PetscReal, Vec, void *);
+PETSC_INTERN PetscErrorCode DestroyTimeSeries(RDy);
 
 // utility functions
 PETSC_INTERN const char *TimeUnitAsString(RDyTimeUnit);

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -42,11 +42,19 @@ typedef struct {
 // This type keeps track of accumulated time series data appended periodically
 // to files.
 typedef struct {
+  // fluxes on boundary edges
   struct {
-    PetscReal water_mass;
-    PetscReal x_momentum;
-    PetscReal y_momentum;
-  } * boundary_fluxes;
+    // numbers of local and global boundary edges on which fluxes are computed
+    PetscInt num_local_edges, num_global_edges;
+    // array of per-boundary offsets in local fluxes array below
+    PetscInt *offsets;
+    // local array of boundary fluxes
+    struct {
+      PetscReal water_mass;
+      PetscReal x_momentum;
+      PetscReal y_momentum;
+    } * fluxes;
+  } boundary_fluxes;
 } RDyTimeSeriesData;
 
 // This type serves as a "virtual table" containing function pointers that
@@ -173,6 +181,7 @@ PETSC_INTERN PetscErrorCode WriteXDMFOutput(TS, PetscInt, PetscReal, Vec, void *
 
 // time series
 PETSC_INTERN PetscErrorCode InitTimeSeries(RDy);
+PETSC_INTERN PetscErrorCode AccumulateBoundaryFluxes(RDy, RDyBoundary *, PetscInt ne, PetscReal[ne][3]);
 PETSC_INTERN PetscErrorCode WriteTimeSeries(TS, PetscInt, PetscReal, Vec, void *);
 PETSC_INTERN PetscErrorCode DestroyTimeSeries(RDy);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(rdycore
   rdymesh.c
   rdyadvance.c
   rdysetup.c
+  time_series.c
   write_xdmf_output.c
 )
 add_dependencies(rdycore cyaml yaml)

--- a/src/print_config.c
+++ b/src/print_config.c
@@ -52,7 +52,7 @@ static PetscErrorCode PrintTime(RDy rdy) {
 static PetscErrorCode PrintRestart(RDy rdy) {
   PetscFunctionBegin;
   RDyLogDetail(rdy, "Restart:");
-  if (rdy->config.restart.frequency > 0) {
+  if (rdy->config.restart.interval > 0) {
     char format[12];
     if (rdy->config.restart.format == PETSC_VIEWER_NATIVE) {
       strcpy(format, "binary");
@@ -60,7 +60,7 @@ static PetscErrorCode PrintRestart(RDy rdy) {
       strcpy(format, "hdf5");
     }
     RDyLogDetail(rdy, "  File format: %s", format);
-    RDyLogDetail(rdy, "  Frequency: %d", rdy->config.restart.frequency);
+    RDyLogDetail(rdy, "  interval: %d", rdy->config.restart.interval);
   } else {
     RDyLogDetail(rdy, "  (disabled)");
   }

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -78,9 +78,9 @@ PetscErrorCode DetermineOutputFile(RDy rdy, PetscInt step, PetscReal time, const
       } else {
         // output data is grouped into batches of a fixed number of time steps
         PetscInt batch_size = rdy->config.output.batch_size;
-        PetscInt freq       = rdy->config.output.frequency;
-        PetscInt batch      = step / freq / batch_size;
-        PetscInt max_batch  = rdy->config.time.max_step / freq / batch_size;
+        PetscInt interval   = rdy->config.output.interval;
+        PetscInt batch      = step / interval / batch_size;
+        PetscInt max_batch  = rdy->config.time.max_step / interval / batch_size;
         if (max_batch < 1) max_batch = 1;
         PetscCall(GenerateIndexedFilename(prefix, batch, max_batch, suffix, filename));
       }
@@ -109,11 +109,11 @@ static PetscErrorCode DestroyOutputViewer(RDy rdy) {
   PetscFunctionReturn(0);
 }
 
-// this writes a log message for output at the proper frequency
+// this writes a log message for output at the proper interval
 PetscErrorCode WriteOutputLogMessage(TS ts, PetscInt step, PetscReal time, Vec X, void *ctx) {
   PetscFunctionBegin;
   RDy rdy = ctx;
-  if (step % rdy->config.output.frequency == 0) {
+  if (step % rdy->config.output.interval == 0) {
     static const char *formats[3] = {"binary", "XDMF", "CGNS"};
     const char        *format     = formats[rdy->config.output.format];
     const char        *units      = TimeUnitAsString(rdy->config.time.unit);
@@ -130,8 +130,8 @@ static PetscErrorCode CreateOutputViewer(RDy rdy) {
   PetscFunctionBegin;
 
   PetscViewerFormat format = PETSC_VIEWER_DEFAULT;
-  if (rdy->config.output.frequency) {
-    RDyLogDebug(rdy, "Writing output every %d timestep(s)", rdy->config.output.frequency);
+  if (rdy->config.output.interval) {
+    RDyLogDebug(rdy, "Writing output every %d timestep(s)", rdy->config.output.interval);
     switch (rdy->config.output.format) {
       case OUTPUT_CGNS:
         // we've already configured this viewer in SetAdditionalOptions (see read_config_file.c)
@@ -206,7 +206,7 @@ PetscErrorCode RDyAdvance(RDy rdy) {
     PetscCall(CreateOutputDir(rdy));
 
     // set up monitoring functions for handling restarts and outputs
-    // if (rdy->config.restart_frequency) {
+    // if (rdy->config.restart.interval) {
     //   PetscCall(TSMonitorSet(rdy->ts, WriteRestartFiles, rdy, NULL));
     // }
 

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -154,7 +154,7 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   if ((*rdy)->X_local) VecDestroy(&((*rdy)->X_local));
 
   // destroy time series
-  PetscCall(DestroyTimeSeries(rdy));
+  PetscCall(DestroyTimeSeries(*rdy));
 
   // destroy DMs
   if ((*rdy)->aux_dm) DMDestroy(&((*rdy)->aux_dm));

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -148,9 +148,13 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   if ((*rdy)->ts) TSDestroy(&((*rdy)->ts));
 
   // destroy vectors
+  if ((*rdy)->water_src) VecDestroy(&((*rdy)->water_src));
   if ((*rdy)->R) VecDestroy(&((*rdy)->R));
   if ((*rdy)->X) VecDestroy(&((*rdy)->X));
   if ((*rdy)->X_local) VecDestroy(&((*rdy)->X_local));
+
+  // destroy time series
+  PetscCall(DestroyTimeSeries(rdy));
 
   // destroy DMs
   if ((*rdy)->aux_dm) DMDestroy(&((*rdy)->aux_dm));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -818,8 +818,10 @@ static PetscErrorCode InitBoundaryConditions(RDy rdy) {
         bc->salinity = &rdy->config.salinity_conditions[sal_index];
       }
     } else {
-      // set a reflecting BC on this boundary
-      bc->flow = reflecting_flow;
+      // this boundary wasn't explicitly requested, so set up an auto-generated
+      // reflecting BC
+      bc->flow           = reflecting_flow;
+      bc->auto_generated = PETSC_TRUE;
     }
   }
 

--- a/src/read_config_file.c
+++ b/src/read_config_file.c
@@ -166,7 +166,7 @@ static const cyaml_schema_field_t logging_fields_schema[] = {
 // ---------------
 // restart:
 //   format: <binary|hdf5>
-//   frequency: <value-in-steps>  # default: 0 (no restarts)
+//   interval: <value-in-steps>  # default: 0 (no restarts)
 
 // mapping of strings to file formats
 static const cyaml_strval_t restart_file_formats[] = {
@@ -177,7 +177,7 @@ static const cyaml_strval_t restart_file_formats[] = {
 // mapping of restart fields to members of RDyRestartSection
 static const cyaml_schema_field_t restart_fields_schema[] = {
     CYAML_FIELD_ENUM("format", CYAML_FLAG_DEFAULT, RDyRestartSection, format, restart_file_formats, CYAML_ARRAY_LEN(restart_file_formats)),
-    CYAML_FIELD_INT("frequency", CYAML_FLAG_DEFAULT, RDyRestartSection, frequency),
+    CYAML_FIELD_INT("interval", CYAML_FLAG_DEFAULT, RDyRestartSection, interval),
     CYAML_FIELD_END
 };
 
@@ -186,7 +186,7 @@ static const cyaml_schema_field_t restart_fields_schema[] = {
 // ---------------
 // output:
 //   format: <binary|xdmf|cgns>
-//   frequency: <number-of-steps-between-output-dumps> # default: 0 (no output)
+//   interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
 //   batch_size: <number-of-steps-stored-in-each-output-file> # default: 1
 
 // mapping of strings to file formats
@@ -196,11 +196,18 @@ static const cyaml_strval_t output_file_formats[] = {
     {"cgns",   OUTPUT_CGNS  },
 };
 
+// mapping of time_series fields to members of RDyTimeSeries
+static const cyaml_schema_field_t output_time_series_fields_schema[] = {
+    CYAML_FIELD_INT("boundary_fluxes", CYAML_FLAG_DEFAULT, RDyTimeSeries, boundary_fluxes),
+    CYAML_FIELD_END
+};
+
 // mapping of output fields to members of RDyOutputSection
 static const cyaml_schema_field_t output_fields_schema[] = {
     CYAML_FIELD_ENUM("format", CYAML_FLAG_DEFAULT, RDyOutputSection, format, output_file_formats, CYAML_ARRAY_LEN(output_file_formats)),
-    CYAML_FIELD_INT("frequency", CYAML_FLAG_DEFAULT, RDyOutputSection, frequency),
+    CYAML_FIELD_INT("interval", CYAML_FLAG_DEFAULT, RDyOutputSection, interval),
     CYAML_FIELD(INT, "batch_size", CYAML_FLAG_OPTIONAL, RDyOutputSection, batch_size, {.missing = 1}),
+    CYAML_FIELD_MAPPING("time_series", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_series, output_time_series_fields_schema),
     CYAML_FIELD_END
 };
 
@@ -610,10 +617,10 @@ static PetscErrorCode SetAdditionalOptions(RDy rdy) {
   //--------
 
   // set the solution monitoring interval (except for XDMF, which does its own thing)
-  if ((rdy->config.output.frequency > 0) && (rdy->config.output.format != OUTPUT_XDMF)) {
+  if ((rdy->config.output.interval > 0) && (rdy->config.output.format != OUTPUT_XDMF)) {
     PetscCall(PetscOptionsHasName(NULL, NULL, "-ts_monitor_solution_interval", &has_param));
     if (!has_param) {
-      snprintf(value, VALUE_LEN, "%d", rdy->config.output.frequency);
+      snprintf(value, VALUE_LEN, "%d", rdy->config.output.interval);
       PetscOptionsSetValue(NULL, "-ts_monitor_solution_interval", value);
     }
   }

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -357,6 +357,9 @@ static PetscErrorCode ComputeBC(RDy rdy, RDyBoundary *boundary, PetscReal tiny_h
     }
   }
 
+  // accumulate boundary fluxes if we are asked to track time series
+  PetscCall(AccumulateBoundaryFluxes(rdy, boundary, boundary->num_edges, flux_vec_bnd));
+
   PetscFunctionReturn(0);
 }
 

--- a/src/tests/test_read_config_file.c
+++ b/src/tests/test_read_config_file.c
@@ -79,7 +79,7 @@ static void TestFullSpec(void **state) {
       "  level: detail\n\n"
       "restart:\n"
       "  format: hdf5\n"
-      "  frequency: 10\n\n"
+      "  interval: 10\n\n"
       "grid:\n"
       "  file: planar_dam_10x5.msh\n\n"
       "surface_composition:\n"

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -1,0 +1,95 @@
+#include <private/rdycoreimpl.h>
+#include <private/rdymemoryimpl.h>
+
+static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
+  PetscFunctionBegin;
+
+  // count up boundary fluxes and allocate storage.
+  PetscInt num_boundary_fluxes = 0;
+  for (PetscInt b = 0; b < rdy->num_boundaries; ++b) {
+    RDyCondition bc = rdy->boundary_conditions[b];
+    if (!bc.auto_generated) {  // exclude auto-generated boundary conditions
+      RDyBoundary *boundary = &rdy->boundaries[b];
+      num_boundary_fluxes += boundary->num_edges;
+    }
+  }
+  PetscCall(RDyAlloc(PetscReal, 3 * num_boundary_fluxes, &rdy->time_series.boundary_fluxes));
+
+  PetscFunctionReturn(0);
+}
+
+// Initializes time series data storage.
+PetscErrorCode InitTimeSeries(RDy rdy) {
+  PetscFunctionBegin;
+  if (rdy->config.output.time_series.boundary_fluxes > 0) {
+    InitBoundaryFluxes(rdy);
+    PetscCall(TSMonitorSet(rdy->ts, WriteTimeSeries, rdy, NULL));
+  }
+  PetscFunctionReturn(0);
+}
+
+static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscReal time) {
+  PetscFunctionBegin;
+  char dir[PETSC_MAX_PATH_LEN];
+  PetscCall(GetOutputDir(rdy, dir));
+  char path[PETSC_MAX_PATH_LEN];
+  snprintf(path, PETSC_MAX_PATH_LEN - 1, "%s/boundary_fluxes.dat", dir);
+  FILE *fp;
+  PetscCall(PetscFOpen(rdy->comm, path, "a", &fp));  // append to end of file
+  PetscInt n = 0;                                    // offset index for time series data
+  for (PetscInt b = 0; b < rdy->num_boundaries; ++b) {
+    RDyCondition bc = rdy->boundary_conditions[b];
+    if (!bc.auto_generated) {  // exclude auto-generated boundary conditions
+      RDyBoundary *boundary = &rdy->boundaries[b];
+      for (PetscInt e = 0; e < boundary->num_edges; ++e, ++n) {
+        PetscInt         edge_id        = boundary->edge_ids[e];
+        PetscInt         global_edge_id = rdy->mesh.edges.global_ids[edge_id];
+        RDyVector        edge_normal    = rdy->mesh.edges.normals[edge_id];
+        PetscInt         boundary_id    = rdy->boundary_ids[b];
+        RDyConditionType bc_type        = bc.flow->type;
+        PetscReal        water_mass     = rdy->time_series.boundary_fluxes[n].water_mass;
+        PetscReal        x_momentum     = rdy->time_series.boundary_fluxes[n].x_momentum;
+        PetscReal        y_momentum     = rdy->time_series.boundary_fluxes[n].y_momentum;
+
+        // tab-delimited data format is:
+        // 1. simulation time (in desired units)
+        // 2. (global) index of boundary edge
+        // 3. integer ID indicating the boundary to which the boundary edge belongs
+        // 4. integer ID indicating the type of boundary condition on the boundary edge
+        // 5. water mass flux
+        // 6. x-momentum flux
+        // 7. y-momentum flux
+        // 8. boundary edge normal x component
+        // 9. boundary edge normal y component
+        PetscCall(PetscFPrintf(rdy->comm, fp, "%e\t%d\t%d\t%d\t%e\t%e\t%e\t%e\t%e\n", time, global_edge_id, boundary_id, (PetscInt)bc_type,
+                               water_mass, x_momentum, y_momentum, edge_normal.V[0], edge_normal.V[2]));
+      }
+
+      // zero the boundary fluxes so they can begin reaccumulating
+      memset(rdy->time_series.boundary_fluxes, 0, 3 * n * sizeof(PetscReal));
+    }
+  }
+  PetscCall(PetscFClose(rdy->comm, fp));
+  PetscFunctionReturn(0);
+}
+
+// This monitoring function writes out all requested time series data.
+PetscErrorCode WriteTimeSeries(TS ts, PetscInt step, PetscReal time, Vec X, void *ctx) {
+  PetscFunctionBegin;
+
+  RDy rdy = ctx;
+  if (step % rdy->config.output.time_series.boundary_fluxes == 0) {
+    PetscCall(WriteBoundaryFluxes(rdy, time));
+  }
+
+  PetscFunctionReturn(0);
+}
+
+// Free resources allocated to time series.
+PetscErrorCode DestroyTimeSeries(RDy rdy) {
+  PetscFunctionBegin;
+  if (rdy->time_series.boundary_fluxes) {
+    RDyFree(rdy->time_series.boundary_fluxes);
+  }
+  PetscFunctionReturn(0);
+}

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -4,8 +4,14 @@
 static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
   PetscFunctionBegin;
 
-  // Allocate per-boundary flux offsets
+  // allocate per-boundary flux offsets
   PetscCall(RDyAlloc(PetscInt, rdy->num_boundaries + 1, &(rdy->time_series.boundary_fluxes.offsets)));
+
+  // make sure the number of degrees of freedom is the same as the number of
+  // boundary fluxes
+  PetscInt ndof;
+  PetscCall(VecGetBlockSize(rdy->X_local, &ndof));
+  PetscCheck(rdy->comm, ndof == 3, PETSC_ERR_USER, "ndof must be the same as # of boundary fluxes (3)");
 
   // count the number of global boundary edges (excluding those for
   // auto-generated boundary conditions and those not locally owned)
@@ -21,7 +27,7 @@ static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
         if (rdy->mesh.cells.is_local[cell_id]) ++num_boundary_edges;
       }
     }
-    rdy->time_series.boundary_fluxes.offsets[b + 1] = 3 * num_boundary_edges;
+    rdy->time_series.boundary_fluxes.offsets[b + 1] = ndof * num_boundary_edges;
   }
   rdy->time_series.boundary_fluxes.num_local_edges = num_boundary_edges;
 

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -178,7 +178,7 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
     // of edges, and to gather global flux metadata/data
     MPI_Gather(&num_local_edges, 1, MPI_INT, NULL, 1, MPI_INT, 0, rdy->comm);
     MPI_Gatherv(local_flux_md, 3 * num_local_edges, MPI_INT, NULL, NULL, NULL, MPI_INT, 0, rdy->comm);
-    MPI_Gatherv(local_flux_data, 5 * num_local_edges, MPI_INT, NULL, NULL, NULL, MPI_INT, 0, rdy->comm);
+    MPI_Gatherv(local_flux_data, 5 * num_local_edges, MPI_DOUBLE, NULL, NULL, NULL, MPI_DOUBLE, 0, rdy->comm);
   }
 
   // zero the boundary fluxes so they can begin reaccumulating

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -157,18 +157,6 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
       PetscReal y_momentum     = global_flux_data[5 * e + 2];
       PetscReal x_normal       = global_flux_data[5 * e + 3];
       PetscReal y_normal       = global_flux_data[5 * e + 4];
-      /*
-          for (PetscInt e = 0; e < num_local_edges; ++e) {
-            PetscInt  global_edge_id = local_flux_md[3 * e];
-            PetscInt  boundary_id    = local_flux_md[3 * e + 1];
-            PetscInt  bc_type        = local_flux_md[3 * e + 2];
-            PetscReal water_mass     = local_flux_data[5 * e];
-            PetscReal x_momentum     = local_flux_data[5 * e + 1];
-            PetscReal y_momentum     = local_flux_data[5 * e + 2];
-            PetscReal x_normal       = local_flux_data[5 * e + 3];
-            PetscReal y_normal       = local_flux_data[5 * e + 4];
-      */
-
       PetscCall(PetscFPrintf(rdy->comm, fp, "%e\t%d\t%d\t%d\t%e\t%e\t%e\t%e\t%e\n", time, global_edge_id, boundary_id, bc_type, water_mass,
                              x_momentum, y_momentum, x_normal, y_normal));
     }

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -4,16 +4,32 @@
 static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
   PetscFunctionBegin;
 
-  // count up boundary fluxes and allocate storage.
-  PetscInt num_boundary_fluxes = 0;
+  // Allocate per-boundary flux offsets
+  PetscCall(RDyAlloc(PetscInt, rdy->num_boundaries + 1, &(rdy->time_series.boundary_fluxes.offsets)));
+
+  // count the number of global boundary edges (excluding those for
+  // auto-generated boundary conditions and those not locally owned)
+  // and compute local flux offsets
+  PetscInt num_boundary_edges = 0;
   for (PetscInt b = 0; b < rdy->num_boundaries; ++b) {
     RDyCondition bc = rdy->boundary_conditions[b];
-    if (!bc.auto_generated) {  // exclude auto-generated boundary conditions
+    if (!bc.auto_generated) {
       RDyBoundary *boundary = &rdy->boundaries[b];
-      num_boundary_fluxes += boundary->num_edges;
+      for (PetscInt e = 0; e < boundary->num_edges; ++e) {
+        PetscInt edge_id = boundary->edge_ids[e];
+        PetscInt cell_id = rdy->mesh.edges.cell_ids[2 * edge_id];
+        if (rdy->mesh.cells.is_local[cell_id]) ++num_boundary_edges;
+      }
     }
+    rdy->time_series.boundary_fluxes.offsets[b + 1] = 3 * num_boundary_edges;
   }
-  PetscCall(RDyAlloc(PetscReal, 3 * num_boundary_fluxes, &rdy->time_series.boundary_fluxes));
+  rdy->time_series.boundary_fluxes.num_local_edges = num_boundary_edges;
+
+  // determine the global number of boundary edges
+  MPI_Allreduce(&num_boundary_edges, &rdy->time_series.boundary_fluxes.num_global_edges, 1, MPI_INT, MPI_SUM, rdy->comm);
+
+  // allocate (local) boundary flux storage
+  PetscCall(RDyAlloc(PetscReal, 3 * num_boundary_edges, &(rdy->time_series.boundary_fluxes.fluxes)));
 
   PetscFunctionReturn(0);
 }
@@ -21,6 +37,7 @@ static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
 // Initializes time series data storage.
 PetscErrorCode InitTimeSeries(RDy rdy) {
   PetscFunctionBegin;
+  rdy->time_series = (RDyTimeSeriesData){0};
   if (rdy->config.output.time_series.boundary_fluxes > 0) {
     InitBoundaryFluxes(rdy);
     PetscCall(TSMonitorSet(rdy->ts, WriteTimeSeries, rdy, NULL));
@@ -28,48 +45,129 @@ PetscErrorCode InitTimeSeries(RDy rdy) {
   PetscFunctionReturn(0);
 }
 
+// Accumulates boundary fluxes on the given boundary from the given array of
+// fluxes on boundary edges.
+PetscErrorCode AccumulateBoundaryFluxes(RDy rdy, RDyBoundary *boundary, PetscInt num_edges, PetscReal fluxes[num_edges][3]) {
+  PetscFunctionBegin;
+  RDyTimeSeriesData *time_series = &rdy->time_series;
+  if (time_series->boundary_fluxes.fluxes) {
+    // figure out whether this boundary has an auto-generated BC
+    PetscBool auto_generated = PETSC_FALSE;
+    PetscInt  b              = boundary - rdy->boundaries;
+    auto_generated           = rdy->boundary_conditions[b].auto_generated;
+
+    // if not, accumulate fluxes locally
+    if (!auto_generated) {
+      PetscInt n = rdy->time_series.boundary_fluxes.offsets[b];
+      for (PetscInt e = 0; e < boundary->num_edges; ++e, ++n) {
+        PetscInt edge_id = boundary->edge_ids[e];
+        PetscInt cell_id = rdy->mesh.edges.cell_ids[2 * edge_id];
+        if (rdy->mesh.cells.is_local[cell_id]) {
+          time_series->boundary_fluxes.fluxes[n].water_mass += fluxes[n][0];
+          time_series->boundary_fluxes.fluxes[n].x_momentum += fluxes[n][1];
+          time_series->boundary_fluxes.fluxes[n].y_momentum += fluxes[n][2];
+        }
+      }
+    }
+  }
+  PetscFunctionReturn(0);
+}
+
 static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscReal time) {
   PetscFunctionBegin;
-  char dir[PETSC_MAX_PATH_LEN];
-  PetscCall(GetOutputDir(rdy, dir));
-  char path[PETSC_MAX_PATH_LEN];
-  snprintf(path, PETSC_MAX_PATH_LEN - 1, "%s/boundary_fluxes.dat", dir);
-  FILE *fp;
-  PetscCall(PetscFOpen(rdy->comm, path, "a", &fp));  // append to end of file
-  PetscInt n = 0;                                    // offset index for time series data
+
+  PetscInt num_local_edges  = rdy->time_series.boundary_fluxes.num_local_edges;
+  PetscInt num_global_edges = rdy->time_series.boundary_fluxes.num_global_edges;
+
+  // flux metadata (global edge ID, boundary ID, BC type)
+  PetscInt local_flux_md[3 * num_local_edges];
+
+  // flux data itself (mass, x-momentum, y-momentum, edge x normal, edge y normal)
+  PetscReal local_flux_data[5 * num_local_edges];
+
+  // gather local metadata/data
+  PetscInt n = 0;
   for (PetscInt b = 0; b < rdy->num_boundaries; ++b) {
     RDyCondition bc = rdy->boundary_conditions[b];
     if (!bc.auto_generated) {  // exclude auto-generated boundary conditions
       RDyBoundary *boundary = &rdy->boundaries[b];
       for (PetscInt e = 0; e < boundary->num_edges; ++e, ++n) {
-        PetscInt         edge_id        = boundary->edge_ids[e];
-        PetscInt         global_edge_id = rdy->mesh.edges.global_ids[edge_id];
-        RDyVector        edge_normal    = rdy->mesh.edges.normals[edge_id];
-        PetscInt         boundary_id    = rdy->boundary_ids[b];
-        RDyConditionType bc_type        = bc.flow->type;
-        PetscReal        water_mass     = rdy->time_series.boundary_fluxes[n].water_mass;
-        PetscReal        x_momentum     = rdy->time_series.boundary_fluxes[n].x_momentum;
-        PetscReal        y_momentum     = rdy->time_series.boundary_fluxes[n].y_momentum;
+        PetscInt edge_id = boundary->edge_ids[e];
+        PetscInt cell_id = rdy->mesh.edges.cell_ids[2 * edge_id];
+        if (rdy->mesh.cells.is_local[cell_id]) {
+          local_flux_md[3 * n]     = rdy->mesh.edges.global_ids[edge_id];
+          local_flux_md[3 * n + 1] = rdy->boundary_ids[b];
+          local_flux_md[3 * n + 2] = bc.flow->type;
 
-        // tab-delimited data format is:
-        // 1. simulation time (in desired units)
-        // 2. (global) index of boundary edge
-        // 3. integer ID indicating the boundary to which the boundary edge belongs
-        // 4. integer ID indicating the type of boundary condition on the boundary edge
-        // 5. water mass flux
-        // 6. x-momentum flux
-        // 7. y-momentum flux
-        // 8. boundary edge normal x component
-        // 9. boundary edge normal y component
-        PetscCall(PetscFPrintf(rdy->comm, fp, "%e\t%d\t%d\t%d\t%e\t%e\t%e\t%e\t%e\n", time, global_edge_id, boundary_id, (PetscInt)bc_type,
-                               water_mass, x_momentum, y_momentum, edge_normal.V[0], edge_normal.V[2]));
+          local_flux_data[5 * n]     = rdy->time_series.boundary_fluxes.fluxes[n].water_mass;
+          local_flux_data[5 * n + 1] = rdy->time_series.boundary_fluxes.fluxes[n].x_momentum;
+          local_flux_data[5 * n + 2] = rdy->time_series.boundary_fluxes.fluxes[n].y_momentum;
+          RDyVector edge_normal      = rdy->mesh.edges.normals[edge_id];
+          local_flux_data[5 * n + 3] = edge_normal.V[0];
+          local_flux_data[5 * n + 3] = edge_normal.V[1];
+        }
       }
-
-      // zero the boundary fluxes so they can begin reaccumulating
-      memset(rdy->time_series.boundary_fluxes, 0, 3 * n * sizeof(PetscReal));
     }
   }
-  PetscCall(PetscFClose(rdy->comm, fp));
+
+  // gather local metadata/data into global arrays on the root process and
+  // write them out
+  if (rdy->rank == 0) {
+    // we need the number of local edges on each proc to determine the send
+    // counts and displacements to pass to MPI_Gatherv below
+    PetscInt n_local_edges[rdy->nproc];
+    MPI_Gather(&num_local_edges, 1, MPI_INT, n_local_edges, 1, MPI_INT, 0, rdy->comm);
+
+    // local -> global flux metadata
+    PetscInt n_recv_counts[rdy->nproc], n_recv_displs[rdy->nproc];
+    n_recv_displs[0] = 0;
+    for (PetscInt p = 0; p < rdy->nproc; ++p) {
+      n_recv_counts[p] = 3 * n_local_edges[p];
+      if (p < rdy->nproc - 1) n_recv_displs[p + 1] = n_recv_displs[p] + n_recv_counts[p];
+    }
+    PetscInt global_flux_md[3 * num_global_edges];
+    MPI_Gatherv(local_flux_md, 3 * num_local_edges, MPI_INT, global_flux_md, n_recv_counts, n_recv_displs, MPI_INT, 0, rdy->comm);
+
+    // local -> global flux data
+    for (PetscInt p = 0; p < rdy->nproc; ++p) {
+      n_recv_counts[p] = 3 * n_local_edges[p];
+      if (p < rdy->nproc - 1) n_recv_displs[p + 1] = n_recv_displs[p] + n_recv_counts[p];
+    }
+    PetscReal global_flux_data[5 * num_global_edges];
+    MPI_Gatherv(local_flux_data, 5 * num_local_edges, MPI_INT, global_flux_data, n_recv_counts, n_recv_displs, MPI_INT, 0, rdy->comm);
+
+    // write the data to the end of the boundary fluxes file
+    char dir[PETSC_MAX_PATH_LEN];
+    PetscCall(GetOutputDir(rdy, dir));
+    char path[PETSC_MAX_PATH_LEN];
+    snprintf(path, PETSC_MAX_PATH_LEN - 1, "%s/boundary_fluxes.dat", dir);
+    FILE *fp;
+    PetscCall(PetscFOpen(rdy->comm, path, "a", &fp));  // append to end of file
+    for (PetscInt e = 0; e < num_global_edges; ++e) {
+      PetscInt  global_edge_id = global_flux_md[3 * e];
+      PetscInt  boundary_id    = global_flux_md[3 * e + 1];
+      PetscInt  bc_type        = global_flux_md[3 * e + 2];
+      PetscReal water_mass     = global_flux_data[5 * e];
+      PetscReal x_momentum     = global_flux_data[5 * e + 1];
+      PetscReal y_momentum     = global_flux_data[5 * e + 2];
+      PetscReal x_normal       = global_flux_data[5 * e + 3];
+      PetscReal y_normal       = global_flux_data[5 * e + 4];
+
+      PetscCall(PetscFPrintf(rdy->comm, fp, "%e\t%d\t%d\t%d\t%e\t%e\t%e\t%e\t%e\n", time, global_edge_id, boundary_id, bc_type, water_mass,
+                             x_momentum, y_momentum, x_normal, y_normal));
+    }
+    PetscCall(PetscFClose(rdy->comm, fp));
+  } else {
+    // send the root proc information that allows it to compute global numbers
+    // of edges, and to gather global flux metadata/data
+    MPI_Gather(&num_local_edges, 1, MPI_INT, NULL, 1, MPI_INT, 0, rdy->comm);
+    MPI_Gatherv(local_flux_md, 3 * num_local_edges, MPI_INT, NULL, NULL, NULL, MPI_INT, 0, rdy->comm);
+    MPI_Gatherv(local_flux_data, 5 * num_local_edges, MPI_INT, NULL, NULL, NULL, MPI_INT, 0, rdy->comm);
+  }
+
+  // zero the boundary fluxes so they can begin reaccumulating
+  memset(rdy->time_series.boundary_fluxes.fluxes, 0, 5 * num_global_edges * sizeof(PetscReal));
+
   PetscFunctionReturn(0);
 }
 
@@ -88,8 +186,9 @@ PetscErrorCode WriteTimeSeries(TS ts, PetscInt step, PetscReal time, Vec X, void
 // Free resources allocated to time series.
 PetscErrorCode DestroyTimeSeries(RDy rdy) {
   PetscFunctionBegin;
-  if (rdy->time_series.boundary_fluxes) {
-    RDyFree(rdy->time_series.boundary_fluxes);
+  if (rdy->time_series.boundary_fluxes.fluxes) {
+    RDyFree(rdy->time_series.boundary_fluxes.offsets);
+    RDyFree(rdy->time_series.boundary_fluxes.fluxes);
   }
   PetscFunctionReturn(0);
 }

--- a/src/write_xdmf_output.c
+++ b/src/write_xdmf_output.c
@@ -28,7 +28,7 @@ static PetscErrorCode WriteXDMFHDF5Data(RDy rdy, PetscInt step, PetscReal time) 
   RDyLogDetail(rdy, "Step %d: writing XDMF HDF5 output at t = %g %s to %s", step, time, units, fname);
 
   // write the grid if we're the first step in a batch.
-  PetscInt dataset = step / rdy->config.output.frequency;
+  PetscInt dataset = step / rdy->config.output.interval;
   if (dataset % rdy->config.output.batch_size == 0) {
     PetscCall(PetscViewerHDF5Open(rdy->comm, fname, FILE_MODE_WRITE, &viewer));
     PetscCall(PetscViewerPushFormat(viewer, PETSC_VIEWER_HDF5_XDMF));
@@ -255,7 +255,7 @@ static PetscErrorCode WriteXDMFXMFData(RDy rdy, PetscInt step, PetscReal time) {
 PetscErrorCode WriteXDMFOutput(TS ts, PetscInt step, PetscReal time, Vec X, void *ctx) {
   PetscFunctionBegin;
   RDy rdy = ctx;
-  if (step % rdy->config.output.frequency == 0) {
+  if (step % rdy->config.output.interval == 0) {
     PetscReal t = ConvertTimeFromSeconds(time, rdy->config.time.unit);
     if (rdy->config.output.format == OUTPUT_XDMF) {
       PetscCall(WriteXDMFHDF5Data(rdy, step, t));


### PR DESCRIPTION
I've got the boundary flux output capability working for non-CEED SWE fluxes. If we like what we see here, I can poke around with CEED and see whether/how I need to change how we accumulate boundary fluxes.

Also, I've changed `output.frequency` to `output.interval` to match the `coupling_interval` parameter.

Closes #63 