### PR TITLE
Allowing the log file to be overridden with a function call

### DIFF
--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -26,6 +26,9 @@ PETSC_EXTERN PetscErrorCode RDyOnFinalize(void (*)(void));
 PETSC_EXTERN PetscErrorCode RDyFinalize(void);
 PETSC_EXTERN PetscBool RDyInitialized(void);
 
+// RDycore online configuration
+PETSC_EXTERN PetscErrorCode RDySetLogFile(const char*);
+
 // RDycore setup/breakdown
 PETSC_EXTERN PetscErrorCode RDyCreate(MPI_Comm, const char*, RDy*);
 PETSC_EXTERN PetscErrorCode RDySetup(RDy);

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -923,6 +923,19 @@ static PetscErrorCode InitSolution(RDy rdy) {
   PetscFunctionReturn(0);
 }
 
+// the name of the log file set by RDySetLogFile below
+static char overridden_logfile_[PETSC_MAX_PATH_LEN] = {0};
+
+/// Sets the name of the log file for RDycore. If this function is called, the
+/// name passed to it overrides any log filename set in the YAML config file.
+/// @param log_file [in] the name of the log file written by RDycore
+PetscErrorCode RDySetLogFile(const char *filename) {
+  PetscFunctionBegin;
+  strncpy(overridden_logfile_, filename, PETSC_MAX_PATH_LEN-1);
+  overridden_logfile_[PETSC_MAX_PATH_LEN-1] = '\0';
+  PetscFunctionReturn(0);
+}
+
 /// Performs any setup needed by RDy, reading from the specified configuration
 /// file.
 PetscErrorCode RDySetup(RDy rdy) {
@@ -930,6 +943,11 @@ PetscErrorCode RDySetup(RDy rdy) {
 
   // note: default config values are specified in the YAML input schema!
   PetscCall(ReadConfigFile(rdy));
+
+  // override the log file name if necessary
+  if (overridden_logfile_[0]) {
+    strcpy(rdy->config.logging.file, overridden_logfile_);
+  }
 
   // open the primary log file
   if (strlen(rdy->config.logging.file)) {

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -926,13 +926,14 @@ static PetscErrorCode InitSolution(RDy rdy) {
 // the name of the log file set by RDySetLogFile below
 static char overridden_logfile_[PETSC_MAX_PATH_LEN] = {0};
 
-/// Sets the name of the log file for RDycore. If this function is called, the
-/// name passed to it overrides any log filename set in the YAML config file.
+/// Sets the name of the log file for RDycore. If this function is called
+/// before RDySetup, the name passed to it overrides any log filename set in
+/// the YAML config file.
 /// @param log_file [in] the name of the log file written by RDycore
 PetscErrorCode RDySetLogFile(const char *filename) {
   PetscFunctionBegin;
-  strncpy(overridden_logfile_, filename, PETSC_MAX_PATH_LEN-1);
-  overridden_logfile_[PETSC_MAX_PATH_LEN-1] = '\0';
+  strncpy(overridden_logfile_, filename, PETSC_MAX_PATH_LEN - 1);
+  overridden_logfile_[PETSC_MAX_PATH_LEN - 1] = '\0';
   PetscFunctionReturn(0);
 }
 


### PR DESCRIPTION
This PR adds an `RDySetLogFile` function in C and Fortran to allow an external client (e.g. E3SM) to override the log file specified in the input YAML file.

Closes #75 