### PR TITLE
Corrects the DM for global-to-local scatter

### DIFF
--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -802,7 +802,7 @@ static PetscErrorCode InitSolution(RDy rdy) {
       PetscInt nblocks_nat;
       PetscCall(VecGetBlockSize(natural, &nblocks_nat));
       PetscCheck((ndof == nblocks_nat), rdy->comm, PETSC_ERR_USER,
-                 "The block size of the initial condition ('%d') do not match with the nDOFs ('%d')", nblocks_nat, ndof);
+                 "The block size of the initial condition ('%d') does not match with the number of DOFs ('%d')", nblocks_nat, ndof);
 
       // scatter natural-to-global
       PetscCall(DMPlexNaturalToGlobalBegin(rdy->dm, natural, global));


### PR DESCRIPTION
The IC vector that is loaded has nDOF=3 (for SWE). Thus, `rdy->dm` should be used
instead of `rdy->aux_dm` for the global-to-local scatter.

Fixes #141