### PR TITLE
Fixes error catching for setting PETSc on supported machines

### DIFF
--- a/config/install.frontier.gnugpu.debug.32bit.sh
+++ b/config/install.frontier.gnugpu.debug.32bit.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+#source modules.pm-gpu.gnugpu
+
+./configure \
+--with-cc=/opt/cray/pe/craype/2.7.19/bin/cc \
+--with-cxx=/opt/cray/pe/craype/2.7.19/bin/CC \
+--with-fc=/opt/cray/pe/craype/2.7.19/bin/ftn \
+--with-fortran-bindings=1 \
+--with-mpiexec="srun -g 8 --smpiargs=-gpu " \
+--with-batch=0 \
+--download-kokkos \
+--download-kokkos-kernels \
+--with-kokkos-kernels-tpl=0 \
+--with-make-np=8 \
+--with-netcdf-dir=/opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1 \
+--with-pnetcdf-dir=/opt/cray/pe/parallel-netcdf/1.12.3.1/gnu/9.1 \
+--with-hdf5-dir=/opt/cray/pe/hdf5-parallel/1.12.2.1/gnu/9.1 \
+--with-hip=1 \
+--with-hipc=/opt/rocm-5.4.0/bin/hipcc \
+--download-parmetis \
+--download-metis \
+--download-zlib \
+--download-scalapack \
+--download-sowing \
+--download-triangle \
+--download-exodusii \
+--download-libceed \
+--with-debugging=0 \
+--with-64-bit-indices=1 \
+PETSC_ARCH=frontier-gpu-debug-32bit-gcc-11-2-0-fc288817
+

--- a/config/install.frontier.gnugpu.debug.64bit.sh
+++ b/config/install.frontier.gnugpu.debug.64bit.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+#source modules.pm-gpu.gnugpu
+
+./configure \
+--with-cc=/opt/cray/pe/craype/2.7.19/bin/cc \
+--with-cxx=/opt/cray/pe/craype/2.7.19/bin/CC \
+--with-fc=/opt/cray/pe/craype/2.7.19/bin/ftn \
+--with-fortran-bindings=1 \
+--with-mpiexec="srun -g 8 --smpiargs=-gpu " \
+--with-batch=0 \
+--download-kokkos \
+--download-kokkos-kernels \
+--with-kokkos-kernels-tpl=0 \
+--with-make-np=8 \
+--with-netcdf-dir=/opt/cray/pe/netcdf-hdf5parallel/4.9.0.1/gnu/9.1 \
+--with-pnetcdf-dir=/opt/cray/pe/parallel-netcdf/1.12.3.1/gnu/9.1 \
+--with-hdf5-dir=/opt/cray/pe/hdf5-parallel/1.12.2.1/gnu/9.1 \
+--with-hip=1 \
+--with-hipc=/opt/rocm-5.4.0/bin/hipcc \
+--download-parmetis \
+--download-metis \
+--download-zlib \
+--download-scalapack \
+--download-sowing \
+--download-triangle \
+--download-exodusii \
+--download-libceed \
+--with-debugging=1 \
+--with-64-bit-indices=1 \
+PETSC_ARCH=frontier-gpu-debug-64bit-gcc-11-2-0-fc288817
+

--- a/config/set_petsc_settings.sh
+++ b/config/set_petsc_settings.sh
@@ -11,7 +11,7 @@ display_help() {
     echo "   --pm <cpu|gpu>         Type of Perlmutter nodes (cpu or gpu)"
     echo "   --64bit                With 64bit support (optional)"
     echo
-    exit 1
+    return 1
 }
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -82,7 +82,7 @@ if [ "$mach" = "pm" ]; then
   else
     echo "The only supported options for -pm are cpu or gpu."
     display_help
-    exit 1
+    return 1
   fi
 
 elif [ "$mach" = "frontier"  ]; then
@@ -95,6 +95,12 @@ elif [ "$mach" = "frontier"  ]; then
      export PETSC_ARCH=frontier-gpu-opt-64bit-gcc-11-2-0-fc288817
   fi
 
+  if [[ ! -z "$pm_node" ]]; then
+     echo "The --pm_node <$pm_node> was specified, which is applicable is only for Perlmutter,"
+     echo "but the machine detected is Frontier."
+     return 1
+  fi
+
 elif [ "$mach" = "aurora"  ]; then
 
   MODULE_FILE=$DIR/modules.aurora.oneapi
@@ -105,10 +111,16 @@ elif [ "$mach" = "aurora"  ]; then
      export PETSC_ARCH=aurora-opt-64bit-oneapi-ifx-fc288817
   fi
 
