### PR TITLE
Adds options to temporally interpolate SS and BC

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -33,7 +33,8 @@ static PetscErrorCode OpenData(char *filename, Vec *data_vec, PetscInt *ndata) {
 
 // For a given cur_time,
 //   cur_data = value_1 if cur_time >= time_1 and cur_time < time_2
-PetscErrorCode GetCurrentData(PetscScalar *data_ptr, PetscInt ndata, PetscReal cur_time, PetscBool temporally_interpolate, PetscInt *cur_data_idx, PetscReal *cur_data) {
+PetscErrorCode GetCurrentData(PetscScalar *data_ptr, PetscInt ndata, PetscReal cur_time, PetscBool temporally_interpolate, PetscInt *cur_data_idx,
+                              PetscReal *cur_data) {
   PetscFunctionBegin;
 
   PetscBool found  = PETSC_FALSE;
@@ -60,7 +61,7 @@ PetscErrorCode GetCurrentData(PetscScalar *data_ptr, PetscInt ndata, PetscReal c
     *cur_data     = data_ptr[ndata * 2 - 1];
   } else {
     if (temporally_interpolate) {
-      *cur_data = (cur_time - time_dn)/(time_up - time_dn) * (data_up - data_dn) + data_dn;
+      *cur_data = (cur_time - time_dn) / (time_up - time_dn) * (data_up - data_dn) + data_dn;
     } else {
       *cur_data = data_dn;
     }

--- a/driver/main.c
+++ b/driver/main.c
@@ -33,19 +33,24 @@ static PetscErrorCode OpenData(char *filename, Vec *data_vec, PetscInt *ndata) {
 
 // For a given cur_time,
 //   cur_data = value_1 if cur_time >= time_1 and cur_time < time_2
-PetscErrorCode GetCurrentData(PetscScalar *data_ptr, PetscInt ndata, PetscReal cur_time, PetscInt *cur_data_idx, PetscReal *cur_data) {
+PetscErrorCode GetCurrentData(PetscScalar *data_ptr, PetscInt ndata, PetscReal cur_time, PetscBool temporally_interpolate, PetscInt *cur_data_idx, PetscReal *cur_data) {
   PetscFunctionBegin;
 
   PetscBool found  = PETSC_FALSE;
   PetscInt  stride = 2;
+  PetscReal time_up, time_dn;
+  PetscReal data_up, data_dn;
 
   for (PetscInt itime = 0; itime < ndata - 1; itime++) {
-    PetscReal time_dn = data_ptr[itime * stride];
-    PetscReal time_up = data_ptr[itime * stride + 2];
+    time_dn = data_ptr[itime * stride];
+    data_dn = data_ptr[itime * stride + 1];
+
+    time_up = data_ptr[itime * stride + 2];
+    data_up = data_ptr[itime * stride + 3];
+
     if (cur_time >= time_dn && cur_time < time_up) {
       found         = PETSC_TRUE;
       *cur_data_idx = itime;
-      *cur_data     = data_ptr[itime * stride + 1];
       break;
     }
   }
@@ -53,6 +58,12 @@ PetscErrorCode GetCurrentData(PetscScalar *data_ptr, PetscInt ndata, PetscReal c
   if (!found) {
     *cur_data_idx = ndata - 1;
     *cur_data     = data_ptr[ndata * 2 - 1];
+  } else {
+    if (temporally_interpolate) {
+      *cur_data = (cur_time - time_dn)/(time_up - time_dn) * (data_up - data_dn) + data_dn;
+    } else {
+      *cur_data = data_dn;
+    }
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -82,6 +93,10 @@ int main(int argc, char *argv[]) {
     char      rainfile[PETSC_MAX_PATH_LEN], bcfile[PETSC_MAX_PATH_LEN];
     PetscCall(PetscOptionsGetString(NULL, NULL, "-rain", rainfile, sizeof(rainfile), &rain_specified));
     PetscCall(PetscOptionsGetString(NULL, NULL, "-bc", bcfile, sizeof(bcfile), &bc_specified));
+
+    PetscBool interpolate_rain = PETSC_FALSE, interpolate_bc = PETSC_FALSE;
+    PetscCall(PetscOptionsGetBool(NULL, NULL, "-interpolate_rain", &interpolate_rain, NULL));
+    PetscCall(PetscOptionsGetBool(NULL, NULL, "-interpolate_bc", &interpolate_bc, NULL));
 
     Vec          rain_vec = NULL, bc_vec = NULL;
     PetscScalar *rain_ptr = NULL, *bc_ptr = NULL;
@@ -158,9 +173,9 @@ int main(int argc, char *argv[]) {
         PetscCall(RDySetWaterSource(rdy, rain));
       } else {
         PetscReal cur_rain;
-        PetscCall(GetCurrentData(rain_ptr, nrain, time, &cur_rain_idx, &cur_rain));
+        PetscCall(GetCurrentData(rain_ptr, nrain, time, interpolate_rain, &cur_rain_idx, &cur_rain));
 
-        if (cur_rain_idx != prev_rain_idx) {  // is it time to update the source term?
+        if (interpolate_rain || cur_rain_idx != prev_rain_idx) {  // is it time to update the source term?
           prev_rain_idx = cur_rain_idx;
           for (PetscInt icell = 0; icell < n; icell++) {
             rain[icell] = cur_rain;
@@ -171,8 +186,8 @@ int main(int argc, char *argv[]) {
 
       if (bc_specified && num_edges_dirc_bc > 0) {
         PetscReal cur_bc;
-        PetscCall(GetCurrentData(bc_ptr, nbc, time, &cur_bc_idx, &cur_bc));
-        if (cur_bc_idx != prev_bc_idx) {  // is it time to update the bc?
+        PetscCall(GetCurrentData(bc_ptr, nbc, time, interpolate_bc, &cur_bc_idx, &cur_bc));
+        if (interpolate_bc || cur_bc_idx != prev_bc_idx) {  // is it time to update the bc?
           prev_bc_idx = cur_bc_idx;
           for (PetscInt iedge = 0; iedge < num_edges_dirc_bc; iedge++) {
             bc_values[iedge * 3]     = cur_bc;

--- a/driver/tests/swe_roe/CMakeLists.txt
+++ b/driver/tests/swe_roe/CMakeLists.txt
@@ -75,6 +75,6 @@ file (COPY
       DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1 2)
   foreach(config basic)
-    add_test(houston_c_np_${np}_${config} ${PETSC_MPIEXEC} ${PETSC_MPIEXEC_FLAGS} -n ${np} ${rdycore_driver} Houston1km.DirichletBC.yaml -rain Houston1km.Rain.bin -bc Houston1km.BC.bin ${${config}_args})
+    add_test(houston_c_np_${np}_${config} ${PETSC_MPIEXEC} ${PETSC_MPIEXEC_FLAGS} -n ${np} ${rdycore_driver} Houston1km.DirichletBC.yaml -rain Houston1km.Rain.bin -bc Houston1km.BC.bin -interpolate_bc ${${config}_args})
   endforeach()
 endforeach()


### PR DESCRIPTION
The C and Fortran drivers are updated to include an option to temporally interpolate
the rain and dirichlet boundary condition by adding `-interpolate_rain` and/or
`-interpolate_bc` as command line argument. The use of temporally interpolated
dirichlet BC avoids the oscillations that were previously simulated.

The Houston tests are updated to use temporally interpolated BC.