### PR TITLE
Basic documentation structure and YAML input spec

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -35,5 +35,16 @@ jobs:
         run: mkdocs build --strict --verbose
       # deploy only when it is a push
       - if: ${{ github.event_name == 'push' }}
-        name: Deploy
-        run: mkdocs gh-deploy
+        name: GitHub Pages action
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          # Do not remove existing pr-preview pages
+          clean-exclude: pr-preview
+          folder: ./site/
+      # If it's a PR from within the same repo, deploy to a preview page
+      # For security reasons, PRs from forks cannot write into gh-pages for now
+      - if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+        name: Preview docs
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,39 @@
+name: Build and deploy gh-pages branch with Mkdocs
+
+on:
+  # Runs every time main branch is updated
+  push:
+    branches: ["main"]
+  # Runs every time a PR is open against main
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  # Prevent 2+ copies of this workflow from running concurrently
+  group: rdycore-docs-action
+
+jobs:
+  Build-and-Deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          show-progress: false
+          fetch-depth: 0 # Needed, or else gh-pages won't be fetched, and push rejected
+          submodules: false # speeds up clone and not building anything in submodules
+      - name: Show action trigger
+        run: echo "= The job was automatically triggered by a ${{github.event_name}} event."
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4.7.0
+        with:
+          python-version: "3.10"
+      - name: Install python deps
+        run: python3 -m pip install mkdocs-material pymdown-extensions mkdocs-monorepo-plugin mdutils mkdocs-bibtex
+      # build every time (PR or push to main)
+      - name: Build
+        run: mkdocs build --strict --verbose
+      # deploy only when it is a push
+      - if: ${{ github.event_name == 'push' }}
+        name: Deploy
+        run: mkdocs gh-deploy

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -1,0 +1,3 @@
+# RDycore Developer Guide
+
+More to come!

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,20 @@
+# Overview
+
+RDycore is a performance-portable, GPU-capable river model used to study
+compound flooding, intended for use with the Department of Energy's [Energy
+Exascale Earth System Model (E3SM)](https://e3sm.org).
+
+* The [Installation Guide](installation.md) shows you how to build and install
+  RDycore on your own machine or on a supported high-performance platform.
+* The [User Guide](user/index.md) describes how to use RDycore in its standalone and
+  E3SM-integrated forms.
+* The [Developer Guide](developer/index.md) lays out some basic principles and
+  guidelines we use in developing RDycore.
+
+### Acknowledgements
+
+RDycore is funded by the US Department of Energy's (DOE) [Scientific Discovery
+Through Advanced Computing (SciDAC)](https://www.scidac.gov/) program through a
+joint parternship between the DOE Office of Science's [Biological and
+Environmental Research](https://science.osti.gov/ber) and [Advanced
+Scientific Computing Research](https://science/osti.gov/ascr) programs.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,112 @@
+# Installation
+
+RDycore builds and runs on the following platforms:
+
+* Linux and Mac laptops and workstations
+* [Frontier](https://www.olcf.ornl.gov/frontier/) (Oak Ridge National Laboratory)
+* [Perlmutter](https://docs.nersc.gov/systems/perlmutter/) (NERSC)
+
+## Required Software
+
+To build RDycore, you need:
+
+* [CMake v3.14+](https://cmake.org/)
+* GNU Make
+* reliable C, C++, and Fortran compilers
+* a working MPI installation (like [OpenMPI](https://www.open-mpi.org/)
+  or [MPICH](https://www.mpich.org/))
+* [PETSc](https://petsc.org/release/) (Git revision `b3128c15e0e`), built with
+  the following third-party libraries:
+    * cgns
+    * exodusii
+    * fblaslapack
+    * hdf5
+    * libceed
+    * metis
+    * netcdf
+    * parmetis
+    * pnetcdf
+    * zlib
+
+You can obtain all of these freely on the Linux and Mac platforms. On Linux,
+just use your favorite package manager. On a Mac, you can get the Clang C/C++
+compiler by installing XCode, and then use a package manager like
+[Homebrew](https://brew.sh/) or [MacPorts](https://www.macports.org/) to get
+the rest.
+
+## Clone the Repository
+
+First, go get the [source code](https://github.com/RDycore/RDycore)
+at GitHub:
+
+=== "SSH"
+    ```bash
+    git clone git@github.com:RDycore/RDycore.git
+    ```
+=== "HTTPS"
+    ```bash
+    git clone https://github.com/RDycore/RDycore.git
+    ```
+
+This places an `RDycore` folder into your current path.
+
+## Configure RDycore
+
+RDycore uses CMake, and can be easily configured as long as
+[PETSc is installed](https://petsc.org/release/install/) and [the `PETSC_DIR`
+and `PETSC_ARCH` environment variables are set
+properly](https://petsc.org/release/install/multibuild/#environmental-variables-petsc-dir-and-petsc-arch).
+Usually all you need to do is change to your `RDycore` source directory and type
+
+```bash
+cmake -S . -B build
+```
+
+where `build` is the name of your build directory relative to the source
+directory. If you want to install RDycore somewhere afterward, e.g. to be able
+to configure E3SM to use it, you can set the prefix for the installation path
+using the `CMAKE_INSTALL_PREFIX` parameter:
+
+```bash
+cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/path/to/install
+```
+
+## Build, Test, and Install RDycore
+
+After you've configured RDycore, you can build it:
+
+1. From the build directory, type `make -j` to build the library.
+4. To run tests for the library (and the included drivers), type
+   `make test`.
+5. To install the model to the location (indicated by your `CMAKE_INSTALL_PREFIX`,
+   if you specified it), type `make install`. By default, products are installed
+   in the `include`, `lib`, `bin`, and `share` subdirectories of this prefix.
+
+## Making code changes and rebuilding
+
+Notice that you must build RDycore in a  **build tree**, separate from its source
+trees. This is standard practice in CMake-based build systems, and it allows you
+to build several different configurations without leaving generated and compiled
+files all over your source directory. However, you might have to change the way
+you work in order to be productive in this kind of environment.
+
+When you make a code change, make sure you build from the build directory that
+you created in step 1 above:
+
+```bash
+cd /path/to/RDycore/build
+make -j
+```
+
+You can also run tests from this build directory with `make test`.
+
+This is very different from how some people like to work. One method of making
+this easier is to use an editor in a dedicated window, and have another window
+open with a terminal, sitting in your `build` directory. If you're using a fancy
+modern editor, it might have a CMake-based workflow that handles all of this for
+you.
+
+The build directory has a structure that mirrors the source directory, and you
+can type `make` in any one of its subdirectories to do partial builds. In
+practice, though, it's safest to always build from the top of the build tree.
+

--- a/docs/javascript/mathjax.js
+++ b/docs/javascript/mathjax.js
@@ -1,0 +1,17 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise()
+})
+

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -1,0 +1,5 @@
+# RDycore User Guide
+
+* [YAML input specification](input.md)
+
+More soon!

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -114,8 +114,8 @@ flow_conditions:
     momentum: [0, 0]
   - name: dam_bottom_ic
     type: dirichlet
-    height: 5
-    momentum: [0, 0]
+    file: dam_ics.dat
+    format: binary
   - name: reflecting_bc
     type: reflecting
   - name: outflow_bc
@@ -144,14 +144,26 @@ elsewhere in the file. The parameters that define a flow condition are
       is defined by a critical outflow condition. Useful only for boundary
       conditions.
 
-In the case of a Dirichlet condition, flow is prescribed by the following
-parameters:
+In the case of a Dirichlet condition, flow is prescribed by providing parameters
+to set the water height and momentum. This can be done in one of two ways:
 
-* `height`: the height of water [m] at the relevant point (within a cell
-  or on its boundary)
-* `momentum`: a 2-component sequence/list containing the `x` and `y` components
-  of the momentum [kg m/s] at the relevant point (within a cell or on its
-  boundary)
+1. By specifying the parameters directly using the following fields:
+
+    * `height`: the height of water [m] at the relevant point (within a cell
+      or on its boundary)
+    * `momentum`: a 2-component sequence/list containing the `x` and `y` components
+      of the momentum [kg m/s] at the relevant point (within a cell or on its
+      boundary)
+
+2. By specifying a file from which data for these parameters is to be read. The
+   data will be read into the components of the solution vector that correspond
+   to the cells belonging to the region to which this flow condition is
+   assigned:
+
+   * `file`: the path for the file from which data is read, specified relative
+     to the directory in which the RDycore executable was run.
+   * `format`: the format of the data in the file, which current must be
+     `binary` (specifying PETSc's binary format).
 
 ## `grid`
 
@@ -362,8 +374,20 @@ that define a salinity condition are
       only for boundary conditions. Currently, only homogeneous Neumann conditions
       are supported.
 
-In the case of a Dirichlet condition, a salinity concentration is prescribed
-by a `concentration` parameter.
+In the case of a Dirichlet condition, a salinity concentration is prescribed by
+providing one or more parameters. This can be done in one of two ways:
+
+1. By specifying the concentration directly using the `concentration` parameter
+
+2. By specifying a file from which concentration data is to be read. The
+   data will be read into the components of the solution vector that correspond
+   to the cells belonging to the region to which this flow condition is
+   assigned:
+
+   * `file`: the path for the file from which data is read, specified relative
+     to the directory in which the RDycore executable was run.
+   * `format`: the format of the data in the file, which current must be
+     `binary` (specifying PETSc's binary format).
 
 ## `sediment_conditions`
 
@@ -391,8 +415,20 @@ that define a sediment condition are
       useful only for boundary conditions. Currently, only homogeneous Neumann
       conditions are supported.
 
-In the case of a Dirichlet condition, a sediment concentrations is prescribed
-by a `concentration` parameter.
+In the case of a Dirichlet condition, a sediment concentration is prescribed by
+providing one or more parameters. This can be done in one of two ways:
+
+1. By specifying the concentration directly using the `concentration` parameter
+
+2. By specifying a file from which concentration data is to be read. The
+   data will be read into the components of the solution vector that correspond
+   to the cells belonging to the region to which this flow condition is
+   assigned:
+
+   * `file`: the path for the file from which data is read, specified relative
+     to the directory in which the RDycore executable was run.
+   * `format`: the format of the data in the file, which current must be
+     `binary` (specifying PETSc's binary format).
 
 ## `sources`
 

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -1,3 +1,127 @@
 # RDycore YAML Input Specification
 
+You can configure an RDycore simulation by creating a text file that uses
+the [YAML](https://yaml.org/) markup language. Typically, these files have a
+`.yml` or `.yaml` suffix like `dam-break.yaml`. In this section, we describe
+how to express the specifics for your simulation using the YAML syntax.
+
+RDycore's YAML input is broken up into several sections, each responsible for a
+different aspect of the desired simulation. These sections fall into several
+broad categories:
+
+* Model equations and discretizations
+    * [physics](input.md#physіcs): configures the different physical models
+      represented within RDycore
+    * [numerics](input.md#numerics): specifies the numerical methods used
+      to solve the model equations
+* Simulation diagnostics, output, and restarts
+    * [logging](input.md#logging): controls informational messages logged to
+      files or to the terminal
+    * [output](input.md#output): configures simulation output, including
+      scalable I/O formats and related parameters
+* Material properties
+    * [materials](input.md#materials): defines the materials available to
+      the simulation
+    * [surface_composition](input.md#surface_composition): associates
+      materials defined in the `materials` section with files in which the
+      relevant material properties are stored
+* Spatial discretization
+    * [grid](input.md#grid): controls RDycore's spatial discretization
+    * [regions](input.md#regions): associates regions (disjoint sets of cells)
+      defined in a grid file with human-readable names
+    * [boundaries](input.md#boundaries): associates boundaries (disjoint sets of
+      edges) defined in a grid file with human-readable names
+* Initial and boundary conditions, source terms
+    * [initial_conditions](input.md#initial_conditions): associates initial
+      conditions (as defined in `flow_conditions`, `sediment_conditions`, and/or
+      `salinity_conditions`) with specific regions defined in the `regions`
+      section
+    * [sources](input.md#sources): associates source contributions
+      (as defined in `flow_conditions`, `sediment_conditions`, and/or
+      `salinity_conditions`) with specific regions defined in the `regions`
+      section
+    * [boundary_conditions](input.md#boundary_conditions): associates boundary
+      conditions (as defined in `flow_conditions`, `sediment_conditions`, and/or
+      `salinity_conditions`) with specific boundaries defined in the
+      `boundaries` section
+    * [flow_conditions](input.md#flow_conditions): defines flow-related
+      parameters that can be used to specify initial/boundary conditions and
+      sources
+    * [sediment_conditions](input.md#sediment_conditions): defines sediment-related
+      parameters that can be used to specify initial/boundary conditions and
+      sources
+    * [salinity_conditions](input.md#salinity_conditions): defines salinity-related
+      parameters that can be used to specify initial/boundary conditions and
+      sources
+
+Each of these sections is described below, with a motivating example.
+
+## `boundaries`
+
+```yaml
+[boundaries]
+  - name: top_wall
+    mesh_boundary_id: 2
+  - name: bottom_wall
+    mesh_boundary_id: 3
+  - name: exterior
+    mesh_boundary_id: 1
+```
+
+The `boundaries` section is a sequence (list) of boundary definitions, each of
+which contains the following fields:
+
+* `name`: a human-readable name for the boundary
+* `grid_boundary_id`: an integer identifier associated with a disjoint set of
+  grid edges. If this identifier is not found within the grid file specified
+  in the `grid` section, a fatal error occurs.
+
+Boundary definitions can appear in any order within the sequence.
+
+## `boundary_conditions`
+
+## `flow_conditions`
+
+## `grid`
+
+## `logging`
+
+## `materials`
+
+## `numerics`
+
+## `output`
+
+## `physics`
+
+
+## `regions`
+
+```yaml
+[regions]
+  - name: upstream
+    grid_region_id: 2
+  - name: downstream
+    grid_region_id: 1
+```
+
+The `regions` section is a sequence (list) of regions definitions, each of
+which contains the following fields:
+
+* `name`: a human-readable name for the boundary
+* `grid_region_id`: an integer identifier associated with a disjoint set of
+  grid cells. If this identifier is not found within the grid file specified
+  in the `grid` section, a fatal error occurs.
+
+Region definitions can appear in any order within the sequence.
+
+## `initial_conditions`
+
+## `salinity_conditions`
+
+## `sediment_conditions`
+
+## `sources`
+
+## `surface_composition`
 

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -2,8 +2,9 @@
 
 You can configure an RDycore simulation by creating a text file that uses
 the [YAML](https://yaml.org/) markup language. Typically, these files have a
-`.yml` or `.yaml` suffix like `dam-break.yaml`. In this section, we describe
-how to express the specifics for your simulation using the YAML syntax.
+`.yml` or `.yaml` suffix like [`ex2b.yaml`](https://github.com/RDycore/RDycore/blob/main/driver/tests/swe_roe/ex2b.yaml).
+In this section, we describe how to express the specifics for your simulation
+using the YAML syntax.
 
 RDycore's YAML input is broken up into several sections, each responsible for a
 different aspect of the desired simulation. These sections fall into several

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -9,29 +9,31 @@ RDycore's YAML input is broken up into several sections, each responsible for a
 different aspect of the desired simulation. These sections fall into several
 broad categories:
 
-* Model equations and discretizations
+* **Model equations and discretizations**
     * [physics](input.md#physіcs): configures the different physical models
       represented within RDycore
     * [numerics](input.md#numerics): specifies the numerical methods used
       to solve the model equations
-* Simulation diagnostics, output, and restarts
+    * [grid](input.md#grid): defines RDycore's discrete computational domain
+    * [regions](input.md#regions): associates regions (disjoint sets of cells)
+      defined in a grid file with human-readable names
+    * [boundaries](input.md#boundaries): associates boundaries (disjoint sets of
+      edges) defined in a grid file with human-readable names
+    * [time](input.md#time): defines the timespan for the simulation, sets
+      limits and units for time stepping
+* **Simulation diagnostics, output, and restarts**
     * [logging](input.md#logging): controls informational messages logged to
       files or to the terminal
     * [output](input.md#output): configures simulation output, including
       scalable I/O formats and related parameters
-* Material properties
+    * [restart](input.md#restart): configures simulation restart dumps
+* **Material properties**
     * [materials](input.md#materials): defines the materials available to
       the simulation
     * [surface_composition](input.md#surface_composition): associates
       materials defined in the `materials` section with files in which the
       relevant material properties are stored
-* Spatial discretization
-    * [grid](input.md#grid): controls RDycore's spatial discretization
-    * [regions](input.md#regions): associates regions (disjoint sets of cells)
-      defined in a grid file with human-readable names
-    * [boundaries](input.md#boundaries): associates boundaries (disjoint sets of
-      edges) defined in a grid file with human-readable names
-* Initial and boundary conditions, source terms
+* **Initial and boundary conditions, source terms**
     * [initial_conditions](input.md#initial_conditions): associates initial
       conditions (as defined in `flow_conditions`, `sediment_conditions`, and/or
       `salinity_conditions`) with specific regions defined in the `regions`
@@ -59,7 +61,7 @@ Each of these sections is described below, with a motivating example.
 ## `boundaries`
 
 ```yaml
-[boundaries]
+boundaries:
   - name: top_wall
     mesh_boundary_id: 2
   - name: bottom_wall
@@ -69,7 +71,7 @@ Each of these sections is described below, with a motivating example.
 ```
 
 The `boundaries` section is a sequence (list) of boundary definitions, each of
-which contains the following fields:
+which contains the following parameters:
 
 * `name`: a human-readable name for the boundary
 * `grid_boundary_id`: an integer identifier associated with a disjoint set of
@@ -80,25 +82,220 @@ Boundary definitions can appear in any order within the sequence.
 
 ## `boundary_conditions`
 
+```yaml
+boundary_conditions:
+  - boundary: top_wall
+    flow: reflecting_bc
+  - boundary: bottom_wall
+    flow: outflow_bc
+```
+
+The `boundary_conditions` section is a sequence (list) associating `flow`,
+`sediment`, and `salinity` conditions (as defined in their respective sections)
+with boundaries (as defined in the `boundaries` section). A boundary can have
+at most one set of boundary conditions associated with it. If no boundary
+conditions are given for a specific boundary, that boundary is assigned an
+automatically-generated reflecting boundary condition and homogeneous Neumann
+sediment and salinity conditions.
+
+The above example shows a valid configuration for a simulation in which sediments
+and salinity are not modeled, so only the `flow` parameter is required. The
+presence of sediment boundary concentrations requires the `sediment` parameter,
+as the presence of salinity concentrations requires the `salinity` parameter.
+
 ## `flow_conditions`
+
+```yaml
+flow_conditions:
+  - name: dam_top_ic
+    type: dirichlet
+    height: 10
+    momentum: [0, 0]
+  - name: dam_bottom_ic
+    type: dirichlet
+    height: 5
+    momentum: [0, 0]
+  - name: reflecting_bc
+    type: reflecting
+  - name: outflow_bc
+    type: critical-outflow
+```
+
+The `flow_conditions` section contains a sequence of sets of parameters defining
+flow within a cell or cell boundary (edge). These flow conditions can be used
+to define initial conditions, source contributions, and boundary conditions
+elsewhere in the file. The parameters that define a flow condition are
+
+* `name`: a human-readable name that can be used to refer to this flow condition
+* `type`: the type of constraint applied by this flow condition. Available
+  options are
+    * `dirichlet`: the condition explicitly specifies the value of relevant
+      flow variables. This is useful for Dirichlet boundary conditions,
+      initial conditions, and source terms.
+    * `neumann`: the condition explicitly specifies the value of the directional
+      derivative of relevant flow variables on cell boundaries. This is useful
+      only for boundary conditions. Currently, only homogeneous Neumann conditions
+      are supported.
+    * `reflecting`: the condition specifies that no flow occurs through a given
+      boundary, and that the boundary reflects the momentum contained in the flow.
+      Useful only for boundary conditions.
+    * `critical-outflow`: the condition specifies that flow through a boundary
+      is defined by a critical outflow condition. Useful only for boundary
+      conditions.
+
+In the case of a Dirichlet condition, flow is prescribed by the following
+parameters:
+
+* `height`: the height of water [m] at the relevant point (within a cell
+  or on its boundary)
+* `momentum`: a 2-component sequence/list containing the `x` and `y` components
+  of the momentum [kg m/s] at the relevant point (within a cell or on its
+  boundary)
 
 ## `grid`
 
+```yaml
+grid:
+  file: breaking-dam.exo
+```
+
+The `grid` section defines the computational domain used by RDycore. Currently,
+has only a single parameter:
+
+* `file`: the file containing the grid representing the computational domain.
+  This grid must be stored in a format supported by PETSc's [DMPlex](https://petsc.org/release/manual/dmplex/)
+  data structure.
+
 ## `logging`
+
+```yaml
+logging:
+  file: rdycore.log
+  level: info
+```
+
+The `logging` section controls how messages emitted by RDycore are logged.
+The relevant parameters in this section are
+
+* `file`: the file to which logged messages are written, relative to the
+  directory in which RDycore (coupled or uncoupled) is executed. If this
+  parameter is omitted, logged messages are written to standard output.
+* `level`: the desired level of detail that determines which messages are
+  logged. Available options are
+    * `none`: no messages are logged
+    * `warning`: only warnings/urgent messages are logged
+    * `info`: warnings and informational messages are logged
+    * `detail`: warnings, informational messages, and messages with some
+      degree of technical detail are logged
+    * `debug`: all messages including debugging prints are logged
 
 ## `materials`
 
+```yaml
+materials:
+  - name: smooth
+    manning: 0.015
+  - name: rough
+    manning: 0.075
+```
+
+The `materials` section is a sequence (list) of named materials defined by
+specific material properties. The following parameters define these materials:
+
+* `name`: a human-readable name that can be used to refer to a material
+* `manning`: the value of the [Manning roughness coefficient](https://en.wikipedia.org/wiki/Manning_formula)
+  for the material
+
 ## `numerics`
+
+```yaml
+numerics:
+  spatial: fv
+  temporal: euler
+  riemann: roe
+```
+
+The `numerics` section defines the spatial and temporal discretizations used by
+RDycore. The parameters that define these discretizations are
+
+* `spatial`: determines the spatial discretization. Can be either `fv` for
+  a finite volume method, or `fe` for a finite element method. Currently, only
+  `fv` is implemented. Default value: `fv`
+* `temporal`: determines the method of time integration used. Can be `euler`
+  for the forward Euler method, `rk4` for a 4th-order Runge-Kutta method, or
+  `beuler` for the L-stable backward Euler method. Currently, only `euler` and
+  `rk4` are supported. Default value: `euler`
+* `riemann`: determines the form of the Riemann solver used for the shallow
+  water equations. Can be `roe` for the Roe solver or `hllc` for the HLLC solver.
+  Currently, only `roe` is implemented. Default value: `roe`
 
 ## `output`
 
+```yaml
+output:
+  format: xdmf
+  interval: 100
+  batch_size: 1
+  time_series:
+    boundary_fluxes: 10
+```
+
+The `output` section control simulation output, including visualization and
+time series data (and excluding restart data). Relevant parameters are
+
+* `format`: the format of the output written. Available options are
+    * `none`: no output is written. This is the default value.
+    * `binary`: output is written using PETSc's binary data format
+    * `xdmf`: output is written to the [XDMF](https://xdmf.org/index.php/XDMF_Model_and_Format) format
+    * `cgns`: output is written to the [CFD General Notation System (CGNS)](https://cgns.github.io/) format
+* `interval`: the number of time steps between output dumps. Default value: 0 (no output)
+* `batch_size`: the number of time steps for which output data is stored in a
+  single file. For example, a batch size of 10 specifies that each individual
+  output file stores data for 10 time steps. Default value: 1
+* `time_series`: this subsection controls time series simulation output, which
+  is useful for inspection and possibly even coupling. Currently, this subsection
+  has only one parameter:
+    * `boundary_fluxes`: the interval (number of timesteps) at which boundary
+      flux data is appended to a tab-delimited text file
+
 ## `physics`
 
+```yaml
+physics:
+  flow:
+    mode: swe
+    bed_friction: false
+    tiny: 1e-7
+  sediment: false
+  salinity: false
+```
+
+The `physics` section determines which model physics are active in RDycore.
+There are three available physical models.
+
+First is the flow model, which is configured in the `flow` subsection. This
+model determines how flooding is represented within RDycore. The relevant
+parameters in this subsection are:
+
+* `mode`, which determines how the height of floodwater is computed. Valid
+   parameters are `swe` ([shallow water equations](https://en.wikipedia.org/wiki/Shallow_water_equations))
+   and `diffusive` ([diffusive wave approximation](https://en.wikipedia.org/wiki/Shallow_water_equations#Diffusive_wave),
+   not yet supported). This parameter is required and has no default value.
+* `bed_friction`, which can be set to `true` or `false` to enable/disable
+  riverbed friction. Default value: `false`
+* `tiny_h`, which is the water height below which a given point is assumed to
+  be dry. Default value: `1e-7`
+
+The second physical model is the sediment model. You can enable or disable this
+by setting the `sediment` parameter to `true` or `false`.
+
+The third physical model is the salinity model, which you can also enable or
+disable this by setting the `salinity` parameter to `true` or `false`.
 
 ## `regions`
 
 ```yaml
-[regions]
+regions:
   - name: upstream
     grid_region_id: 2
   - name: downstream
@@ -106,7 +303,7 @@ Boundary definitions can appear in any order within the sequence.
 ```
 
 The `regions` section is a sequence (list) of regions definitions, each of
-which contains the following fields:
+which contains the following parameters:
 
 * `name`: a human-readable name for the boundary
 * `grid_region_id`: an integer identifier associated with a disjoint set of
@@ -117,11 +314,146 @@ Region definitions can appear in any order within the sequence.
 
 ## `initial_conditions`
 
+```yaml
+initial_conditions:
+  - region: upstream
+    flow: dam_top_ic
+  - region: downstream
+    flow: dam_bottom_ic
+```
+
+The `initial_conditions` section is a sequence (list) associating `flow`,
+`sediment`, and `salinity` conditions (as defined in their respective sections)
+with regions (as defined in the `regions` section). A region must have exactly
+one set of initial conditions associated with it. The above example shows a valid
+configuration for a simulation in which sediments and salinity are not modeled,
+so only the `flow` parameter is required. The presence of sediment concentrations
+requires the `sediment` parameter, as the presence of salinity concentrations
+requires the `salinity` parameter.
+
+## `restart`
+
+This section is not yet implemented.
+
 ## `salinity_conditions`
+
+```yaml
+salinity_conditions:
+  - name: my-sal-condition
+    type: dirichlet
+    concentration: 1
+```
+
+The `salinity_conditions` section contains a sequence of sets of parameters
+defining the salinity concentration within a cell or cell boundary (edge).
+A salinity condition can be used to define initial conditions, source
+contributions, and boundary conditions elsewhere in the file. The parameters
+that define a salinity condition are
+
+* `name`: a human-readable name that can be used to refer to the salinity condition
+* `type`: the type of constraint applied by this salinity condition. Available
+  options are
+    * `dirichlet`: the condition explicitly specifies the value of the
+      salinity concentration. This is useful for Dirichlet boundary conditions,
+      initial conditions, and source terms.
+    * `neumann`: the condition explicitly specifies the value of the directional
+      derivative of the concentration on cell boundaries. This is useful
+      only for boundary conditions. Currently, only homogeneous Neumann conditions
+      are supported.
+
+In the case of a Dirichlet condition, a salinity concentration is prescribed
+by a `concentration` parameter.
 
 ## `sediment_conditions`
 
+```yaml
+sediment_conditions:
+  - name: my-sed-condition
+    type: dirichlet
+    concentration: 1
+```
+
+The `sediment_conditions` section contains a sequence of sets of parameters
+defining the sediment concentration within a cell or cell boundary (edge).
+A sediment condition can be used to define initial conditions, source
+contributions, and boundary conditions elsewhere in the file. The parameters
+that define a sediment condition are
+
+* `name`: a human-readable name that can be used to refer to the sediment condition
+* `type`: the type of constraint applied by this sediment condition. Available
+  options are
+    * `dirichlet`: the condition explicitly specifies the value of the
+      sediment concentration. This is useful for Dirichlet boundary conditions,
+      initial conditions, and source terms.
+    * `neumann`: the condition explicitly specifies the value of the directional
+      derivative of the sediment concentration on cell boundaries. This is
+      useful only for boundary conditions. Currently, only homogeneous Neumann
+      conditions are supported.
+
+In the case of a Dirichlet condition, a sediment concentrations is prescribed
+by a `concentration` parameter.
+
 ## `sources`
+
+```yaml
+sources:
+  - region: upstream
+    flow: dam_top_src
+  - region: downstream
+    flow: dam_bottom_src
+```
+
+The `sources` section is a sequence (list) associating `flow`, `sediment`, and
+`salinity` sources (as defined in their respective sections) with regions (as
+defined in the `regions` section). Sources are optional for each region--if
+omitted, a region has no source contributions. A region may have no more than
+one set of source conditions associated with it. The above example shows a valid
+configuration for a simulation in which sediments and salinity are not modeled,
+so only the `flow` parameter is required. The presence of sediment sources
+requires the `sediment` parameter, as the presence of salinity sources requires
+the `salinity` parameter.
 
 ## `surface_composition`
 
+```yaml
+surface_composition:
+  - region: upstream
+    material: smooth
+  - region: downstream
+    material: rough
+```
+
+The `surface_composition` section is a sequence (list) associating materials
+(as defined in the `materials` section) with regions (as defined in the
+`regions` section). Since regions and materials both have human-readable names,
+the association between the two is made clear by the `region` and `material`
+parameters in each entry. A region is understood to be completely filled with
+the material with which it is associated--the relationship between regions and
+materials is necessarily 1:1.
+
+## `time`
+
+```yaml
+time:
+  final_time: 1
+    unit: years
+    max_step: 1000
+    time_step: 0.001
+    coupling_interval: 0.01
+```
+
+The `time` section determines the time-stepping strategy used by RDycore using
+the following parameters:
+
+* `units`: the units in which time is expressed in the input file. Available
+  options are `seconds`, `minutes`, `hours`, `days`, `months`, and `years`.
+  This parameter is required and has no default value.
+* `final_time`: the time at which the simulation ends (in the desired units)
+* `max_step`: the number of steps after which the simulation ends
+* `time_step`: a fixed size used for the time step in the desired units.
+* `coupling_inverval`: the time interval (in the desired units) at which
+  RDycore advances without coupling to E3SM. By default, RDycore runs a single
+  time step without coupling to E3SM.
+
+Exactly two of `final_time`, `max_step`, and `time_step` must be specified.
+The missing parameter is then computed from those parameters given.

--- a/docs/user/input.md
+++ b/docs/user/input.md
@@ -1,0 +1,3 @@
+# RDycore YAML Input Specification
+
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,3 +49,5 @@ extra_javascript:
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 repo_url: https://github.com/RDycore/RDycore
+
+use_directory_urls: false

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,51 @@
+site_name: "RDycore: A River / Flooding dynamical core for E3SM"
+
+nav:
+  - 'Home': 'index.md'
+  - 'User Guide':
+    - 'Overview': 'user/index.md'
+    - 'Installation': 'installation.md'
+    - 'YAML Input Specification': 'user/input.md'
+  - 'Developer Guide':
+    - 'Overview': 'developer/index.md'
+
+edit_uri: ""
+
+theme:
+  name: material
+  palette:
+  palette:
+  - media: "(prefers-color-scheme: light)"
+    scheme: default
+    toggle:
+      icon: material/weather-sunny
+      name: Switch to dark mode
+  - media: "(prefers-color-scheme: dark)"
+    scheme: slate
+    primary: cyan
+    toggle:
+      icon: material/weather-night
+      name: Switch to light mode
+  features:
+    - navigation.indices
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+#    - navigation.tabs
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.arithmatex:
+      generic: true
+  - tables
+
+extra_javascript:
+  - javascript/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
+repo_url: https://github.com/RDycore/RDycore


### PR DESCRIPTION
This PR is a start on our documentation structure using an E3SM-approved approach. I've made provisions for a User Guide and a Developer Guide, and I've started documenting RDycore's YAML input format.

Closes #48