### PR TITLE
Addressed a couple of issues in writing boundary fluxes

### DIFF
--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -42,6 +42,8 @@ typedef struct {
 // This type keeps track of accumulated time series data appended periodically
 // to files.
 typedef struct {
+  // last step for which time series data was written
+  PetscInt last_step;
   // fluxes on boundary edges
   struct {
     // numbers of local and global boundary edges on which fluxes are computed

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -231,6 +231,7 @@ PetscErrorCode RDyAdvance(RDy rdy) {
 
   PetscReal interval = ConvertTimeToSeconds(rdy->config.time.coupling_interval, rdy->config.time.unit);
   PetscCall(TSSetMaxTime(rdy->ts, time + interval));
+  PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
   PetscCall(TSSetTimeStep(rdy->ts, rdy->dt));
   PetscCall(TSSetSolution(rdy->ts, rdy->X));
 
@@ -253,17 +254,10 @@ PetscErrorCode RDyAdvance(RDy rdy) {
     PetscCall(TSSolve(rdy->ts, rdy->X));
   }
 
-  // Are we finished?
+  // are we finished?
   PetscCall(TSGetTime(rdy->ts, &time));
   PetscReal final_time = ConvertTimeToSeconds(rdy->config.time.final_time, rdy->config.time.unit);
   if (time >= final_time) {
-    // if we've overstepped the final time, interpolate backward
-    if (time > final_time) {
-      PetscCall(TSInterpolate(rdy->ts, final_time, rdy->X));
-      PetscCall(TSSetTime(rdy->ts, final_time));
-      PetscCall(TSMonitor(rdy->ts, -1, final_time, rdy->X));
-    }
-
     // clean up
     PetscCall(DestroyOutputViewer(rdy));
   }


### PR DESCRIPTION
This PR has two changes:

1. Boundary flux files are now overwritten when starting a new simulation
2. All time series are now written only once per step

If you set `coupling_interval` to the same value as `time_step`, you'll still see two steps in your `-ts_monitor` output, which is just an artifact of how TS monitoring works and how we're handling E3SM <-> RDycore coupling. Basically, we're running TS to the end of the next coupling interval, and then restarting it for the next coupling interval, so every time we restart it, we get the beginning-of-step monitoring output. This shouldn't affect our time series data output anymore.

Closes #71