### PR TITLE
Few minor updates to support E3SM-RDycore coupling for more than 1 proc

### DIFF
--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -54,6 +54,7 @@ PETSC_EXTERN PetscErrorCode RDyGetTimeStep(RDy, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetStep(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, PetscReal*);
 
+PETSC_EXTERN PetscErrorCode RDyGetNumGlobalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditions(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryEdges(RDy, const PetscInt, PetscInt*);

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -10,7 +10,7 @@ module rdycore
   implicit none
 
   public :: RDyDouble, RDy, RDyInit, RDyFinalize, RDyInitialized, &
-            RDyCreate, RDySetup, RDyAdvance, RDyDestroy, &
+            RDyCreate, RDySetup, RDyAdvance, RDyDestroy, RDyGetNumGlobalCells, &
             RDyGetNumLocalCells, RDyGetNumBoundaryConditions, &
             RDyGetNumBoundaryEdges, RDyGetBoundaryConditionFlowType, &
             RDySetDirichletBoundaryValues, &
@@ -62,6 +62,12 @@ module rdycore
     integer(c_int) function rdysetup_(rdy) bind(c, name="RDySetup")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
+    end function
+
+    integer(c_int) function rdygetnumglobalcells_(rdy, num_cells_global) bind(c, name="RDyGetNumGlobalCells")
+      use iso_c_binding, only: c_int, c_ptr
+      type(c_ptr), value, intent(in)  :: rdy
+      PetscInt,           intent(out) :: num_cells_global
     end function
 
     integer(c_int) function rdygetnumlocalcells_(rdy, num_cells) bind(c, name="RDyGetNumLocalCells")
@@ -370,6 +376,13 @@ contains
     type(RDy), intent(inout) :: rdy_
     integer,   intent(out)   :: ierr
     ierr = rdysetup_(rdy_%c_rdy)
+  end subroutine
+
+  subroutine RDyGetNumGlobalCells(rdy_, num_cells_global, ierr)
+    type(RDy), intent(inout) :: rdy_
+    PetscInt,  intent(out)   :: num_cells_global
+    integer,   intent(out)   :: ierr
+    ierr = rdygetnumglobalcells_(rdy_%c_rdy, num_cells_global)
   end subroutine
 
   subroutine RDyGetNumLocalCells(rdy_, num_cells, ierr)

--- a/src/f90-mod/tests/test_coupling.F90
+++ b/src/f90-mod/tests/test_coupling.F90
@@ -51,7 +51,7 @@ contains
     ! !LOCAL VARIABLES:
     character(len=1024) :: log_file = 'rof_modelio.log'
     PetscViewer         :: viewer
-    PetscInt            :: size
+    PetscInt            :: num_cells_global
     PetscErrorCode      :: ierr
 
     ! initialize subsystems
@@ -65,6 +65,8 @@ contains
     ! allocate memory for grid-level rain data
     PetscCallA(RDyGetNumLocalCells(rdy_, num_cells_owned, ierr))
     allocate(rain_data(num_cells_owned))
+
+    PetscCallA(RDyGetNumLocalCells(rdy_, num_cells_global, ierr))
 
   end subroutine rdycore_init
 

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -2,6 +2,12 @@
 #include <private/rdysweimpl.h>
 #include <rdycore.h>
 
+PetscErrorCode RDyGetNumGlobalCells(RDy rdy, PetscInt *num_cells_global) {
+  PetscFunctionBegin;
+  *num_cells_global = rdy->mesh.num_cells_global;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 PetscErrorCode RDyGetNumLocalCells(RDy rdy, PetscInt *num_cells) {
   PetscFunctionBegin;
   *num_cells = rdy->mesh.num_cells_local;


### PR DESCRIPTION
- Extracts the total or global number of cells in the mesh.
- Set natural cell ID to be the same as local cell ID when running on only one processor.
