### PR TITLE
Adds prefix to boundary_fluxes.dat file

### DIFF
--- a/src/time_series.c
+++ b/src/time_series.c
@@ -194,7 +194,12 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
     char dir[PETSC_MAX_PATH_LEN];
     PetscCall(GetOutputDir(rdy, dir));
     char path[PETSC_MAX_PATH_LEN];
-    snprintf(path, PETSC_MAX_PATH_LEN - 1, "%s/boundary_fluxes.dat", dir);
+
+    size_t config_len = strlen(rdy->config_file);
+    char   prefix[config_len + 1];
+    PetscCall(DetermineConfigPrefix(rdy, prefix));
+
+    snprintf(path, PETSC_MAX_PATH_LEN - 1, "%s/%s-boundary_fluxes.dat", dir, prefix);
     FILE *fp = NULL;
     if (step == 0) {  // write a header on the first step
       PetscCall(PetscFOpen(rdy->comm, path, "w", &fp));


### PR DESCRIPTION
A prefix is added to the file to ensure the file is not overwritten when another simulation is run.

Fixes #148