### PR TITLE
Corrects the setting of values in a CeedVector

### DIFF
--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -31,7 +31,7 @@ PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, PetscInt n, R
 PETSC_INTERN PetscErrorCode SWEFluxOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetBoundaryFlux(CeedOperator, RDyBoundary, CeedOperatorField *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetDirichletBoundaryValues(CeedOperator, RDyBoundary, CeedOperatorField *);
-PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyBoundary boundary, PetscReal[3 * boundary.num_edges]);
+PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyMesh *, RDyBoundary boundary, PetscReal[3 * boundary.num_edges]);
 
 PETSC_INTERN PetscErrorCode CreateSWESourceOperator(Ceed, RDyMesh *mesh, RDyMaterial[mesh->num_cells], PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWESourceOperatorSetTimeStep(CeedOperator, PetscReal);

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -31,7 +31,8 @@ PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, PetscInt n, R
 PETSC_INTERN PetscErrorCode SWEFluxOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetBoundaryFlux(CeedOperator, RDyBoundary, CeedOperatorField *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetDirichletBoundaryValues(CeedOperator, RDyBoundary, CeedOperatorField *);
-PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyMesh *, RDyBoundary boundary, PetscReal[3 * boundary.num_edges]);
+PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyMesh *, RDyBoundary boundary,
+                                                                      PetscReal[3 * boundary.num_edges]);
 
 PETSC_INTERN PetscErrorCode CreateSWESourceOperator(Ceed, RDyMesh *mesh, RDyMaterial[mesh->num_cells], PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWESourceOperatorSetTimeStep(CeedOperator, PetscReal);

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -56,7 +56,7 @@ PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, PetscInt boundary_index, P
   // dispatch this call to CEED or PETSc
   PetscReal tiny_h = rdy->config.physics.flow.tiny_h;
   if (rdy->ceed_resource[0]) {  // ceed
-    PetscCall(SWEFluxOperatorSetDirichletBoundaryValues(rdy->ceed_rhs.op_edges, rdy->boundaries[boundary_index], boundary_values));
+    PetscCall(SWEFluxOperatorSetDirichletBoundaryValues(rdy->ceed_rhs.op_edges, &rdy->mesh, rdy->boundaries[boundary_index], boundary_values));
   } else {  // petsc
     // fetch the boundary data
     RiemannDataSWE bdata;

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -331,7 +331,7 @@ PetscErrorCode SWEFluxOperatorGetDirichletBoundaryValues(CeedOperator flux_op, R
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator flux_op, RDyBoundary boundary,
+PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator flux_op, RDyMesh *mesh, RDyBoundary boundary,
                                                          PetscReal boundary_values[3 * boundary.num_edges]) {
   PetscFunctionBeginUser;
 
@@ -346,9 +346,11 @@ PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator flux_op, R
 
   // set the boundary values
   for (PetscInt i = 0; i < boundary.num_edges; ++i) {
-    dirichlet_ceed[i][0] = boundary_values[num_comp * i];
-    dirichlet_ceed[i][1] = boundary_values[num_comp * i + 1];
-    dirichlet_ceed[i][2] = boundary_values[num_comp * i + 2];
+    PetscInt edge_id = boundary.edge_ids[i];
+    PetscInt cell_id = mesh->edges.cell_ids[2 * edge_id];
+    dirichlet_ceed[cell_id][0] = boundary_values[num_comp * i];
+    dirichlet_ceed[cell_id][1] = boundary_values[num_comp * i + 1];
+    dirichlet_ceed[cell_id][2] = boundary_values[num_comp * i + 2];
   }
 
   // copy the values into the CEED operator

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -346,8 +346,8 @@ PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator flux_op, R
 
   // set the boundary values
   for (PetscInt i = 0; i < boundary.num_edges; ++i) {
-    PetscInt edge_id = boundary.edge_ids[i];
-    PetscInt cell_id = mesh->edges.cell_ids[2 * edge_id];
+    PetscInt edge_id           = boundary.edge_ids[i];
+    PetscInt cell_id           = mesh->edges.cell_ids[2 * edge_id];
     dirichlet_ceed[cell_id][0] = boundary_values[num_comp * i];
     dirichlet_ceed[cell_id][1] = boundary_values[num_comp * i + 1];
     dirichlet_ceed[cell_id][2] = boundary_values[num_comp * i + 2];

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -110,7 +110,6 @@ CEED_QFUNCTION(SWEFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], 
   CeedScalar(*accum_flux)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[2];
   const SWEContext context            = (SWEContext)ctx;
 
-  const CeedScalar dt      = context->dtime;
   const CeedScalar tiny_h  = context->tiny_h;
   const CeedScalar gravity = context->gravity;
 
@@ -121,9 +120,9 @@ CEED_QFUNCTION(SWEFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], 
     if (qL.h > tiny_h || qR.h > tiny_h) {
       SWERiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flux, &amax);
       for (CeedInt j = 0; j < 3; j++) {
-        cell_L[j][i] = flux[j] * geom[2][i];
-        cell_R[j][i] = flux[j] * geom[3][i];
-        accum_flux[j][i] += flux[j] * dt;  // time-integrated flux density
+        cell_L[j][i]     = flux[j] * geom[2][i];
+        cell_R[j][i]     = flux[j] * geom[3][i];
+        accum_flux[j][i] = flux[j];
       }
     }
   }
@@ -138,7 +137,6 @@ CEED_QFUNCTION(SWEBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const CeedSc
   CeedScalar(*accum_flux)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[1];
   const SWEContext context            = (SWEContext)ctx;
 
-  const CeedScalar dt      = context->dtime;
   const CeedScalar tiny_h  = context->tiny_h;
   const CeedScalar gravity = context->gravity;
 
@@ -149,8 +147,8 @@ CEED_QFUNCTION(SWEBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const CeedSc
       CeedScalar flux[3], amax;
       SWERiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flux, &amax);
       for (CeedInt j = 0; j < 3; j++) {
-        cell_L[j][i] = flux[j] * geom[2][i];
-        accum_flux[j][i] += flux[j] * dt;  // time-integrated flux density
+        cell_L[j][i]     = flux[j] * geom[2][i];
+        accum_flux[j][i] = flux[j];
       }
     }
   }
@@ -190,7 +188,6 @@ CEED_QFUNCTION(SWEBoundaryFlux_Outflow_Roe)(void *ctx, CeedInt Q, const CeedScal
   CeedScalar(*accum_flux)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[1];
   const SWEContext context            = (SWEContext)ctx;
 
-  const CeedScalar dt      = context->dtime;
   const CeedScalar tiny_h  = context->tiny_h;
   const CeedScalar gravity = context->gravity;
 
@@ -205,8 +202,8 @@ CEED_QFUNCTION(SWEBoundaryFlux_Outflow_Roe)(void *ctx, CeedInt Q, const CeedScal
       CeedScalar flux[3], amax;
       SWERiemannFlux_Roe(gravity, tiny_h, qL, qR, sn, cn, flux, &amax);
       for (CeedInt j = 0; j < 3; j++) {
-        cell_L[j][i] = flux[j] * geom[2][i];
-        accum_flux[j][i] += flux[j] * dt;  // time-integrated flux density
+        cell_L[j][i]     = flux[j] * geom[2][i];
+        accum_flux[j][i] = flux[j];
       }
     }
   }

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -356,13 +356,6 @@ static PetscErrorCode ComputeBC(RDy rdy, RDyBoundary boundary, PetscReal tiny_h,
     }
   }
 
