### PR TITLE
Uses PetscInt_FMT instead of `%d`

### DIFF
--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -138,7 +138,7 @@ static PetscErrorCode GenerateE3SMCheckpointFilename(const char *directory, cons
   PetscFunctionBegin;
   int  num_digits = (int)(log10((double)max_index_val)) + 1;
   char fmt[16]    = {0};
-  snprintf(fmt, 15, ".%%0%dd.%%s", num_digits);
+  snprintf(fmt, 15, ".%%0%" PetscInt_FMT "d.%%s", num_digits);
   char ending[PETSC_MAX_PATH_LEN];
   snprintf(ending, PETSC_MAX_PATH_LEN - 1, fmt, index, suffix);
   snprintf(filename, PETSC_MAX_PATH_LEN - 1, "%s/%s.rdycore.r%s", directory, prefix, ending);

--- a/src/ensemble.c
+++ b/src/ensemble.c
@@ -19,7 +19,7 @@ PetscErrorCode ConfigureEnsembleMember(RDy rdy) {
   if (!rdy->config.ensemble.members[color].name[0]) {
     int  num_digits = (int)(log10((double)rdy->config.ensemble.size)) + 1;
     char fmt[16]    = {0};
-    snprintf(fmt, 15, "%%0%dd", num_digits);
+    snprintf(fmt, 15, "%%0%" PetscInt_FMT "d", num_digits);
     char suffix[16];
     sprintf(suffix, fmt, color);
     sprintf(rdy->config.ensemble.members[color].name, "ensemble_%s", suffix);

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -38,7 +38,8 @@ PetscErrorCode CreateDirectory(MPI_Comm comm, const char *directory) {
   MPI_Bcast(&result_and_errno, 2, MPI_INT, 0, comm);
   int result = result_and_errno[0];
   int err_no = result_and_errno[1];
-  PetscCheck((result == 0) || (err_no == EEXIST), comm, PETSC_ERR_USER, "Could not create directory: %s (errno = %d)", directory, err_no);
+  PetscCheck((result == 0) || (err_no == EEXIST), comm, PETSC_ERR_USER, "Could not create directory: %s (errno = %" PetscInt_FMT ")", directory,
+             err_no);
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -69,7 +70,7 @@ PetscErrorCode GenerateIndexedFilename(const char *directory, const char *prefix
   PetscFunctionBegin;
   int  num_digits = (int)(log10((double)max_index_val)) + 1;
   char fmt[16]    = {0};
-  snprintf(fmt, 15, "-%%0%dd.%%s", num_digits);
+  snprintf(fmt, 15, "-%%0%" PetscInt_FMT "d.%%s", num_digits);
   char ending[PETSC_MAX_PATH_LEN];
   snprintf(ending, PETSC_MAX_PATH_LEN - 1, fmt, index, suffix);
   snprintf(filename, PETSC_MAX_PATH_LEN - 1, "%s/%s%s", directory, prefix, ending);
@@ -116,7 +117,7 @@ PetscErrorCode DetermineOutputFile(RDy rdy, PetscInt step, PetscReal time, const
     }
   } else if (rdy->config.output.format == OUTPUT_CGNS) {
     // the CGNS viewer handles its own batching and only needs a format string
-    snprintf(filename, PETSC_MAX_PATH_LEN - 1, "%s/%s-%%d.%s", output_dir, prefix, suffix);
+    snprintf(filename, PETSC_MAX_PATH_LEN - 1, "%s/%s-%%" PetscInt_FMT ".%s", output_dir, prefix, suffix);
   } else {
     PetscCheck(PETSC_FALSE, rdy->comm, PETSC_ERR_USER, "Unsupported output format specified.");
   }

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -73,8 +73,8 @@ PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_in
 
   RDyCondition boundary_cond = rdy->boundary_conditions[boundary_index];
   PetscCheck(boundary_cond.flow->type == CONDITION_DIRICHLET, rdy->comm, PETSC_ERR_USER,
-             "Trying to set dirichlet values for boundary with index %" PetscInt_FMT ", but it has a different type (%d)", boundary_index,
-             boundary_cond.flow->type);
+             "Trying to set dirichlet values for boundary with index %" PetscInt_FMT ", but it has a different type (%" PetscInt_FMT ")",
+             boundary_index, boundary_cond.flow->type);
 
   // dispatch this call to CEED or PETSc
   PetscReal tiny_h = rdy->config.physics.flow.tiny_h;

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -190,7 +190,7 @@ static PetscErrorCode InitRegions(RDy rdy) {
   PetscCheck(label, rdy->comm, PETSC_ERR_USER, "No regions (cell sets) found in grid! Cannot assign initial conditions.");
   PetscCall(DMLabelGetNumValues(label, &rdy->num_regions));
   PetscCheck(rdy->num_regions <= MAX_NUM_REGIONS, rdy->comm, PETSC_ERR_USER,
-             "Number of regions in mesh (%" PetscInt_FMT ") exceeds MAX_NUM_REGIONS (%d)", rdy->num_regions, MAX_NUM_REGIONS);
+             "Number of regions in mesh (%" PetscInt_FMT ") exceeds MAX_NUM_REGIONS (%" PetscInt_FMT ")", rdy->num_regions, MAX_NUM_REGIONS);
 
   // fetch region IDs
   IS region_id_is;
@@ -311,7 +311,8 @@ static PetscErrorCode InitBoundaries(RDy rdy) {
   if (label) {  // found face sets!
     PetscCall(DMLabelGetNumValues(label, &num_boundaries_in_file));
     PetscCheck(num_boundaries_in_file <= MAX_NUM_BOUNDARIES, rdy->comm, PETSC_ERR_USER,
-               "Number of boundaries in mesh (%" PetscInt_FMT ") exceeds MAX_NUM_BOUNDARIES (%d)", num_boundaries_in_file, MAX_NUM_BOUNDARIES);
+               "Number of boundaries in mesh (%" PetscInt_FMT ") exceeds MAX_NUM_BOUNDARIES (%" PetscInt_FMT ")", num_boundaries_in_file,
+               MAX_NUM_BOUNDARIES);
 
     // fetch boundary IDs
     PetscCall(DMLabelGetValueIS(label, &boundary_id_is));
@@ -961,7 +962,7 @@ static PetscErrorCode PauseIfRequested(RDy rdy) {
       MPI_Gather(hostname, 65, MPI_CHAR, hostnames, 65, MPI_CHAR, 0, rdy->comm);
       PetscFPrintf(rdy->comm, stderr, "  PIDs (host):\n");
       for (PetscMPIInt p = 0; p < rdy->nproc; ++p) {
-        PetscFPrintf(rdy->comm, stderr, "    rank %d (%s): %d:\n", p, &hostnames[p * 65], pids[p]);
+        PetscFPrintf(rdy->comm, stderr, "    rank %" PetscInt_FMT " (%s): %" PetscInt_FMT ":\n", p, &hostnames[p * 65], pids[p]);
       }
 
       // wait for input on rank 0
@@ -970,7 +971,7 @@ static PetscErrorCode PauseIfRequested(RDy rdy) {
       }
       MPI_Barrier(rdy->comm);
     } else {
-      PetscFPrintf(rdy->comm, stderr, "  PID on host %s: %d\n", hostname, pid);
+      PetscFPrintf(rdy->comm, stderr, "  PID on host %s: %" PetscInt_FMT "\n", hostname, pid);
       getchar();
     }
   }

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -207,7 +207,7 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
       PetscCall(TSGetStepNumber(ts, &nstep));
 
       char file[PETSC_MAX_PATH_LEN];
-      sprintf(file, "F_ceed_nstep%" PetscInt_FMT "_N%d.bin", nstep, rdy->nproc);
+      sprintf(file, "F_ceed_nstep%" PetscInt_FMT "_N%" PetscInt_FMT ".bin", nstep, rdy->nproc);
 
       PetscViewer viewer;
       PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, file, FILE_MODE_WRITE, &viewer));
@@ -224,7 +224,7 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
       PetscCall(TSGetStepNumber(ts, &nstep));
 
       char file[PETSC_MAX_PATH_LEN];
-      sprintf(file, "F_petsc_nstep%" PetscInt_FMT "_N%d.bin", nstep, rdy->nproc);
+      sprintf(file, "F_petsc_nstep%" PetscInt_FMT "_N%" PetscInt_FMT ".bin", nstep, rdy->nproc);
 
       PetscViewer viewer;
       PetscCall(PetscViewerBinaryOpen(PETSC_COMM_WORLD, file, FILE_MODE_WRITE, &viewer));

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -528,7 +528,8 @@ static PetscErrorCode SWESubOperatorGetOperatorField(CeedOperator op, CeedInt su
   CeedInt num_sub_op;
   PetscCallCEED(CeedCompositeOperatorGetNumSub(op, &num_sub_op));
   PetscCheck(sub_op_idx < num_sub_op, PETSC_COMM_WORLD, PETSC_ERR_USER,
-             "Trying to extract info about Ceed subporator = %d, but total number of Ceed operators = %d", sub_op_idx, num_sub_op);
+             "Trying to extract info about Ceed subporator = %" PetscInt_FMT ", but total number of Ceed operators = %" PetscInt_FMT "", sub_op_idx,
+             num_sub_op);
 
   // get the source sub-operator responsible for the water source (the first one)
   CeedOperator *sub_ops;


### PR DESCRIPTION
To avoid warning for PETSc configured with 64-bit integers, PetscInt_FMT is used.