### PR TITLE
Reduces memory allocation/deallocating within each time step

### DIFF
--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -177,6 +177,9 @@ struct _p_RDy {
     CeedScalar           dt;
 
   } ceed_rhs;
+
+  RiemannDataSWE *datal_internal_edges, *datar_internal_edges;
+  RiemannDataSWE **datal_bnd_edges, **datar_bnd_edges;
 };
 
 PETSC_INTERN PetscErrorCode ReadConfigFile(RDy);

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -6,6 +6,7 @@
 #include <private/rdyconfigimpl.h>
 #include <private/rdylogimpl.h>
 #include <private/rdymeshimpl.h>
+#include <private/rdysweimpl.h>
 #include <rdycore.h>
 
 // This type defines a region consisting of cells identified by their local

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -178,9 +178,11 @@ struct _p_RDy {
 
   } ceed_rhs;
 
-  RiemannDataSWE datal_internal_edges, datar_internal_edges;
-  RiemannDataSWE *datal_bnd_edges, *datar_bnd_edges;
-  RiemannDataSWE data_cells;
+  struct {
+    RiemannDataSWE datal_internal_edges, datar_internal_edges;
+    RiemannDataSWE *datal_bnd_edges, *datar_bnd_edges;
+    RiemannDataSWE data_cells;
+  } data_swe;
 };
 
 PETSC_INTERN PetscErrorCode ReadConfigFile(RDy);

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -178,7 +178,7 @@ struct _p_RDy {
 
   } ceed_rhs;
 
-  RiemannDataSWE *datal_internal_edges, *datar_internal_edges;
+  RiemannDataSWE datal_internal_edges, datar_internal_edges;
   RiemannDataSWE **datal_bnd_edges, **datar_bnd_edges;
 };
 

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -180,6 +180,7 @@ struct _p_RDy {
 
   RiemannDataSWE datal_internal_edges, datar_internal_edges;
   RiemannDataSWE *datal_bnd_edges, *datar_bnd_edges;
+  RiemannDataSWE data_cells;
 };
 
 PETSC_INTERN PetscErrorCode ReadConfigFile(RDy);

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -179,7 +179,7 @@ struct _p_RDy {
   } ceed_rhs;
 
   RiemannDataSWE datal_internal_edges, datar_internal_edges;
-  RiemannDataSWE **datal_bnd_edges, **datar_bnd_edges;
+  RiemannDataSWE *datal_bnd_edges, *datar_bnd_edges;
 };
 
 PETSC_INTERN PetscErrorCode ReadConfigFile(RDy);

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -1,0 +1,55 @@
+#ifndef RDYSWEIMPL_H
+#define RDYSWEIMPL_H
+
+#include <private/rdymemoryimpl.h>
+
+#include <petscsys.h>
+
+typedef struct {
+  PetscInt   N;            // number of data values
+  PetscReal *h, *hu, *hv;  // prognostic SWE variables
+  PetscReal *u, *v;        // diagnostic variables
+} RiemannDataSWE;
+
+// Diagnostic structure that captures information about the conditions under
+// which the maximum courant number is encountered. If you change this struct,
+// update the call to MPI_Type_create_struct in InitMPITypesAndOps below.
+typedef struct {
+  PetscReal max_courant_num;  // maximum courant number
+  PetscInt  global_edge_id;   // edge at which the max courant number was encountered
+  PetscInt  global_cell_id;   // cell in which the max courant number was encountered
+} CourantNumberDiagnostics;
+
+static PetscErrorCode RiemannDataSWECreate(PetscInt N, RiemannDataSWE *data) {
+  PetscFunctionBegin;
+
+  data->N = N;
+  PetscCall(RDyAlloc(PetscReal, data->N, &data->h));
+  PetscCall(RDyAlloc(PetscReal, data->N, &data->hu));
+  PetscCall(RDyAlloc(PetscReal, data->N, &data->hv));
+  PetscCall(RDyAlloc(PetscReal, data->N, &data->u));
+  PetscCall(RDyAlloc(PetscReal, data->N, &data->v));
+
+  PetscCall(RDyFill(PetscReal, data->N, data->h, 0.0));
+  PetscCall(RDyFill(PetscReal, data->N, data->hu, 0.0));
+  PetscCall(RDyFill(PetscReal, data->N, data->hv, 0.0));
+  PetscCall(RDyFill(PetscReal, data->N, data->u, 0.0));
+  PetscCall(RDyFill(PetscReal, data->N, data->v, 0.0));
+
+  PetscFunctionReturn(0);
+}
+
+static PetscErrorCode RiemannDataSWEDestroy(RiemannDataSWE data) {
+  PetscFunctionBegin;
+
+  data.N = 0;
+  PetscCall(RDyFree(data.h));
+  PetscCall(RDyFree(data.hu));
+  PetscCall(RDyFree(data.hv));
+  PetscCall(RDyFree(data.u));
+  PetscCall(RDyFree(data.v));
+
+  PetscFunctionReturn(0);
+}
+
+#endif // rdyswe_h

