### PR TITLE
Fixes the indices for CEED restriction

### DIFF
--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -205,10 +205,9 @@ static PetscErrorCode CreateBoundaryFluxOperator(Ceed ceed, RDyMesh *mesh, RDyBo
       PetscInt iedge = boundary.edge_ids[e];
       if (!edges->is_owned[iedge]) continue;
       PetscInt l   = edges->cell_ids[2 * iedge];
-      PetscInt r   = edges->cell_ids[2 * iedge + 1];
       offset_l[oe] = l * num_comp;
       if (offset_dirichlet) {  // Dirichlet boundary values
-        offset_dirichlet[oe] = r * num_comp;
+        offset_dirichlet[oe] = l * num_comp;
       }
 
       g[oe][0] = edges->sn[iedge];


### PR DESCRIPTION
The indices for the right cell on boundary are negative and the indices for the left cell should be instead used.

Fixes #111