### PR TITLE
Fixes the computation of next coupling time

### DIFF
--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -243,16 +243,12 @@ PetscErrorCode RDyAdvance(RDy rdy) {
   PetscReal time;
   PetscCall(TSGetTime(rdy->ts, &time));
 
-  PetscReal interval = ConvertTimeToSeconds(rdy->config.time.coupling_interval, rdy->config.time.unit);
-  PetscCall(TSSetMaxTime(rdy->ts, time + interval));
+  PetscReal interval           = ConvertTimeToSeconds(rdy->config.time.coupling_interval, rdy->config.time.unit);
+  PetscReal next_coupling_time = time + interval;
+  PetscCall(TSSetMaxTime(rdy->ts, next_coupling_time));
   PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
   PetscCall(TSSetTimeStep(rdy->ts, rdy->dt));
   PetscCall(TSSetSolution(rdy->ts, rdy->X));
-
-  PetscReal next_coupling_time = interval;
-  while (next_coupling_time < time) {
-    next_coupling_time += interval;
-  }
 
   // advance the solution to the specified time (handling preloading if requested)
   RDyLogDetail(rdy, "Advancing from t = %g to %g...", ConvertTimeFromSeconds(time, rdy->config.time.unit),


### PR DESCRIPTION
Running the following code

```
cd driver/tests/swe_roe
../../rdycore ex2b_ic_file.yaml
```

shows that the computation of `next_coupling_time` is incorrect.

```
...
DETAIL: Advancing from t = 4.975 to 4.975...
DETAIL: Advancing from t = 4.98 to 4.98...
DETAIL: Advancing from t = 4.985 to 4.985...
DETAIL: Advancing from t = 4.99 to 4.99...
DETAIL: Advancing from t = 4.995 to 4.995...
DETAIL: Step 1000: writing XDMF HDF5 output at t = 5. hr to output/ex2b_ic_file-1000.h5
DETAIL: Step 1000: writing XDMF XMF output at t = 5. hr to output/ex2b_ic_file-1000.xmf
```