-  // integrate the boundary fluxes and accumulate them in case we are asked
-  // to track time series
-  for (PetscInt e = 0; e < boundary.num_edges; ++e) {
-    for (PetscInt i = 0; i < 3; ++i) {
-      flux_vec_bnd[e][i] *= rdy->dt;
-    }
-  }
   PetscCall(AccumulateBoundaryFluxes(rdy, boundary, flux_vec_bnd));
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -108,8 +108,8 @@ PetscErrorCode InitTimeSeries(RDy rdy) {
 }
 
 // Accumulates boundary fluxes on the given boundary from the given array of
-// time-integrated flux densities on boundary edges.
-PetscErrorCode AccumulateBoundaryFluxes(RDy rdy, RDyBoundary boundary, PetscReal time_integrated_flux_densities[boundary.num_edges][3]) {
+// fluxes on boundary edges.
+PetscErrorCode AccumulateBoundaryFluxes(RDy rdy, RDyBoundary boundary, PetscReal fluxes[boundary.num_edges][3]) {
   PetscFunctionBegin;
   RDyTimeSeriesData *time_series = &rdy->time_series;
   if (time_series->boundary_fluxes.fluxes) {
@@ -122,9 +122,9 @@ PetscErrorCode AccumulateBoundaryFluxes(RDy rdy, RDyBoundary boundary, PetscReal
         PetscInt  cell_id  = rdy->mesh.edges.cell_ids[2 * edge_id];
         PetscReal edge_len = rdy->mesh.edges.lengths[edge_id];
         if (rdy->mesh.cells.is_local[cell_id]) {
-          time_series->boundary_fluxes.fluxes[n].water_mass += edge_len * time_integrated_flux_densities[e][0];
-          time_series->boundary_fluxes.fluxes[n].x_momentum += edge_len * time_integrated_flux_densities[e][1];
-          time_series->boundary_fluxes.fluxes[n].y_momentum += edge_len * time_integrated_flux_densities[e][2];
+          time_series->boundary_fluxes.fluxes[n].water_mass += edge_len * fluxes[e][0];
+          time_series->boundary_fluxes.fluxes[n].x_momentum += edge_len * fluxes[e][1];
+          time_series->boundary_fluxes.fluxes[n].y_momentum += edge_len * fluxes[e][2];
           ++n;
         }
       }


### PR DESCRIPTION
The size of the CeedVector associated with the boundary condition if 
of the total number of grid cells (local + ghosted). So, the dirichlet values
(p/hu/hv) need to be saved in the CeedVector corresponding to the `cell_id`
of boundary cells.