--- a/src/physics_swe.c
+++ b/src/physics_swe.c
@@ -269,6 +269,7 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
       PetscCall(PetscViewerDestroy(&viewer));
     }
   } else {
+    PetscCall(ComputeDiagnosticVariables(rdy));
     PetscCall(RHSFunctionForInternalEdges(rdy, F, &courant_num_diags));
     PetscCall(RHSFunctionForBoundaryEdges(rdy, F, &courant_num_diags));
     PetscCall(AddSourceTerm(rdy, F));  // TODO: move source term to use libCEED

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -967,6 +967,25 @@ PetscErrorCode RDySetLogFile(RDy rdy, const char *filename) {
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
+  PetscFunctionBegin;
+
+  RDyMesh  *mesh  = &rdy->mesh;
+  PetscInt  num = mesh->num_internal_edges;
+
+  RiemannDataSWE *datal, *datar;
+  PetscCall(RDyAlloc(sizeof(RiemannDataSWE), 1, &datal));
+  PetscCall(RDyAlloc(sizeof(RiemannDataSWE), 1, &datar));
+
+  PetscCall(RiemannDataSWECreate(num, datal));
+  PetscCall(RiemannDataSWECreate(num, datar));
+
+  rdy->datal_internal_edges = datal;
+  rdy->datar_internal_edges = datar;
+
+  PetscFunctionReturn(0);
+}
+
 /// Performs any setup needed by RDy, reading from the specified configuration
 /// file.
 PetscErrorCode RDySetup(RDy rdy) {
@@ -1024,6 +1043,9 @@ PetscErrorCode RDySetup(RDy rdy) {
 
   RDyLogDebug(rdy, "Initializing solution data...");
   PetscCall(InitSolution(rdy));
+
+  RDyLogDebug(rdy, "Initializing data structures for computing fluxes...");
+  PetscCall(InitDataStructsForComputingFlux(rdy));
 
   if (rdy->ceed_resource[0]) {
     RDyLogDebug(rdy, "Setting up the CEED Operator...");

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -982,8 +982,8 @@ static PetscErrorCode AllocateFluxStorage(RDy rdy) {
   PetscCall(RiemannDataSWECreate(num, datal));
   PetscCall(RiemannDataSWECreate(num, datar));
 
-  rdy->datal_internal_edges = *datal;
-  rdy->datar_internal_edges = *datar;
+  rdy->data_swe.datal_internal_edges = *datal;
+  rdy->data_swe.datar_internal_edges = *datar;
 
   RiemannDataSWE *datal_bnd, *datar_bnd;
   PetscCall(RDyAlloc(sizeof(RiemannDataSWE), rdy->num_boundaries, &datal_bnd));
@@ -997,8 +997,8 @@ static PetscErrorCode AllocateFluxStorage(RDy rdy) {
     PetscCall(RiemannDataSWECreate(num_edges, &datar_bnd[b]));
   }
 
-  rdy->datal_bnd_edges = &(*datal_bnd);
-  rdy->datar_bnd_edges = &(*datar_bnd);
+  rdy->data_swe.datal_bnd_edges = &(*datal_bnd);
+  rdy->data_swe.datar_bnd_edges = &(*datar_bnd);
 
   PetscFunctionReturn(0);
 }
@@ -1015,7 +1015,7 @@ static PetscErrorCode AllocateSourceTermStorage(RDy rdy) {
 
   PetscCall(RiemannDataSWECreate(num, data));
 
-  rdy->data_cells = *data;
+  rdy->data_swe.data_cells = *data;
 
   PetscFunctionReturn(0);
 }

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -970,8 +970,8 @@ PetscErrorCode RDySetLogFile(RDy rdy, const char *filename) {
 PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
   PetscFunctionBegin;
 
-  RDyMesh  *mesh  = &rdy->mesh;
-  PetscInt  num = mesh->num_internal_edges;
+  RDyMesh *mesh = &rdy->mesh;
+  PetscInt num  = mesh->num_internal_edges;
 
   RiemannDataSWE *datal, *datar;
   PetscCall(RDyAlloc(sizeof(RiemannDataSWE), 1, &datal));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -969,7 +969,7 @@ PetscErrorCode RDySetLogFile(RDy rdy, const char *filename) {
 
 /// For computing fluxes, allocates structs to hold values left and right
 /// of internal and boundary edges
-PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
+static PetscErrorCode AllocateFluxStorage(RDy rdy) {
   PetscFunctionBegin;
 
   RDyMesh *mesh = &rdy->mesh;
@@ -1004,7 +1004,7 @@ PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
 }
 
 /// Allocates a struct for computing the source/sink term
-PetscErrorCode InitDataStructsForSourceTerm(RDy rdy) {
+static PetscErrorCode AllocateSourceTermStorage(RDy rdy) {
   PetscFunctionBegin;
 
   RDyMesh *mesh = &rdy->mesh;
@@ -1079,10 +1079,10 @@ PetscErrorCode RDySetup(RDy rdy) {
   PetscCall(InitSolution(rdy));
 
   RDyLogDebug(rdy, "Initializing data structures for computing fluxes...");
-  PetscCall(InitDataStructsForComputingFlux(rdy));
+  PetscCall(AllocateFluxStorage(rdy));
 
   RDyLogDebug(rdy, "Initializing data structures for computing source term...");
-  PetscCall(InitDataStructsForSourceTerm(rdy));
+  PetscCall(AllocateSourceTermStorage(rdy));
 
   if (rdy->ceed_resource[0]) {
     RDyLogDebug(rdy, "Setting up the CEED Operator...");

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -967,6 +967,8 @@ PetscErrorCode RDySetLogFile(RDy rdy, const char *filename) {
   PetscFunctionReturn(0);
 }
 
+/// For computing fluxes, allocates structs to hold values left and right
+/// of internal and boundary edges
 PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
   PetscFunctionBegin;
 
@@ -1001,6 +1003,7 @@ PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
   PetscFunctionReturn(0);
 }
 
+/// Allocates a struct for computing the source/sink term
 PetscErrorCode InitDataStructsForSourceTerm(RDy rdy) {
   PetscFunctionBegin;
 

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -980,8 +980,8 @@ PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
   PetscCall(RiemannDataSWECreate(num, datal));
   PetscCall(RiemannDataSWECreate(num, datar));
 
-  rdy->datal_internal_edges = datal;
-  rdy->datar_internal_edges = datar;
+  rdy->datal_internal_edges = *datal;
+  rdy->datar_internal_edges = *datar;
 
   PetscFunctionReturn(0);
 }

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -972,6 +972,7 @@ PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
 
   RDyMesh *mesh = &rdy->mesh;
   PetscInt num  = mesh->num_internal_edges;
+  printf("mesh->num_internal_edges = %d\n", num);
 
   RiemannDataSWE *datal, *datar;
   PetscCall(RDyAlloc(sizeof(RiemannDataSWE), 1, &datal));
@@ -982,6 +983,21 @@ PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
 
   rdy->datal_internal_edges = *datal;
   rdy->datar_internal_edges = *datar;
+
+  RiemannDataSWE *datal_bnd, *datar_bnd;
+  PetscCall(RDyAlloc(sizeof(RiemannDataSWE), rdy->num_boundaries, &datal_bnd));
+  PetscCall(RDyAlloc(sizeof(RiemannDataSWE), rdy->num_boundaries, &datar_bnd));
+
+  for (PetscInt b = 0; b < rdy->num_boundaries; b++) {
+    RDyBoundary *boundary  = &rdy->boundaries[b];
+    PetscInt     num_edges = boundary->num_edges;
+
+    PetscCall(RiemannDataSWECreate(num_edges, &datal_bnd[b]));
+    PetscCall(RiemannDataSWECreate(num_edges, &datar_bnd[b]));
+  }
+
+  rdy->datal_bnd_edges = &(*datal_bnd);
+  rdy->datar_bnd_edges = &(*datar_bnd);
 
   PetscFunctionReturn(0);
 }

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -972,7 +972,6 @@ PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
 
   RDyMesh *mesh = &rdy->mesh;
   PetscInt num  = mesh->num_internal_edges;
-  printf("mesh->num_internal_edges = %d\n", num);
 
   RiemannDataSWE *datal, *datar;
   PetscCall(RDyAlloc(sizeof(RiemannDataSWE), 1, &datal));
@@ -998,6 +997,22 @@ PetscErrorCode InitDataStructsForComputingFlux(RDy rdy) {
 
   rdy->datal_bnd_edges = &(*datal_bnd);
   rdy->datar_bnd_edges = &(*datar_bnd);
+
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode InitDataStructsForSourceTerm(RDy rdy) {
+  PetscFunctionBegin;
+
+  RDyMesh *mesh = &rdy->mesh;
+  PetscInt num  = mesh->num_cells;
+
+  RiemannDataSWE *data;
+  PetscCall(RDyAlloc(sizeof(RiemannDataSWE), 1, &data));
+
+  PetscCall(RiemannDataSWECreate(num, data));
+
+  rdy->data_cells = *data;
 
   PetscFunctionReturn(0);
 }
@@ -1062,6 +1077,9 @@ PetscErrorCode RDySetup(RDy rdy) {
 
   RDyLogDebug(rdy, "Initializing data structures for computing fluxes...");
   PetscCall(InitDataStructsForComputingFlux(rdy));
+
+  RDyLogDebug(rdy, "Initializing data structures for computing source term...");
+  PetscCall(InitDataStructsForSourceTerm(rdy));
 
   if (rdy->ceed_resource[0]) {
     RDyLogDebug(rdy, "Setting up the CEED Operator...");

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -2,56 +2,10 @@
 #define swe_flux_petsc_h
 
 #include <petscsys.h>
+#include <private/rdysweimpl.h>
 
 // gravitational acceleration [m/s/s]
 static const PetscReal GRAVITY = 9.806;
-
-typedef struct {
-  PetscInt   N;            // number of data values
-  PetscReal *h, *hu, *hv;  // prognostic SWE variables
-  PetscReal *u, *v;        // diagnostic variables
-} RiemannDataSWE;
-
-// Diagnostic structure that captures information about the conditions under
-// which the maximum courant number is encountered. If you change this struct,
-// update the call to MPI_Type_create_struct in InitMPITypesAndOps below.
-typedef struct {
-  PetscReal max_courant_num;  // maximum courant number
-  PetscInt  global_edge_id;   // edge at which the max courant number was encountered
-  PetscInt  global_cell_id;   // cell in which the max courant number was encountered
-} CourantNumberDiagnostics;
-
-static PetscErrorCode RiemannDataSWECreate(PetscInt N, RiemannDataSWE *data) {
-  PetscFunctionBegin;
-
-  data->N = N;
-  PetscCall(RDyAlloc(PetscReal, data->N, &data->h));
-  PetscCall(RDyAlloc(PetscReal, data->N, &data->hu));
-  PetscCall(RDyAlloc(PetscReal, data->N, &data->hv));
-  PetscCall(RDyAlloc(PetscReal, data->N, &data->u));
-  PetscCall(RDyAlloc(PetscReal, data->N, &data->v));
-
-  PetscCall(RDyFill(PetscReal, data->N, data->h, 0.0));
-  PetscCall(RDyFill(PetscReal, data->N, data->hu, 0.0));
-  PetscCall(RDyFill(PetscReal, data->N, data->hv, 0.0));
-  PetscCall(RDyFill(PetscReal, data->N, data->u, 0.0));
-  PetscCall(RDyFill(PetscReal, data->N, data->v, 0.0));
-
-  PetscFunctionReturn(0);
-}
-
-static PetscErrorCode RiemannDataSWEDestroy(RiemannDataSWE data) {
-  PetscFunctionBegin;
-
-  data.N = 0;
-  PetscCall(RDyFree(data.h));
-  PetscCall(RDyFree(data.hu));
-  PetscCall(RDyFree(data.hv));
-  PetscCall(RDyFree(data.u));
-  PetscCall(RDyFree(data.v));
-
-  PetscFunctionReturn(0);
-}
 
 // computes velocities in x and y-dir based on momentum in x and y-dir
 // N - Size of the array

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -176,17 +176,17 @@ static PetscErrorCode RHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberD
     PetscInt r     = edges->cell_ids[2 * iedge + 1];
 
     if (r != -1) {
-      datal->h[ii]   = datac->h[l];
-      datal->u[ii]   = datac->u[l];
-      datal->v[ii]   = datac->v[l];
-      datal->hu[ii]  = datac->hu[l];
-      datal->hv[ii]  = datac->hv[l];
+      datal->h[ii]  = datac->h[l];
+      datal->u[ii]  = datac->u[l];
+      datal->v[ii]  = datac->v[l];
+      datal->hu[ii] = datac->hu[l];
+      datal->hv[ii] = datac->hv[l];
 
-      datar->h[ii]   = datac->h[r];
-      datar->u[ii]   = datac->u[r];
-      datar->v[ii]   = datac->v[r];
-      datar->hu[ii]  = datac->hu[r];
-      datar->hv[ii]  = datac->hv[r];
+      datar->h[ii]  = datac->h[r];
+      datar->u[ii]  = datac->u[r];
+      datar->v[ii]  = datac->v[r];
+      datar->hu[ii] = datac->hu[r];
+      datar->hv[ii] = datac->hv[r];
 
       cn_vec_int[ii] = edges->cn[iedge];
       sn_vec_int[ii] = edges->sn[iedge];
@@ -242,8 +242,8 @@ static PetscErrorCode RHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberD
 // Before computing BC fluxes, perform common precomputation irrespective of BC type that include:
 // (i) extracting h/hu/hv from the solution vector X, and
 // (ii) compute velocities (u/v) from momentum (hu/hv).
-static PetscErrorCode PerformPrecomputationForBC(RDy rdy, RDyBoundary *boundary, PetscReal tiny_h, PetscInt N, RiemannDataSWE *datal, RiemannDataSWE *datac, PetscReal cn[N],
-                                                 PetscReal sn[N]) {
+static PetscErrorCode PerformPrecomputationForBC(RDy rdy, RDyBoundary *boundary, PetscReal tiny_h, PetscInt N, RiemannDataSWE *datal,
+                                                 RiemannDataSWE *datac, PetscReal cn[N], PetscReal sn[N]) {
   PetscFunctionBeginUser;
 
   RDyEdges *edges = &rdy->mesh.edges;
@@ -316,8 +316,8 @@ static PetscErrorCode ComputeBC(RDy rdy, RDyBoundary *boundary, PetscReal tiny_h
 
 // applies a reflecting boundary condition on the given boundary, computing
 // fluxes F for the solution vector components X
-static PetscErrorCode ApplyReflectingBC(RDy rdy, RDyBoundary *boundary, RiemannDataSWE *datal, RiemannDataSWE *datar, RiemannDataSWE *datac, PetscReal tiny_h,
-                                        CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
+static PetscErrorCode ApplyReflectingBC(RDy rdy, RDyBoundary *boundary, RiemannDataSWE *datal, RiemannDataSWE *datar, RiemannDataSWE *datac,
+                                        PetscReal tiny_h, CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
   PetscFunctionBeginUser;
 
   RDyCells *cells = &rdy->mesh.cells;
@@ -351,8 +351,8 @@ static PetscErrorCode ApplyReflectingBC(RDy rdy, RDyBoundary *boundary, RiemannD
 
 // applies a critical outflow boundary condition, computing
 // fluxes F for the solution vector components X
-static PetscErrorCode ApplyCriticalOutflowBC(RDy rdy, RDyBoundary *boundary, RiemannDataSWE *datal, RiemannDataSWE *datar, RiemannDataSWE *datac, PetscReal tiny_h,
-                                             CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
+static PetscErrorCode ApplyCriticalOutflowBC(RDy rdy, RDyBoundary *boundary, RiemannDataSWE *datal, RiemannDataSWE *datar, RiemannDataSWE *datac,
+                                             PetscReal tiny_h, CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
   PetscFunctionBeginUser;
 
   RDyCells *cells = &rdy->mesh.cells;

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -165,9 +165,9 @@ static PetscErrorCode RHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberD
   PetscReal sn_vec_int[num], cn_vec_int[num];
   PetscReal flux_vec_int[num][3], amax_vec_int[num];
 
-  RiemannDataSWE *datal = &rdy->datal_internal_edges;
-  RiemannDataSWE *datar = &rdy->datar_internal_edges;
-  RiemannDataSWE *datac = &rdy->data_cells;
+  RiemannDataSWE *datal = &rdy->data_swe.datal_internal_edges;
+  RiemannDataSWE *datar = &rdy->data_swe.datar_internal_edges;
+  RiemannDataSWE *datac = &rdy->data_swe.data_cells;
 
   // Collect the h/hu/hv for left and right cells to compute u/v
   for (PetscInt ii = 0; ii < mesh->num_internal_edges; ii++) {
@@ -406,9 +406,9 @@ static PetscErrorCode RHSFunctionForBoundaryEdges(RDy rdy, Vec F, CourantNumberD
   // loop over all boundaries and apply boundary conditions
   for (PetscInt b = 0; b < rdy->num_boundaries; ++b) {
     RDyBoundary    *boundary = &rdy->boundaries[b];
-    RiemannDataSWE *datal    = &rdy->datal_bnd_edges[b];
-    RiemannDataSWE *datar    = &rdy->datar_bnd_edges[b];
-    RiemannDataSWE *datac    = &rdy->data_cells;
+    RiemannDataSWE *datal    = &rdy->data_swe.datal_bnd_edges[b];
+    RiemannDataSWE *datar    = &rdy->data_swe.datar_bnd_edges[b];
+    RiemannDataSWE *datac    = &rdy->data_swe.data_cells;
 
     switch (rdy->boundary_conditions[b].flow->type) {
       case CONDITION_REFLECTING:
@@ -444,7 +444,7 @@ static PetscErrorCode ComputeDiagnosticVariables(RDy rdy) {
   PetscScalar *x_ptr;
   PetscCall(VecGetArray(rdy->X_local, &x_ptr));
 
-  RiemannDataSWE *data = &rdy->data_cells;
+  RiemannDataSWE *data = &rdy->data_swe.data_cells;
 
   // Collect the h/hu/hv for cells to compute u/v
   for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
@@ -478,7 +478,7 @@ static PetscErrorCode AddSourceTerm(RDy rdy, Vec F) {
   PetscCall(VecGetBlockSize(rdy->X_local, &ndof));
   PetscCheck(ndof == 3, rdy->comm, PETSC_ERR_USER, "Number of dof in local vector must be 3!");
 
-  RiemannDataSWE *data = &rdy->data_cells;
+  RiemannDataSWE *data = &rdy->data_swe.data_cells;
 
   for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
     if (cells->is_local[icell]) {

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -165,8 +165,8 @@ static PetscErrorCode RHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberD
   PetscReal sn_vec_int[num], cn_vec_int[num];
   PetscReal flux_vec_int[num][3], amax_vec_int[num];
 
-  RiemannDataSWE *datal = rdy->datal_internal_edges;
-  RiemannDataSWE *datar = rdy->datar_internal_edges;
+  RiemannDataSWE *datal = &rdy->datal_internal_edges;
+  RiemannDataSWE *datar = &rdy->datar_internal_edges;
 
   // Collect the h/hu/hv for left and right cells to compute u/v
   for (PetscInt ii = 0; ii < mesh->num_internal_edges; ii++) {

--- a/src/swe_flux_petsc.h
+++ b/src/swe_flux_petsc.h
@@ -167,6 +167,7 @@ static PetscErrorCode RHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberD
 
   RiemannDataSWE *datal = &rdy->datal_internal_edges;
   RiemannDataSWE *datar = &rdy->datar_internal_edges;
+  RiemannDataSWE *datac = &rdy->data_cells;
 
   // Collect the h/hu/hv for left and right cells to compute u/v
   for (PetscInt ii = 0; ii < mesh->num_internal_edges; ii++) {
@@ -175,13 +176,17 @@ static PetscErrorCode RHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberD
     PetscInt r     = edges->cell_ids[2 * iedge + 1];
 
     if (r != -1) {
-      datal->h[ii]  = x_ptr[l * ndof + 0];
-      datal->hu[ii] = x_ptr[l * ndof + 1];
-      datal->hv[ii] = x_ptr[l * ndof + 2];
+      datal->h[ii]   = datac->h[l];
+      datal->u[ii]   = datac->u[l];
+      datal->v[ii]   = datac->v[l];
+      datal->hu[ii]  = datac->hu[l];
+      datal->hv[ii]  = datac->hv[l];
 
-      datar->h[ii]  = x_ptr[r * ndof + 0];
-      datar->hu[ii] = x_ptr[r * ndof + 1];
-      datar->hv[ii] = x_ptr[r * ndof + 2];
+      datar->h[ii]   = datac->h[r];
+      datar->u[ii]   = datac->u[r];
+      datar->v[ii]   = datac->v[r];
+      datar->hu[ii]  = datac->hu[r];
+      datar->hv[ii]  = datac->hv[r];
 
       cn_vec_int[ii] = edges->cn[iedge];
       sn_vec_int[ii] = edges->sn[iedge];
@@ -190,8 +195,6 @@ static PetscErrorCode RHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberD
 
   // Compute u/v for left and right cells
   const PetscReal tiny_h = rdy->config.physics.flow.tiny_h;
-  PetscCall(GetVelocityFromMomentum(tiny_h, datal));
-  PetscCall(GetVelocityFromMomentum(tiny_h, datar));
 
   // Call Riemann solver (only Roe currently supported)
   PetscCheck(rdy->config.numerics.riemann == RIEMANN_ROE, rdy->comm, PETSC_ERR_USER, "Invalid Riemann solver selected! (Only roe is supported)");


### PR DESCRIPTION
In the PETSc version of the solver, few data structures are allocated during initialization 
for computing internal, boundary, and source term. This replaces the pervious code in
which data structures were allocated/deallocated within each time step.