+  if [[ ! -z "$pm_node" ]]; then
+     echo "The --pm_node <$pm_node> was specified, which is applicable is only for Perlmutter,"
+     echo "but the machine detected is Aurora."
+     return 1
+  fi
+
 else
   echo "Could not determine the machine. mach=$mach"
   display_help
-  exit 1
+  return 1
 fi
 
 echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"

--- a/config/set_petsc_settings.sh
+++ b/config/set_petsc_settings.sh
@@ -101,7 +101,7 @@ if [ "$mach" = "pm" ]; then
   else
     echo "The only supported options for -pm are cpu or gpu."
     display_help
-    return 1
+    exit 0
   fi
 
 elif [ "$mach" = "frontier"  ]; then
@@ -121,14 +121,14 @@ elif [ "$mach" = "frontier"  ]; then
       # Got installation error
       #export PETSC_ARCH=frontier-gpu-debug-64bit-gcc-11-2-0-fc288817
        echo "On Frontier, PETSc with 64bit and debugging turned on has not been installed."
-       return 1
+       exit 0
     fi
   fi
 
   if [[ ! -z "$pm_node" ]]; then
      echo "The --pm_node <$pm_node> was specified, which is applicable is only for Perlmutter,"
      echo "but the machine detected is Frontier."
-     return 1
+     exit 0
   fi
 
 elif [ "$mach" = "aurora"  ]; then
@@ -140,27 +140,27 @@ elif [ "$mach" = "aurora"  ]; then
       export PETSC_ARCH=aurora-opt-32bit-oneapi-ifx-fc288817
     else
        echo "On Aurora, --with-debugging 1 was selected, but PETSc has not been installed with debugging turned on."
-       return 1
+       exit 0
     fi
   else
     if [ "$with_debugging" -eq 0 ]; then
       export PETSC_ARCH=aurora-opt-64bit-oneapi-ifx-fc288817
     else
        echo "On Aurora, --with-debugging 1 was selected, but PETSc has not been installed with debugging turned on."
-       return 1
+       exit 0
     fi
   fi
 
   if [[ ! -z "$pm_node" ]]; then
      echo "The --pm_node <$pm_node> was specified, which is applicable is only for Perlmutter,"
      echo "but the machine detected is Aurora."
-     return 1
+     exit 0
   fi
 
 else
   echo "Could not determine the machine. mach=$mach"
   display_help
-  return 1
+  exit 0
 fi
 
 echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"

--- a/config/set_petsc_settings.sh
+++ b/config/set_petsc_settings.sh
@@ -3,6 +3,7 @@
 pm_node=
 mach=
 with64bit=0
+with_debugging=0
 
 display_help() {
     echo "Usage: $0 " >&2
@@ -10,6 +11,7 @@ display_help() {
     echo "   -h, --help             Display this message"
     echo "   --pm <cpu|gpu>         Type of Perlmutter nodes (cpu or gpu)"
     echo "   --64bit                With 64bit support (optional)"
+    echo "   --with-debugging <0|1> With or without debugging version (optional)"
     echo
     return 1
 }
@@ -21,6 +23,7 @@ do
   case "$1" in
     --pm ) pm_node="$2"; shift ;;
     --64bit ) with64bit=1 ;;
+    ----with-debugging) with_debugging="$2"; shift ;;
     -*)
       display_help
       exit 0
@@ -64,9 +67,17 @@ if [ "$mach" = "pm" ]; then
     MODULE_FILE=$DIR/modules.pm-cpu.gnu
     export PETSC_DIR=/global/cfs/projectdirs/m4267/petsc/petsc_main/
     if [ "$with64bit" -eq 0 ]; then
-      export PETSC_ARCH=pm-cpu-opt-32bit-gcc-11-2-0-fc2888174f5
+      if [ "$with_debugging" -eq 0 ]; then
+        export PETSC_ARCH=pm-cpu-opt-32bit-gcc-11-2-0-fc2888174f5
+      else
+        export PETSC_ARCH=pm-cpu-debug-32bit-gcc-11-2-0-fc2888174f5
+      fi
     else
-      export PETSC_ARCH=pm-cpu-opt-64bit-gcc-11-2-0-fc2888174f5
+      if [ "$with_debugging" -eq 0 ]; then
+        export PETSC_ARCH=pm-cpu-opt-64bit-gcc-11-2-0-fc2888174f5
+      else
+        export PETSC_ARCH=pm-cpu-debug-64bit-gcc-11-2-0-fc2888174f5
+      fi
     fi
 
   elif [ "$pm_node" = "gpu" ]; then
@@ -74,9 +85,17 @@ if [ "$mach" = "pm" ]; then
     MODULE_FILE=$DIR/modules.pm-gpu.gnugpu
     export PETSC_DIR=/global/cfs/projectdirs/m4267/petsc/petsc_main/
     if [ "$with64bit" -eq 0 ]; then
