### PR TITLE
Adds support for Dirichlet BCs

### DIFF
--- a/driver/main.F90
+++ b/driver/main.F90
@@ -20,6 +20,7 @@ program rdycore_f90
   type(RDy)           :: rdy_
   PetscErrorCode      :: ierr
   PetscInt            :: n, step
+  PetscInt            :: nbconds, ibcond, num_edges
   PetscReal, pointer  :: h(:), vx(:), vy(:), rain(:)
   PetscReal           :: time, time_step, prev_time, coupling_interval
 
@@ -40,6 +41,12 @@ program rdycore_f90
       ! allocate arrays for inspecting simulation data
       PetscCallA(RDyGetNumLocalCells(rdy_, n, ierr))
       allocate(h(n), vx(n), vy(n), rain(n))
+
+      ! get information about boundary conditions
+      PetscCallA(RDyGetNumBoundaryConditions(rdy_, nbconds, ierr))
+      do ibcond = 0, nbconds-1
+        PetscCallA(RDyGetNumEdgesInABoundaryConditions(rdy_, ibcond, num_edges, ierr))
+      enddo
 
       ! run the simulation to completion using the time parameters in the
       ! config file

--- a/driver/main.F90
+++ b/driver/main.F90
@@ -10,6 +10,8 @@ end module
 
 program rdycore_f90
 #include <petsc/finclude/petsc.h>
+#include <finclude/rdycore.h>
+
   use rdycore
   use driver
   use petsc
@@ -20,7 +22,7 @@ program rdycore_f90
   type(RDy)           :: rdy_
   PetscErrorCode      :: ierr
   PetscInt            :: n, step
-  PetscInt            :: nbconds, ibcond, num_edges
+  PetscInt            :: nbconds, ibcond, num_edges, bcond_type
   PetscReal, pointer  :: h(:), vx(:), vy(:), rain(:)
   PetscReal           :: time, time_step, prev_time, coupling_interval
 
@@ -46,6 +48,7 @@ program rdycore_f90
       PetscCallA(RDyGetNumBoundaryConditions(rdy_, nbconds, ierr))
       do ibcond = 1, nbconds
         PetscCallA(RDyGetNumEdgesInABoundaryConditions(rdy_, ibcond, num_edges, ierr))
+        PetscCallA(RDyGetBoundaryConditionFlowType(rdy_, ibcond, bcond_type, ierr))
       enddo
 
       ! run the simulation to completion using the time parameters in the

--- a/driver/main.F90
+++ b/driver/main.F90
@@ -44,7 +44,7 @@ program rdycore_f90
 
       ! get information about boundary conditions
       PetscCallA(RDyGetNumBoundaryConditions(rdy_, nbconds, ierr))
-      do ibcond = 0, nbconds-1
+      do ibcond = 1, nbconds
         PetscCallA(RDyGetNumEdgesInABoundaryConditions(rdy_, ibcond, num_edges, ierr))
       enddo
 

--- a/driver/main.F90
+++ b/driver/main.F90
@@ -47,7 +47,7 @@ program rdycore_f90
       ! get information about boundary conditions
       PetscCallA(RDyGetNumBoundaryConditions(rdy_, nbconds, ierr))
       do ibcond = 1, nbconds
-        PetscCallA(RDyGetNumEdgesInABoundaryConditions(rdy_, ibcond, num_edges, ierr))
+        PetscCallA(RDyGetNumBoundaryConditionEdges(rdy_, ibcond, num_edges, ierr))
         PetscCallA(RDyGetBoundaryConditionFlowType(rdy_, ibcond, bcond_type, ierr))
       enddo
 

