### PR TITLE
Pkgconfig changes, part 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ pkg_get_variable(PETSc_C_COMPILER PETSc ccompiler)
 pkg_get_variable(PETSc_Fortran_COMPILER PETSc fcompiler)
 include_directories(${PETSc_INCLUDE_DIRS})
 link_directories(${PETSc_LIBRARY_DIRS})
+message(STATUS "PETSc stuffs: ${PETSc_STATIC_LIBRARIES}")
 
 # CEED
 pkg_check_modules(CEED REQUIRED IMPORTED_TARGET ceed)
@@ -52,8 +53,8 @@ endif()
 
 # If needed, determine MPIEXEC using PETSc's configuration. It would be nice
 # if this were included in PETSc.pc
+include(extract_petsc_variable)
 if ("${MPIEXEC}" STREQUAL "")
-  include(extract_petsc_variable)
   extract_petsc_variable("MPIEXEC" MPIEXEC)
 endif()
 
@@ -135,8 +136,13 @@ configure_file(
   @ONLY
 )
 
-# Inherit libraries from PETSc.
-set(RDYCORE_LIBRARIES ${PETSc_LIBRARIES} PkgConfig::CEED m)
+# Inherit libraries from PETSc for shared or static libs.
+extract_petsc_variable("BUILDSHAREDLIB" petsc_shared)
+if (petsc_shared STREQUAL "yes")
+  set(RDYCORE_LIBRARIES ${PETSc_LIBRARIES} PkgConfig::CEED m)
+else()
+  set(RDYCORE_LIBRARIES ${PETSc_STATIC_LIBRARIES} PkgConfig::CEED m)
+endif()
 
 if (ENABLE_TESTS)
   include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,6 @@ pkg_get_variable(PETSc_C_COMPILER PETSc ccompiler)
 pkg_get_variable(PETSc_Fortran_COMPILER PETSc fcompiler)
 include_directories(${PETSc_INCLUDE_DIRS})
 link_directories(${PETSc_LIBRARY_DIRS})
-message(STATUS "PETSc stuffs: ${PETSc_STATIC_LIBRARIES}")
 
 # CEED
 pkg_check_modules(CEED REQUIRED IMPORTED_TARGET ceed)

--- a/cmake/extract_petsc_variable.cmake
+++ b/cmake/extract_petsc_variable.cmake
@@ -1,4 +1,5 @@
-# This function extracts a variable from the petscvariables file
+# This function extracts a variable named varname from the petscvariables file,
+# storing its value in the variable var.
 function(extract_petsc_variable varname var)
   # read petscvariables
   file(READ "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables" petscvariables)

--- a/cmake/extract_petsc_variable.cmake
+++ b/cmake/extract_petsc_variable.cmake
@@ -1,19 +1,26 @@
 # This function extracts a variable from the petscvariables file
 function(extract_petsc_variable varname var)
+  # read petscvariables
   file(READ "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables" petscvariables)
-  string(FIND ${petscvariables} "\nMPIEXEC = " start)
+
+  # find where the variable is set and remove everything preceding its value
+  string(FIND ${petscvariables} "\n${varname} = " start)
   if (${start} EQUAL -1)
     message(FATAL_ERROR "Could not extract ${var_name} from PETSc. Please set ${var_name} using -D${var_name}=...")
   endif()
-  math(EXPR start "${start} + 11")
+  string(LENGTH ${varname} varname_length)
+  math(EXPR start "${start} + ${varname_length} + 4")
   string(SUBSTRING ${petscvariables} ${start} -1 petsc_var)
+
+  # truncate the value at a space or newline, whichever comes first
   string(FIND ${petsc_var} " " space)
   string(FIND ${petsc_var} "\n" newline)
   if (space LESS newline)
-    string(SUBSTRING ${petsc_var} 0 ${space} var)
+    string(SUBSTRING ${petsc_var} 0 ${space} petsc_var)
   else()
-    string(SUBSTRING ${petsc_var} 0 ${newline} var)
+    string(SUBSTRING ${petsc_var} 0 ${newline} petsc_var)
   endif()
-  message(STATUS "Using PETSc-provided ${varname}: ${var}")
-  set(${varname} ${var} PARENT_SCOPE)
+
+  message(STATUS "Extracted PETSc variable: ${varname} = ${petsc_var}")
+  set(${var} ${petsc_var} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
This PR cleans up a few things from the last one and fixes some assumptions made in extracting PETSc configuration variables. Unfortunately, it doesn't seem to address #162 . Nevertheless, it's a slight improvment.