-      export PETSC_ARCH=pm-gpu-opt-32bit-gcc-11-2-0-fc2888174f5
+      if [ "$with_debugging" -eq 0 ]; then
+        export PETSC_ARCH=pm-gpu-opt-32bit-gcc-11-2-0-fc2888174f5
+      else
+        export PETSC_ARCH=pm-gpu-debug-32bit-gcc-11-2-0-fc2888174f5
+      fi
     else
-      export PETSC_ARCH=pm-gpu-opt-64bit-gcc-11-2-0-fc2888174f5
+      if [ "$with_debugging" -eq 0 ]; then
+        export PETSC_ARCH=pm-gpu-opt-64bit-gcc-11-2-0-fc2888174f5
+      else
+        export PETSC_ARCH=pm-gpu-debug-64bit-gcc-11-2-0-fc2888174f5
+      fi
     fi
 
   else
@@ -90,9 +109,17 @@ elif [ "$mach" = "frontier"  ]; then
   MODULE_FILE=$DIR/modules.frontier.gnugpu
   export PETSC_DIR=/lustre/orion/cli192/proj-shared/petsc
   if [ "$with64bit" -eq 0 ]; then
-     export PETSC_ARCH=frontier-gpu-opt-32bit-gcc-11-2-0-fc288817
+    if [ "$with_debugging" -eq 0 ]; then
+      export PETSC_ARCH=frontier-gpu-opt-32bit-gcc-11-2-0-fc288817
+    else
+      export PETSC_ARCH=frontier-gpu-debug-32bit-gcc-11-2-0-fc288817
+    fi
   else
-     export PETSC_ARCH=frontier-gpu-opt-64bit-gcc-11-2-0-fc288817
+    if [ "$with_debugging" -eq 0 ]; then
+      export PETSC_ARCH=frontier-gpu-opt-64bit-gcc-11-2-0-fc288817
+    else
+      export PETSC_ARCH=frontier-gpu-debug-64bit-gcc-11-2-0-fc288817
+    fi
   fi
 
   if [[ ! -z "$pm_node" ]]; then
@@ -106,9 +133,19 @@ elif [ "$mach" = "aurora"  ]; then
   MODULE_FILE=$DIR/modules.aurora.oneapi
   export PETSC_DIR=/lus/gecko/projects/CSC250STMS07_CNDA/bishtgautam/petsc
   if [ "$with64bit" -eq 0 ]; then
-     export PETSC_ARCH=aurora-opt-32bit-oneapi-ifx-fc288817
+    if [ "$with_debugging" -eq 0 ]; then
+      export PETSC_ARCH=aurora-opt-32bit-oneapi-ifx-fc288817
+    else
+       echo "On Aurora, --with-debugging 1 was selected, but PETSc has not been installed with debugging turned on."
+       return 1
+    fi
   else
-     export PETSC_ARCH=aurora-opt-64bit-oneapi-ifx-fc288817
+    if [ "$with_debugging" -eq 0 ]; then
+      export PETSC_ARCH=aurora-opt-64bit-oneapi-ifx-fc288817
+    else
+       echo "On Aurora, --with-debugging 1 was selected, but PETSc has not been installed with debugging turned on."
+       return 1
+    fi
   fi
 
   if [[ ! -z "$pm_node" ]]; then

--- a/config/set_petsc_settings.sh
+++ b/config/set_petsc_settings.sh
@@ -118,7 +118,10 @@ elif [ "$mach" = "frontier"  ]; then
     if [ "$with_debugging" -eq 0 ]; then
       export PETSC_ARCH=frontier-gpu-opt-64bit-gcc-11-2-0-fc288817
     else
-      export PETSC_ARCH=frontier-gpu-debug-64bit-gcc-11-2-0-fc288817
+      # Got installation error
+      #export PETSC_ARCH=frontier-gpu-debug-64bit-gcc-11-2-0-fc288817
+       echo "On Frontier, PETSc with 64bit and debugging turned on has not been installed."
+       return 1
     fi
   fi
 

--- a/config/set_petsc_settings.sh
+++ b/config/set_petsc_settings.sh
@@ -20,7 +20,7 @@ while [ $# -gt 0 ]
 do
   case "$1" in
     --pm ) pm_node="$2"; shift ;;
-    --64bit ) with64bit=1; shift ;;
+    --64bit ) with64bit=1 ;;
     -*)
       display_help
       exit 0


### PR DESCRIPTION
- Report an error when `--pm <cpu|gpu>` is specified on Perlmutter and Aurora.
- Additionally, adds support for the debugging version of PETSc for:
  - Perlmutter: CPU/GPU nodes and 32/64 bit
  - Frontier: Only for 32bit

Fixes #151