--- a/driver/main.c
+++ b/driver/main.c
@@ -37,6 +37,14 @@ int main(int argc, char *argv[]) {
     PetscCalloc1(n * sizeof(PetscReal), &vy);
     PetscCalloc1(n * sizeof(PetscReal), &rain);
 
+    // get information about boundary conditions
+    PetscInt nbcs;
+    PetscCall(RDyGetNumBoundaryConditions(rdy, &nbcs));
+    for (PetscInt ibc = 0; ibc < nbcs; ibc++) {
+      PetscInt num_edges;
+      PetscCall(RDyGetNumEdgesInABoundaryConditions(rdy, ibc, &num_edges));
+    }
+
     // run the simulation to completion using the time parameters in the
     // config file
     PetscReal prev_time, coupling_interval;

--- a/driver/main.c
+++ b/driver/main.c
@@ -41,8 +41,9 @@ int main(int argc, char *argv[]) {
     PetscInt nbcs;
     PetscCall(RDyGetNumBoundaryConditions(rdy, &nbcs));
     for (PetscInt ibc = 0; ibc < nbcs; ibc++) {
-      PetscInt num_edges;
+      PetscInt num_edges, bc_type;
       PetscCall(RDyGetNumEdgesInABoundaryConditions(rdy, ibc, &num_edges));
+      PetscCall(RDyGetBoundaryConditionFlowType(rdy, ibc, &bc_type));
     }
 
     // run the simulation to completion using the time parameters in the

--- a/driver/main.c
+++ b/driver/main.c
@@ -42,7 +42,7 @@ int main(int argc, char *argv[]) {
     PetscCall(RDyGetNumBoundaryConditions(rdy, &nbcs));
     for (PetscInt ibc = 0; ibc < nbcs; ibc++) {
       PetscInt num_edges, bc_type;
-      PetscCall(RDyGetNumEdgesInABoundaryConditions(rdy, ibc, &num_edges));
+      PetscCall(RDyGetNumBoundaryConditionEdges(rdy, ibc, &num_edges));
       PetscCall(RDyGetBoundaryConditionFlowType(rdy, ibc, &bc_type));
     }
 

--- a/driver/tests/swe_roe/CMakeLists.txt
+++ b/driver/tests/swe_roe/CMakeLists.txt
@@ -17,6 +17,17 @@ foreach(np 1 2) # test on 1, 2 processes
   endforeach()
 endforeach()
 
+# Dirichlet BC test
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ex2b_dirichlet_bc.yaml ${MESH_DIR}/planar_dam_10x5.msh
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+foreach(np 1 2) # test on 1, 2 processes
+  foreach(config basic)
+    add_test(swe_roe_ex2b_dirichlet_bc_c_np_${np}_${config} ${PETSC_MPIEXEC} ${PETSC_MPIEXEC_FLAGS} -n ${np} ${rdycore_driver} ex2b_dirichlet_bc.yaml ${${config}_args})
+    add_test(swe_roe_ex2b_dirichlet_bc_f90_np_${np}_${config} ${PETSC_MPIEXEC} ${PETSC_MPIEXEC_FLAGS} -n ${np} ${rdycore_f90_driver} ex2b_dirichlet_bc.yaml ${${config}_args})
+  endforeach()
+endforeach()
+
+
 # Additional tests for CGNS output
 foreach(np 1 2) # test on 1, 2 processes
   set(cgns_output_args -ts_monitor_solution cgns:output/ex2b-%d.cgns -viewer_cgns_batch_size 20 -ts_monitor_solution_interval 100)

--- a/driver/tests/swe_roe/ex2b_dirichlet_bc.yaml
+++ b/driver/tests/swe_roe/ex2b_dirichlet_bc.yaml
@@ -1,0 +1,76 @@
+physics:
+  flow:
+    mode: swe
+
+numerics:
+  spatial: fv
+  temporal: euler
+  riemann: roe
+
+logging:
+  level: detail
+
+time:
+  final_time: 0.005
+  unit: seconds
+  max_step: 100
+
+output:
+  format: xdmf
+  interval: 100
+  batch_size: 20
+  time_series:
+    boundary_fluxes: 10
+
+grid:
+  file: planar_dam_10x5.msh
+
+surface_composition:
+  regions:
+    - id: 1 # upstream region
+      material: smooth
+    - id: 2 # downstream region
+      material: smooth
+
+materials:
+  - name: smooth
+    manning: 0.015
+
+initial_conditions:
+  regions:
+    - id: 1 # upstream region
+      flow: dam_top_ic
+    - id: 2 # downstream region
+      flow: dam_bottom_ic
+
+# The mesh contains three boundaries on which following BCs are being
+# applied:
+# 1. "boundary"    : Reflecting wall BC
+# 2. "top_wall"    : Reflecting wall BC
+# 3. "bottom_wall" : Critical outflow BC
+#
+# Below we define BCs for "top_wall" and "bottom_wall", but do not specify
+# the BC for "boundary". If no BC is specified for a boundary, the reflecting
+# wall BC is assumed.
+boundary_conditions:
+  - id: 1
+    flow: dam_top_ic
+  - id: 2 # top_wall
+    flow: reflecting_bc
+  - id: 3 # bottom_wall
+    flow: outflow_bc
+
+
+flow_conditions:
+  - name: dam_top_ic
+    type: dirichlet
+    height: 10
+    momentum: [0, 0]
+  - name: dam_bottom_ic
+    type: dirichlet
+    height: 5
+    momentum: [0, 0]
+  - name: reflecting_bc
+    type: reflecting
+  - name: outflow_bc
+    type: critical-outflow

--- a/include/finclude/rdycore.h
+++ b/include/finclude/rdycore.h
@@ -1,0 +1,9 @@
+#if !defined (RDYCORECOREDEF_H)
+#define RDYCORECOREDEF_H
+
+#define CONDITION_DIRICHLET        0
+#define CONDITION_NEUMANN          1
+#define CONDITION_REFLECTING       2
+#define CONDITION_CRITICAL_OUTFLOW 3
+
+#endif

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -5,6 +5,7 @@
 #include <limits.h>
 #include <petscviewer.h>
 #include <private/rdylogimpl.h>
+#include <rdycore.h>
 
 // The types in this file ѕerve as an intermediate representation for our input
 // configuration file:
@@ -204,14 +205,6 @@ typedef struct {
 // initial, boundary and source conditions
 // ---------------------------------------
 // The following data structures are used in several sections.
-
-// "kinds" of initial/boundary/source conditions applied to regions/boundaries
-typedef enum {
-  CONDITION_DIRICHLET = 0,    // Dirichlet condition (value is specified)
-  CONDITION_NEUMANN,          // Neumann condition (derivative is specified)
-  CONDITION_REFLECTING,       // Reflecting condition
-  CONDITION_CRITICAL_OUTFLOW  // Critical flow
-} RDyConditionType;
 
 // This type defines an initial/boundary condition and/or source/sink with named
 // flow, sediment, and salinity conditions.

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -38,5 +38,6 @@ PETSC_INTERN PetscErrorCode RiemannDataSWEDestroy(RiemannDataSWE);
 
 PETSC_INTERN PetscErrorCode CreatePetscSWEFlux(PetscInt num_internal_edges, PetscInt n, RDyBoundary[n], void **);
 PETSC_INTERN PetscErrorCode CreatePetscSWESource(RDyMesh *, void *);
+PETSC_INTERN PetscErrorCode InitBoundaryPetscSWEFlux(RDyCells *, RDyEdges *, PetscInt n, RDyBoundary[n], RDyCondition[n], PetscReal, void **);
 
 #endif  // rdyswe_h

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -36,7 +36,7 @@ PETSC_INTERN PetscErrorCode GetRiemannFluxFromSWESourceOperator(CeedOperator, Ce
 PETSC_INTERN PetscErrorCode RiemannDataSWECreate(PetscInt, RiemannDataSWE *);
 PETSC_INTERN PetscErrorCode RiemannDataSWEDestroy(RiemannDataSWE);
 
-PETSC_INTERN PetscErrorCode CreatePetscSWEFlux(RDyMesh *, PetscInt n, RDyBoundary[n], void **);
+PETSC_INTERN PetscErrorCode CreatePetscSWEFlux(PetscInt num_internal_edges, PetscInt n, RDyBoundary[n], void **);
 PETSC_INTERN PetscErrorCode CreatePetscSWESource(RDyMesh *, void *);
 
 #endif  // rdyswe_h

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -45,6 +45,7 @@ PETSC_EXTERN PetscErrorCode RDyGetStep(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDySetCouplingInterval(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditions(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy, PetscReal*);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -47,6 +47,7 @@ PETSC_EXTERN PetscErrorCode RDySetCouplingInterval(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditions(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy, PetscInt, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryConditionFlowType(RDy, PetscInt, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy, PetscReal*);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -46,7 +46,7 @@ PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDySetCouplingInterval(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditions(RDy, PetscInt*);
-PETSC_EXTERN PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy, PetscInt, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditionEdges(RDy, PetscInt, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetBoundaryConditionFlowType(RDy, PetscInt, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDySetDirichletBoundaryConditionValues(RDy, PetscInt, PetscInt, PetscInt, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -48,6 +48,7 @@ PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditions(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy, PetscInt, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetBoundaryConditionFlowType(RDy, PetscInt, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDySetDirichletBoundaryConditionValues(RDy, PetscInt, PetscInt, PetscInt, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy, PetscReal*);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -52,4 +52,12 @@ PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDySetWaterSource(RDy, PetscReal*);
 
+// "kinds" of initial/boundary/source conditions applied to regions/boundaries
+typedef enum {
+  CONDITION_DIRICHLET = 0,    // Dirichlet condition (value is specified)
+  CONDITION_NEUMANN,          // Neumann condition (derivative is specified)
+  CONDITION_REFLECTING,       // Reflecting condition
+  CONDITION_CRITICAL_OUTFLOW  // Critical flow
+} RDyConditionType;
+
 #endif

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -46,6 +46,7 @@ PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDySetCouplingInterval(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditions(RDy, PetscInt*);
+PETSC_EXTERN PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy, PetscInt, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetHeight(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetXVelocity(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetYVelocity(RDy, PetscReal*);

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -9,7 +9,7 @@ module rdycore
 
   public :: RDyDouble, RDy, RDyInit, RDyFinalize, RDyInitialized, &
             RDyCreate, RDySetup, RDyAdvance, RDyDestroy, &
-            RDyGetNumLocalCells, RDyGetHeight, &
+            RDyGetNumLocalCells, RDyGetNumBoundaryConditions, RDyGetHeight, &
             RDyGetXVelocity, RDyGetYVelocity
 
   ! RDycore uses double-precision floating point numbers
@@ -55,6 +55,19 @@ module rdycore
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr),    value, intent(in)  :: rdy
       integer(c_int),        intent(out) :: num_cells
+    end function
+
+    integer(c_int) function rdygetnumboundaryconditions_(rdy, num_bnd_conds) bind(c, name="RDyGetNumBoundaryConditions")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr),    value, intent(in)  :: rdy
+      integer(c_int),        intent(out) :: num_bnd_conds
+    end function
+
+    integer(c_int) function rdygetnumedgesinaboundaryconditions_(rdy, bnd_cond_id, num_edges) bind(c, name="RDyGetNumEdgesInABoundaryConditions")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr),    value, intent(in)  :: rdy
+      integer(c_int), value, intent(in)  :: bnd_cond_id
+      integer(c_int),        intent(out) :: num_edges
     end function
 
     integer(c_int) function rdygettime_(rdy, time) bind(c, name="RDyGetTime")
@@ -193,6 +206,21 @@ contains
     integer,   intent(out)   :: num_cells
     integer,   intent(out)   :: ierr
     ierr = rdygetnumlocalcells_(rdy_%c_rdy, num_cells)
+  end subroutine
+
+  subroutine RDyGetNumBoundaryConditions(rdy_, num_bnd_conds, ierr)
+    type(RDy), intent(inout) :: rdy_
+    integer,   intent(out)   :: num_bnd_conds
+    integer,   intent(out)   :: ierr
+    ierr = rdygetnumboundaryconditions_(rdy_%c_rdy, num_bnd_conds)
+  end subroutine
+
+  subroutine RDyGetNumEdgesInABoundaryConditions(rdy_, bnd_cond_id, num_edges, ierr)
+    type(RDy), intent(inout) :: rdy_
+    integer,   intent(in)    :: bnd_cond_id
+    integer,   intent(out)   :: num_edges
+    integer,   intent(out)   :: ierr
+    ierr = rdygetnumedgesinaboundaryconditions_(rdy_%c_rdy, bnd_cond_id, num_edges)
   end subroutine
 
   subroutine RDyGetTime(rdy_, time, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -11,6 +11,7 @@ module rdycore
             RDyCreate, RDySetup, RDyAdvance, RDyDestroy, &
             RDyGetNumLocalCells, RDyGetNumBoundaryConditions, &
             RDyGetNumEdgesInABoundaryConditions, RDyGetBoundaryConditionFlowType, &
+            RDySetDirichletBoundaryConditionValues, &
             RDyGetHeight, RDyGetXVelocity, RDyGetYVelocity
 
   ! RDycore uses double-precision floating point numbers
@@ -69,6 +70,15 @@ module rdycore
       type(c_ptr),    value, intent(in)  :: rdy
       integer(c_int), value, intent(in)  :: bnd_cond_id
       integer(c_int),        intent(out) :: num_edges
+    end function
+
+    integer(c_int) function rdysetdirichletboundaryconditionvalues_(rdy, bnd_cond_id, num_edges, ndof, bc_values) bind(c, name="RDySetDirichletBoundaryConditionValues")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr),    value, intent(in)  :: rdy
+      integer(c_int), value, intent(in)  :: bnd_cond_id
+      integer(c_int), value, intent(in)  :: num_edges
+      integer(c_int), value, intent(in)  :: ndof
+      type(c_ptr), value, intent(in)     :: bc_values
     end function
 
     integer(c_int) function rdygetboundaryconditionflowtype_(rdy, bnd_cond_id, bnd_cond_type) bind(c, name="RDyGetBoundaryConditionFlowType")
@@ -229,6 +239,16 @@ contains
     integer,   intent(out)   :: num_edges
     integer,   intent(out)   :: ierr
     ierr = rdygetnumedgesinaboundaryconditions_(rdy_%c_rdy, bnd_cond_id-1, num_edges)
+  end subroutine
+
+  subroutine RDySetDirichletBoundaryConditionValues(rdy_, bnd_cond_id, num_edges, ndof, bc_values, ierr)
+    type(RDy),       intent(inout)       :: rdy_
+    integer,         intent(in)          :: bnd_cond_id
+    integer,         intent(in)          :: num_edges
+    integer,         intent(in)          :: ndof
+    real(RDyDouble), pointer, intent(in) :: bc_values(:)
+    integer,         intent(out)         :: ierr
+    ierr = rdysetdirichletboundaryconditionvalues_(rdy_%c_rdy, bnd_cond_id-1, num_edges, ndof, c_loc(bc_values))
   end subroutine
 
   subroutine RDyGetBoundaryConditionFlowType(rdy_, bnd_cond_id, bnd_cond_type, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -220,7 +220,7 @@ contains
     integer,   intent(in)    :: bnd_cond_id
     integer,   intent(out)   :: num_edges
     integer,   intent(out)   :: ierr
-    ierr = rdygetnumedgesinaboundaryconditions_(rdy_%c_rdy, bnd_cond_id, num_edges)
+    ierr = rdygetnumedgesinaboundaryconditions_(rdy_%c_rdy, bnd_cond_id-1, num_edges)
   end subroutine
 
   subroutine RDyGetTime(rdy_, time, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -10,7 +10,7 @@ module rdycore
   public :: RDyDouble, RDy, RDyInit, RDyFinalize, RDyInitialized, &
             RDyCreate, RDySetup, RDyAdvance, RDyDestroy, &
             RDyGetNumLocalCells, RDyGetNumBoundaryConditions, &
-            RDyGetNumEdgesInABoundaryConditions, RDyGetBoundaryConditionFlowType, &
+            RDyGetNumBoundaryConditionEdges, RDyGetBoundaryConditionFlowType, &
             RDySetDirichletBoundaryConditionValues, &
             RDyGetHeight, RDyGetXVelocity, RDyGetYVelocity
 
@@ -65,7 +65,7 @@ module rdycore
       integer(c_int),        intent(out) :: num_bnd_conds
     end function
 
-    integer(c_int) function rdygetnumedgesinaboundaryconditions_(rdy, bnd_cond_id, num_edges) bind(c, name="RDyGetNumEdgesInABoundaryConditions")
+    integer(c_int) function rdygetnumboundaryconditionedges_(rdy, bnd_cond_id, num_edges) bind(c, name="RDyGetNumBoundaryConditionEdges")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr),    value, intent(in)  :: rdy
       integer(c_int), value, intent(in)  :: bnd_cond_id
@@ -233,12 +233,12 @@ contains
     ierr = rdygetnumboundaryconditions_(rdy_%c_rdy, num_bnd_conds)
   end subroutine
 
-  subroutine RDyGetNumEdgesInABoundaryConditions(rdy_, bnd_cond_id, num_edges, ierr)
+  subroutine RDyGetNumBoundaryConditionEdges(rdy_, bnd_cond_id, num_edges, ierr)
     type(RDy), intent(inout) :: rdy_
     integer,   intent(in)    :: bnd_cond_id
     integer,   intent(out)   :: num_edges
     integer,   intent(out)   :: ierr
-    ierr = rdygetnumedgesinaboundaryconditions_(rdy_%c_rdy, bnd_cond_id-1, num_edges)
+    ierr = rdygetnumboundaryconditionedges_(rdy_%c_rdy, bnd_cond_id-1, num_edges)
   end subroutine
 
   subroutine RDySetDirichletBoundaryConditionValues(rdy_, bnd_cond_id, num_edges, ndof, bc_values, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -9,8 +9,9 @@ module rdycore
 
   public :: RDyDouble, RDy, RDyInit, RDyFinalize, RDyInitialized, &
             RDyCreate, RDySetup, RDyAdvance, RDyDestroy, &
-            RDyGetNumLocalCells, RDyGetNumBoundaryConditions, RDyGetHeight, &
-            RDyGetXVelocity, RDyGetYVelocity
+            RDyGetNumLocalCells, RDyGetNumBoundaryConditions, &
+            RDyGetNumEdgesInABoundaryConditions, RDyGetBoundaryConditionFlowType, &
+            RDyGetHeight, RDyGetXVelocity, RDyGetYVelocity
 
   ! RDycore uses double-precision floating point numbers
   integer, parameter :: RDyDouble = selected_real_kind(12)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -70,6 +70,13 @@ module rdycore
       integer(c_int),        intent(out) :: num_edges
     end function
 
+    integer(c_int) function rdygetboundaryconditionflowtype_(rdy, bnd_cond_id, bnd_cond_type) bind(c, name="RDyGetBoundaryConditionFlowType")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr),    value, intent(in)  :: rdy
+      integer(c_int), value, intent(in)  :: bnd_cond_id
+      integer(c_int),        intent(out) :: bnd_cond_type
+    end function
+
     integer(c_int) function rdygettime_(rdy, time) bind(c, name="RDyGetTime")
       use iso_c_binding, only: c_int, c_ptr, c_double
       type(c_ptr),    value, intent(in)  :: rdy
@@ -221,6 +228,14 @@ contains
     integer,   intent(out)   :: num_edges
     integer,   intent(out)   :: ierr
     ierr = rdygetnumedgesinaboundaryconditions_(rdy_%c_rdy, bnd_cond_id-1, num_edges)
+  end subroutine
+
+  subroutine RDyGetBoundaryConditionFlowType(rdy_, bnd_cond_id, bnd_cond_type, ierr)
+    type(RDy), intent(inout) :: rdy_
+    integer,   intent(in)    :: bnd_cond_id
+    integer,   intent(out)   :: bnd_cond_type
+    integer,   intent(out)   :: ierr
+    ierr = rdygetboundaryconditionflowtype_(rdy_%c_rdy, bnd_cond_id-1, bnd_cond_type)
   end subroutine
 
   subroutine RDyGetTime(rdy_, time, ierr)

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -17,10 +17,9 @@ PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy rdy, PetscInt bnd_cond_id
   PetscFunctionBegin;
   PetscCheck(bnd_cond_id < rdy->num_boundaries, rdy->comm, PETSC_ERR_USER,
              "Boundary condition ID (%d) exceeds the max number of boundary conditions (%d)", bnd_cond_id, rdy->num_boundaries);
-  PetscCheck(bnd_cond_id >= 0, rdy->comm, PETSC_ERR_USER,
-             "Boundary condition ID (%d) cannot be less than zero.", bnd_cond_id);
-  RDyBoundary *boundary  = &rdy->boundaries[bnd_cond_id];
-  *num_edges = boundary->num_edges;
+  PetscCheck(bnd_cond_id >= 0, rdy->comm, PETSC_ERR_USER, "Boundary condition ID (%d) cannot be less than zero.", bnd_cond_id);
+  RDyBoundary *boundary = &rdy->boundaries[bnd_cond_id];
+  *num_edges            = boundary->num_edges;
   PetscFunctionReturn(0);
 }
 

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -53,7 +53,8 @@ PetscErrorCode RDySetDirichletBoundaryConditionValues(RDy rdy, PetscInt bnd_cond
 
   RDyCondition *boundary_cond = &rdy->boundary_conditions[bnd_cond_id];
   PetscCheck(boundary_cond->flow->type == CONDITION_DIRICHLET, rdy->comm, PETSC_ERR_USER,
-             "Trying to set dirichlet values for boundary condition (%d), but it is of a different type (%d)", bnd_cond_id, boundary_cond->flow->type);
+             "Trying to set dirichlet values for boundary condition (%d), but it is of a different type (%d)", bnd_cond_id,
+             boundary_cond->flow->type);
 
   RDyCells            *cells    = &rdy->mesh.cells;
   RDyEdges            *edges    = &rdy->mesh.edges;

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -1,4 +1,5 @@
 #include <private/rdycoreimpl.h>
+#include <private/rdysweimpl.h>
 #include <rdycore.h>
 
 PetscErrorCode RDyGetNumLocalCells(RDy rdy, PetscInt *num_cells) {
@@ -13,11 +14,18 @@ PetscErrorCode RDyGetNumBoundaryConditions(RDy rdy, PetscInt *num_bnd_conds) {
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy rdy, PetscInt bnd_cond_id, PetscInt *num_edges) {
+static PetscErrorCode CheckBoundaryConditionID(RDy rdy, PetscInt bnd_cond_id) {
   PetscFunctionBegin;
   PetscCheck(bnd_cond_id < rdy->num_boundaries, rdy->comm, PETSC_ERR_USER,
              "Boundary condition ID (%d) exceeds the max number of boundary conditions (%d)", bnd_cond_id, rdy->num_boundaries);
+
   PetscCheck(bnd_cond_id >= 0, rdy->comm, PETSC_ERR_USER, "Boundary condition ID (%d) cannot be less than zero.", bnd_cond_id);
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy rdy, PetscInt bnd_cond_id, PetscInt *num_edges) {
+  PetscFunctionBegin;
+  PetscCall(CheckBoundaryConditionID(rdy, bnd_cond_id));
   RDyBoundary *boundary = &rdy->boundaries[bnd_cond_id];
   *num_edges            = boundary->num_edges;
   PetscFunctionReturn(0);
@@ -25,11 +33,50 @@ PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy rdy, PetscInt bnd_cond_id
 
 PetscErrorCode RDyGetBoundaryConditionFlowType(RDy rdy, PetscInt bnd_cond_id, PetscInt *bc_type) {
   PetscFunctionBegin;
-  PetscCheck(bnd_cond_id < rdy->num_boundaries, rdy->comm, PETSC_ERR_USER,
-             "Boundary condition ID (%d) exceeds the max number of boundary conditions (%d)", bnd_cond_id, rdy->num_boundaries);
-  PetscCheck(bnd_cond_id >= 0, rdy->comm, PETSC_ERR_USER, "Boundary condition ID (%d) cannot be less than zero.", bnd_cond_id);
+  PetscCall(CheckBoundaryConditionID(rdy, bnd_cond_id));
   RDyCondition *boundary_cond = &rdy->boundary_conditions[bnd_cond_id];
   *bc_type                    = boundary_cond->flow->type;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode RDySetDirichletBoundaryConditionValues(RDy rdy, PetscInt bnd_cond_id, PetscInt num_edges, PetscInt ndof, PetscReal *bc_values) {
+  PetscFunctionBegin;
+
+  PetscCall(CheckBoundaryConditionID(rdy, bnd_cond_id));
+
+  PetscCheck(ndof == 3, rdy->comm, PETSC_ERR_USER, "The number of DOFs (%d) for the boundary condition ID (%d) need to be three.", ndof, bnd_cond_id);
+
+  RDyBoundary *boundary = &rdy->boundaries[bnd_cond_id];
+  PetscCheck(boundary->num_edges == num_edges, rdy->comm, PETSC_ERR_USER,
+             "The number of edges (%d) in the data to set boundary condition for ID = %d, do not match the actual number of edge (%d)", num_edges,
+             bnd_cond_id, boundary->num_edges);
+
+  RDyCondition *boundary_cond = &rdy->boundary_conditions[bnd_cond_id];
+  PetscCheck(boundary_cond->flow->type == CONDITION_DIRICHLET, rdy->comm, PETSC_ERR_USER,
+             "Trying to set dirchlet values for boundary condition (%d), but it is of a different type (%d)", bnd_cond_id, boundary_cond->flow->type);
+
+  RDyCells            *cells    = &rdy->mesh.cells;
+  RDyEdges            *edges    = &rdy->mesh.edges;
+  PetscRiemannDataSWE *data_swe = rdy->petsc_rhs;
+  RiemannDataSWE      *datar    = &data_swe->datar_bnd_edges[bnd_cond_id];
+  PetscReal            tiny_h   = rdy->config.physics.flow.tiny_h;
+
+  for (PetscInt e = 0; e < boundary->num_edges; ++e) {
+    PetscInt iedge = boundary->edge_ids[e];
+    PetscInt icell = edges->cell_ids[2 * iedge];
+
+    if (cells->is_local[icell]) {
+      datar->h[e] = bc_values[e * ndof];
+
+      if (datar->h[e] > tiny_h) {
+        datar->u[e] = bc_values[e * ndof + 1] / datar->h[e];
+        datar->v[e] = bc_values[e * ndof + 2] / datar->h[e];
+      } else {
+        datar->u[e] = 0.0;
+        datar->v[e] = 0.0;
+      }
+    }
+  }
   PetscFunctionReturn(0);
 }
 

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -23,6 +23,16 @@ PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy rdy, PetscInt bnd_cond_id
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode RDyGetBoundaryConditionFlowType(RDy rdy, PetscInt bnd_cond_id, PetscInt *bc_type) {
+  PetscFunctionBegin;
+  PetscCheck(bnd_cond_id < rdy->num_boundaries, rdy->comm, PETSC_ERR_USER,
+             "Boundary condition ID (%d) exceeds the max number of boundary conditions (%d)", bnd_cond_id, rdy->num_boundaries);
+  PetscCheck(bnd_cond_id >= 0, rdy->comm, PETSC_ERR_USER, "Boundary condition ID (%d) cannot be less than zero.", bnd_cond_id);
+  RDyCondition *boundary_cond = &rdy->boundary_conditions[bnd_cond_id];
+  *bc_type                    = boundary_cond->flow->type;
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode RDyGetHeight(RDy rdy, PetscReal *h) {
   PetscFunctionBegin;
 

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -23,7 +23,7 @@ static PetscErrorCode CheckBoundaryConditionID(RDy rdy, PetscInt bnd_cond_id) {
   PetscFunctionReturn(0);
 }
 
-PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy rdy, PetscInt bnd_cond_id, PetscInt *num_edges) {
+PetscErrorCode RDyGetNumBoundaryConditionEdges(RDy rdy, PetscInt bnd_cond_id, PetscInt *num_edges) {
   PetscFunctionBegin;
   PetscCall(CheckBoundaryConditionID(rdy, bnd_cond_id));
   RDyBoundary *boundary = &rdy->boundaries[bnd_cond_id];

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -53,7 +53,7 @@ PetscErrorCode RDySetDirichletBoundaryConditionValues(RDy rdy, PetscInt bnd_cond
 
   RDyCondition *boundary_cond = &rdy->boundary_conditions[bnd_cond_id];
   PetscCheck(boundary_cond->flow->type == CONDITION_DIRICHLET, rdy->comm, PETSC_ERR_USER,
-             "Trying to set dirchlet values for boundary condition (%d), but it is of a different type (%d)", bnd_cond_id, boundary_cond->flow->type);
+             "Trying to set dirichlet values for boundary condition (%d), but it is of a different type (%d)", bnd_cond_id, boundary_cond->flow->type);
 
   RDyCells            *cells    = &rdy->mesh.cells;
   RDyEdges            *edges    = &rdy->mesh.edges;

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -7,6 +7,23 @@ PetscErrorCode RDyGetNumLocalCells(RDy rdy, PetscInt *num_cells) {
   PetscFunctionReturn(0);
 }
 
+PetscErrorCode RDyGetNumBoundaryConditions(RDy rdy, PetscInt *num_bnd_conds) {
+  PetscFunctionBegin;
+  *num_bnd_conds = rdy->num_boundaries;
+  PetscFunctionReturn(0);
+}
+
+PetscErrorCode RDyGetNumEdgesInABoundaryConditions(RDy rdy, PetscInt bnd_cond_id, PetscInt *num_edges) {
+  PetscFunctionBegin;
+  PetscCheck(bnd_cond_id < rdy->num_boundaries, rdy->comm, PETSC_ERR_USER,
+             "Boundary condition ID (%d) exceeds the max number of boundary conditions (%d)", bnd_cond_id, rdy->num_boundaries);
+  PetscCheck(bnd_cond_id >= 0, rdy->comm, PETSC_ERR_USER,
+             "Boundary condition ID (%d) cannot be less than zero.", bnd_cond_id);
+  RDyBoundary *boundary  = &rdy->boundaries[bnd_cond_id];
+  *num_edges = boundary->num_edges;
+  PetscFunctionReturn(0);
+}
+
 PetscErrorCode RDyGetHeight(RDy rdy, PetscReal *h) {
   PetscFunctionBegin;
 

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -1046,6 +1046,8 @@ PetscErrorCode RDySetup(RDy rdy) {
     RDyLogDebug(rdy, "Allocating PETSc data structures for fluxes and sources...");
     PetscCall(CreatePetscSWEFlux(rdy->mesh.num_internal_edges, rdy->num_boundaries, rdy->boundaries, &rdy->petsc_rhs));
     PetscCall(CreatePetscSWESource(&rdy->mesh, rdy->petsc_rhs));
+    PetscCall(InitBoundaryPetscSWEFlux(&rdy->mesh.cells, &rdy->mesh.edges, rdy->num_boundaries, rdy->boundaries, rdy->boundary_conditions,
+                                       rdy->config.physics.flow.tiny_h, &rdy->petsc_rhs));
   }
 
   PetscFunctionReturn(0);

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -1044,7 +1044,7 @@ PetscErrorCode RDySetup(RDy rdy) {
     // allocate storage for our PETSc implementation of the  flux and
     // source terms
     RDyLogDebug(rdy, "Allocating PETSc data structures for fluxes and sources...");
-    PetscCall(CreatePetscSWEFlux(&rdy->mesh, rdy->num_boundaries, rdy->boundaries, &rdy->petsc_rhs));
+    PetscCall(CreatePetscSWEFlux(rdy->mesh.num_internal_edges, rdy->num_boundaries, rdy->boundaries, &rdy->petsc_rhs));
     PetscCall(CreatePetscSWESource(&rdy->mesh, rdy->petsc_rhs));
   }
 

--- a/src/swe/swe_flux_petsc.c
+++ b/src/swe/swe_flux_petsc.c
@@ -447,9 +447,9 @@ static PetscErrorCode ApplyReflectingBC(RDy rdy, RDyBoundary *boundary, RiemannD
   PetscFunctionReturn(0);
 }
 
-// applies a dirchlet boundary condition on the given boundary, computing
+// applies a dirichlet boundary condition on the given boundary, computing
 // fluxes F for the solution vector components X
-static PetscErrorCode ApplyDirchletBC(RDy rdy, RDyBoundary *boundary, RDyCondition *boundary_cond, RiemannDataSWE *datal, RiemannDataSWE *datar,
+static PetscErrorCode ApplyDirichletBC(RDy rdy, RDyBoundary *boundary, RDyCondition *boundary_cond, RiemannDataSWE *datal, RiemannDataSWE *datar,
                                       RiemannDataSWE *datac, PetscReal tiny_h, CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
   PetscFunctionBeginUser;
 
@@ -530,7 +530,7 @@ PetscErrorCode SWERHSFunctionForBoundaryEdges(RDy rdy, Vec F, CourantNumberDiagn
 
     switch (rdy->boundary_conditions[b].flow->type) {
       case CONDITION_DIRICHLET:
-        PetscCall(ApplyDirchletBC(rdy, boundary, boundary_cond, datal, datar, datac, tiny_h, courant_num_diags, f_ptr));
+        PetscCall(ApplyDirichletBC(rdy, boundary, boundary_cond, datal, datar, datac, tiny_h, courant_num_diags, f_ptr));
         break;
       case CONDITION_REFLECTING:
         PetscCall(ApplyReflectingBC(rdy, boundary, datal, datar, datac, tiny_h, courant_num_diags, f_ptr));

--- a/src/swe/swe_flux_petsc.c
+++ b/src/swe/swe_flux_petsc.c
@@ -11,14 +11,12 @@ static const PetscReal GRAVITY = 9.806;
 
 /// For computing fluxes, allocates structs to hold values left and right
 /// of internal and boundary edges. This must be called before CreatePetscSWESource.
-PetscErrorCode CreatePetscSWEFlux(RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary boundaries[num_boundaries], void **petsc_rhs) {
+PetscErrorCode CreatePetscSWEFlux(PetscInt num_internal_edges, PetscInt num_boundaries, RDyBoundary boundaries[num_boundaries], void **petsc_rhs) {
   PetscFunctionBegin;
 
-  PetscInt num = mesh->num_internal_edges;
-
   RiemannDataSWE datal, datar;
-  PetscCall(RiemannDataSWECreate(num, &datal));
-  PetscCall(RiemannDataSWECreate(num, &datar));
+  PetscCall(RiemannDataSWECreate(num_internal_edges, &datal));
+  PetscCall(RiemannDataSWECreate(num_internal_edges, &datar));
 
   RiemannDataSWE *datal_bnd, *datar_bnd;
   PetscCall(RDyAlloc(sizeof(RiemannDataSWE), num_boundaries, &datal_bnd));

--- a/src/swe/swe_flux_petsc.c
+++ b/src/swe/swe_flux_petsc.c
@@ -59,7 +59,8 @@ PetscErrorCode CreatePetscSWESource(RDyMesh *mesh, void *petsc_rhs) {
 }
 
 // Initialize the data on the right handside of the boundary edges.
-PetscErrorCode InitBoundaryPetscSWEFlux(RDyCells *cells, RDyEdges *edges, PetscInt num_boundaries, RDyBoundary boundaries[num_boundaries], RDyCondition boundary_conditions[num_boundaries], PetscReal tiny_h, void **petsc_rhs) {
+PetscErrorCode InitBoundaryPetscSWEFlux(RDyCells *cells, RDyEdges *edges, PetscInt num_boundaries, RDyBoundary boundaries[num_boundaries],
+                                        RDyCondition boundary_conditions[num_boundaries], PetscReal tiny_h, void **petsc_rhs) {
   PetscFunctionBegin;
 
   PetscRiemannDataSWE *data_swe = *petsc_rhs;
@@ -448,8 +449,8 @@ static PetscErrorCode ApplyReflectingBC(RDy rdy, RDyBoundary *boundary, RiemannD
 
 // applies a dirchlet boundary condition on the given boundary, computing
 // fluxes F for the solution vector components X
-static PetscErrorCode ApplyDirchletBC(RDy rdy, RDyBoundary *boundary, RDyCondition *boundary_cond, RiemannDataSWE *datal, RiemannDataSWE *datar, RiemannDataSWE *datac,
-                                        PetscReal tiny_h, CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
+static PetscErrorCode ApplyDirchletBC(RDy rdy, RDyBoundary *boundary, RDyCondition *boundary_cond, RiemannDataSWE *datal, RiemannDataSWE *datar,
+                                      RiemannDataSWE *datac, PetscReal tiny_h, CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
   PetscFunctionBeginUser;
 
   PetscInt  num = boundary->num_edges;

--- a/src/swe/swe_flux_petsc.c
+++ b/src/swe/swe_flux_petsc.c
@@ -82,8 +82,8 @@ PetscErrorCode InitBoundaryPetscSWEFlux(RDyCells *cells, RDyEdges *edges, PetscI
             datar->h[e] = flow_bc->height;
 
             if (flow_bc->height > tiny_h) {
-              datar->u[e] = flow_bc->momentum[0]/flow_bc->height;
-              datar->v[e] = flow_bc->momentum[1]/flow_bc->height;
+              datar->u[e] = flow_bc->momentum[0] / flow_bc->height;
+              datar->v[e] = flow_bc->momentum[1] / flow_bc->height;
             } else {
               datar->u[e] = 0.0;
               datar->v[e] = 0.0;

--- a/src/swe/swe_flux_petsc.c
+++ b/src/swe/swe_flux_petsc.c
@@ -450,7 +450,7 @@ static PetscErrorCode ApplyReflectingBC(RDy rdy, RDyBoundary *boundary, RiemannD
 // applies a dirichlet boundary condition on the given boundary, computing
 // fluxes F for the solution vector components X
 static PetscErrorCode ApplyDirichletBC(RDy rdy, RDyBoundary *boundary, RDyCondition *boundary_cond, RiemannDataSWE *datal, RiemannDataSWE *datar,
-                                      RiemannDataSWE *datac, PetscReal tiny_h, CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
+                                       RiemannDataSWE *datac, PetscReal tiny_h, CourantNumberDiagnostics *courant_num_diags, PetscReal *F) {
   PetscFunctionBeginUser;
 
   PetscInt  num = boundary->num_edges;


### PR DESCRIPTION
- A time-invariant Dirichlet BC can be specified in the inputdeck.
- Multiple functions to query BCs are added.
- Also added is the ability for an external code (e.g., E3SM) to update the values for the Dirichlet BC.
- The current code modifications are only applicable to the PETSc code and similar changes for the CEED version will be added in the future.