### PR TITLE
Adds the Fortran interface for setting coupling interval

### DIFF
--- a/driver/main.F90
+++ b/driver/main.F90
@@ -45,6 +45,8 @@ program rdycore_f90
       ! config file
       PetscCallA(RDyGetTime(rdy_, prev_time, ierr))
       PetscCallA(RDyGetCouplingInterval(rdy_, coupling_interval, ierr))
+      PetscCallA(RDySetCouplingInterval(rdy_, coupling_interval, ierr))
+
       do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
 
         ! apply a 1 mm/hr rain over the entire domain 

--- a/driver/main.c
+++ b/driver/main.c
@@ -42,6 +42,8 @@ int main(int argc, char *argv[]) {
     PetscReal prev_time, coupling_interval;
     RDyGetTime(rdy, &prev_time);
     RDyGetCouplingInterval(rdy, &coupling_interval);
+    RDySetCouplingInterval(rdy, coupling_interval);
+
     while (!RDyFinished(rdy)) { // returns true based on stopping criteria
 
       // apply a 1 mm/hr rain over the entire domain

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -80,7 +80,7 @@ module rdycore
     integer(c_int) function rdysetcouplinginterval_(rdy, interval) bind(c, name="RDySetCouplingInterval")
       use iso_c_binding, only: c_int, c_ptr, c_double
       type(c_ptr),    value, intent(in) :: rdy
-      real(c_double),        intent(in) :: interval
+      real(c_double), value, intent(in) :: interval
     end function
 
     integer(c_int) function rdygetheight_(rdy, h) bind(c, name="RDyGetHeight")

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -77,6 +77,12 @@ module rdycore
       real(c_double),        intent(out) :: interval
     end function
 
+    integer(c_int) function rdysetcouplinginterval_(rdy, interval) bind(c, name="RDySetCouplingInterval")
+      use iso_c_binding, only: c_int, c_ptr, c_double
+      type(c_ptr),    value, intent(in) :: rdy
+      real(c_double),        intent(in) :: interval
+    end function
+
     integer(c_int) function rdygetheight_(rdy, h) bind(c, name="RDyGetHeight")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
@@ -185,6 +191,13 @@ contains
     real(RDyDouble), intent(out)   :: interval
     integer,         intent(out)   :: ierr
     ierr = rdygetcouplinginterval_(rdy_%c_rdy, interval)
+  end subroutine
+
+  subroutine RDySetCouplingInterval(rdy_, interval, ierr)
+    type(RDy),       intent(inout) :: rdy_
+    real(RDyDouble), intent(in)    :: interval
+    integer,         intent(out)   :: ierr
+    ierr = rdysetcouplinginterval_(rdy_%c_rdy, interval)
   end subroutine
 
   subroutine RDyGetStep(rdy_, step, ierr)


### PR DESCRIPTION
The Fortran interface for RDyGetCouplingInterval is added.