### PR TITLE
Makes it possible to run with only time series as output

### DIFF
--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -134,7 +134,7 @@ typedef struct {
 // ---------------
 
 // output file formats
-typedef enum { OUTPUT_BINARY = 0, OUTPUT_XDMF, OUTPUT_CGNS } RDyOutputFormat;
+typedef enum { OUTPUT_NONE = 0, OUTPUT_BINARY, OUTPUT_XDMF, OUTPUT_CGNS } RDyOutputFormat;
 
 // time series output interval parameters appended to files
 typedef struct {

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -140,6 +140,9 @@ static PetscErrorCode CreateOutputViewer(RDy rdy) {
   if (rdy->config.output.interval) {
     RDyLogDebug(rdy, "Writing output every %d timestep(s)", rdy->config.output.interval);
     switch (rdy->config.output.format) {
+      case OUTPUT_NONE:
+        // nothing to do here
+        break;
       case OUTPUT_CGNS:
         // we've already configured this viewer in SetAdditionalOptions (see read_config_file.c)
         break;


### PR DESCRIPTION
This PR makes all entries in the output section of the YAML config file optional, letting us run configurations with only time series, etc.

This is a pretty simple fix, but we might want to add some more tests at some point that test whether all these output configurations are doing what we think they are. Perhaps this is easiest to do as complaints come in for the moment. :-)

Closes #100