### PR TITLE
Exposing time units to interface header and adding to time-related functions

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -487,18 +487,20 @@ int main(int argc, char *argv[]) {
 
     // run the simulation to completion using the time parameters in the
     // config file
+    RDyTimeUnit time_unit;
+    PetscCall(RDyGetTimeUnit(rdy, &time_unit));
     PetscReal prev_time, coupling_interval;
-    RDyGetTime(rdy, &prev_time);
-    RDyGetCouplingInterval(rdy, &coupling_interval);
+    PetscCall(RDyGetTime(rdy, time_unit, &prev_time));
+    PetscCall(RDyGetCouplingInterval(rdy, time_unit, &coupling_interval));
     PetscCall(PetscOptionsGetReal(NULL, NULL, "-coupling_interval", &coupling_interval, NULL));
-    RDySetCouplingInterval(rdy, coupling_interval);
+    PetscCall(RDySetCouplingInterval(rdy, time_unit, coupling_interval));
 
     PetscInt cur_bc_idx = -1, prev_bc_idx = -1;
 
     while (!RDyFinished(rdy)) {  // returns true based on stopping criteria
 
       PetscReal time, time_step;
-      PetscCall(RDyGetTime(rdy, &time));
+      PetscCall(RDyGetTime(rdy, time_unit, &time));
 
       switch (rain_dataset.type) {
         case CONSTANT:
@@ -533,8 +535,8 @@ int main(int argc, char *argv[]) {
 
       // the following just check that RDycore is doing the right thing
 
-      PetscCall(RDyGetTime(rdy, &time));
-      PetscCall(RDyGetTimeStep(rdy, &time_step));
+      PetscCall(RDyGetTime(rdy, time_unit, &time));
+      PetscCall(RDyGetTimeStep(rdy, time_unit, &time_step));
       PetscCheck(time > prev_time, comm, PETSC_ERR_USER, "Non-increasing time!");
       PetscCheck(time_step > 0.0, comm, PETSC_ERR_USER, "Non-positive time step!");
 

--- a/driver/mms.F90
+++ b/driver/mms.F90
@@ -214,22 +214,23 @@ program mms_f90
 
   implicit none
 
-  character(len=1024) :: config_file
-  type(RDy)           :: rdy_
-  PetscMPIInt         :: myrank
-  PetscInt            :: icell, ncells, nedges, nbcs, bc_type, idof
-  PetscMPIInt         :: ncells_glb
-  PetscInt, parameter :: bc_idx = 1
-  PetscReal           :: cur_time
-  PetscReal, pointer  :: xc_cell(:), yc_cell(:), area_cell(:)
-  PetscReal, pointer  :: h_source(:), hu_source(:), hv_source(:), mannings_n(:)
-  PetscReal, pointer  :: xc_edge(:), yc_edge(:), xc_bnd_cell(:), yc_bnd_cell(:), h_bnd(:), hu_bnd(:), hv_bnd(:), bc_values(:)
-  PetscReal, pointer  :: h_soln(:), hu_soln(:), hv_soln(:)
-  PetscReal, pointer  :: h_anal(:), hu_anal(:), hv_anal(:)
-  PetscInt, parameter :: ndof = 3
-  PetscReal           :: err(3), err1(3), err1_glb(3), err2(3), err2_glb(3), errm(3), errm_glb(3), area_cell_sum, area_cell_sum_glb
-  Vec                 :: ic_vec
-  PetscScalar, pointer:: ic_ptr(:)
+  character(len=1024)  :: config_file
+  type(RDy)            :: rdy_
+  PetscMPIInt          :: myrank
+  PetscInt             :: icell, ncells, nedges, nbcs, bc_type, idof
+  PetscMPIInt          :: ncells_glb
+  PetscInt, parameter  :: bc_idx = 1
+  integer(RDyTimeUnit) :: time_unit
+  PetscReal            :: cur_time
+  PetscReal, pointer   :: xc_cell(:), yc_cell(:), area_cell(:)
+  PetscReal, pointer   :: h_source(:), hu_source(:), hv_source(:), mannings_n(:)
+  PetscReal, pointer   :: xc_edge(:), yc_edge(:), xc_bnd_cell(:), yc_bnd_cell(:), h_bnd(:), hu_bnd(:), hv_bnd(:), bc_values(:)
+  PetscReal, pointer   :: h_soln(:), hu_soln(:), hv_soln(:)
+  PetscReal, pointer   :: h_anal(:), hu_anal(:), hv_anal(:)
+  PetscInt, parameter  :: ndof = 3
+  PetscReal            :: err(3), err1(3), err1_glb(3), err2(3), err2_glb(3), errm(3), errm_glb(3), area_cell_sum, area_cell_sum_glb
+  Vec                  :: ic_vec
+  PetscScalar, pointer :: ic_ptr(:)
   PetscErrorCode       :: ierr
 
   if (command_argument_count() < 1) then
@@ -303,8 +304,9 @@ program mms_f90
       PetscCallA(RDySetManningsNForLocalCell(rdy_, ncells, mannings_n, ierr));
       PetscCallA(RDySetInitialConditions(rdy_, ic_vec, ierr));
 
+      PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))
       do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
-        PetscCallA(RDyGetTime(rdy_, cur_time, ierr))
+        PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
 
         call problem1_sourceterm(cur_time, ncells, xc_cell, yc_cell, h_source, hu_source, hv_source)
         if (nedges > 0) then
@@ -332,7 +334,7 @@ program mms_f90
       PetscCallA(RDyGetLocalCellXMomentums(rdy_, ncells, hu_soln, ierr))
       PetscCallA(RDyGetLocalCellYMomentums(rdy_, ncells, hv_soln, ierr))
 
-      PetscCallA(RDyGetTime(rdy_, cur_time, ierr))
+      PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
 
       err1(:) = 0.d0
       err2(:) = 0.d0

--- a/driver/mms.c
+++ b/driver/mms.c
@@ -314,8 +314,10 @@ int main(int argc, char *argv[]) {
     PetscCall(RDySetInitialConditions(rdy, ic_vec));
     PetscCall(VecDestroy(&ic_vec));
 
+    RDyTimeUnit time_unit;
+    PetscCall(RDyGetTimeUnit(rdy, &time_unit));
     while (!RDyFinished(rdy)) {
-      PetscCall(RDyGetTime(rdy, &cur_time));
+      PetscCall(RDyGetTime(rdy, time_unit, &cur_time));
 
       PetscCall(Problem1_SourceTerm(&pdata, cur_time, ncells, xc_cell, yc_cell, h_source, hu_source, hv_source));
       if (nedges > 0) {
@@ -349,7 +351,7 @@ int main(int argc, char *argv[]) {
       errm[idof] = 0.0;
     }
 
-    PetscCall(RDyGetTime(rdy, &cur_time));
+    PetscCall(RDyGetTime(rdy, time_unit, &cur_time));
     for (PetscInt icell = 0; icell < ncells; icell++) {
       PetscCall(Problem1_GetData(&pdata, cur_time, xc_cell[icell], yc_cell[icell], H, &h_anal[icell]));
       PetscCall(Problem1_GetData(&pdata, cur_time, xc_cell[icell], yc_cell[icell], HU, &hu_anal[icell]));

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -97,9 +97,6 @@ typedef struct {
 // time section
 // ------------
 
-// time units
-typedef enum { TIME_SECONDS = 0, TIME_MINUTES, TIME_HOURS, TIME_DAYS, TIME_MONTHS, TIME_YEARS } RDyTimeUnit;
-
 // all time parameters
 typedef struct {
   PetscReal   final_time;         // final simulation time [unit]

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -55,6 +55,7 @@ typedef enum { RDY_TIME_SECONDS = 0, RDY_TIME_MINUTES, RDY_TIME_HOURS, RDY_TIME_
 PETSC_EXTERN PetscErrorCode RDyGetTimeUnit(RDy, RDyTimeUnit*);
 PETSC_EXTERN PetscErrorCode RDyGetTime(RDy, RDyTimeUnit, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetTimeStep(RDy, RDyTimeUnit, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyConvertTime(RDyTimeUnit, PetscReal, RDyTimeUnit, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetStep(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, RDyTimeUnit, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDySetCouplingInterval(RDy, RDyTimeUnit, PetscReal);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -50,7 +50,7 @@ PETSC_EXTERN PetscBool      RDyFinished(RDy);
 PETSC_EXTERN PetscBool      RDyRestarted(RDy);
 
 // time units
-typedef enum { TIME_SECONDS = 0, TIME_MINUTES, TIME_HOURS, TIME_DAYS, TIME_MONTHS, TIME_YEARS } RDyTimeUnit;
+typedef enum { RDY_TIME_SECONDS = 0, RDY_TIME_MINUTES, RDY_TIME_HOURS, RDY_TIME_DAYS, RDY_TIME_MONTHS, RDY_TIME_YEARS } RDyTimeUnit;
 
 PETSC_EXTERN PetscErrorCode RDyGetTimeUnit(RDy, RDyTimeUnit*);
 PETSC_EXTERN PetscErrorCode RDyGetTime(RDy, RDyTimeUnit, PetscReal*);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -49,10 +49,15 @@ PETSC_EXTERN PetscErrorCode RDyAdvance(RDy);
 PETSC_EXTERN PetscBool      RDyFinished(RDy);
 PETSC_EXTERN PetscBool      RDyRestarted(RDy);
 
-PETSC_EXTERN PetscErrorCode RDyGetTime(RDy, PetscReal*);
-PETSC_EXTERN PetscErrorCode RDyGetTimeStep(RDy, PetscReal*);
+// time units
+typedef enum { TIME_SECONDS = 0, TIME_MINUTES, TIME_HOURS, TIME_DAYS, TIME_MONTHS, TIME_YEARS } RDyTimeUnit;
+
+PETSC_EXTERN PetscErrorCode RDyGetTimeUnit(RDy, RDyTimeUnit*);
+PETSC_EXTERN PetscErrorCode RDyGetTime(RDy, RDyTimeUnit, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetTimeStep(RDy, RDyTimeUnit, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyGetStep(RDy, PetscInt*);
-PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyGetCouplingInterval(RDy, RDyTimeUnit, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDySetCouplingInterval(RDy, RDyTimeUnit, PetscReal);
 
 PETSC_EXTERN PetscErrorCode RDyGetNumGlobalCells(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumLocalCells(RDy, PetscInt*);
@@ -79,8 +84,6 @@ PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellYCentroids(RDy rdy, const PetscInt
 PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]);
 
 PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscInt values[size]);
-
-PETSC_EXTERN PetscErrorCode RDySetCouplingInterval(RDy, PetscReal);
 
 PETSC_EXTERN PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_index, const PetscInt size, const PetscInt ndof, PetscReal values[size]);
 PETSC_EXTERN PetscErrorCode RDySetWaterSourceForLocalCell(RDy rdy, const PetscInt size, PetscReal values[size]);

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -14,8 +14,8 @@ module rdycore
             RDyGetNumLocalCells, RDyGetNumBoundaryConditions, &
             RDyGetNumBoundaryEdges, RDyGetBoundaryConditionFlowType, &
             RDySetDirichletBoundaryValues, &
-            RDyGetTimeUnit, RDyGetTime, RDyGetTimeStep, RDyGetStep, &
-            RDyGetCouplingInterval, RDySetCouplingInterval, &
+            RDyGetTimeUnit, RDyGetTime, RDyGetTimeStep, RDyConvertTime, &
+            RDyGetStep, RDyGetCouplingInterval, RDySetCouplingInterval, &
             RDyGetLocalCellHeights, RDyGetLocalCellXMomentums, RDyGetLocalCellYMomentums, &
             RDyGetLocalCellXCentroids, RDyGetLocalCellYCentroids, RDyGetLocalCellZCentroids, &
             RDyGetLocalCellAreas, RDyGetLocalCellNaturalIDs, &
@@ -132,6 +132,14 @@ module rdycore
       type(c_ptr),    value, intent(in)  :: rdy
       integer(c_int), value, intent(in)  :: time_unit
       real(c_double),        intent(out) :: dt
+    end function
+
+    integer(c_int) function rdyconverttime_(unit_from, t_from, unit_to, t_to) bind(c, name="RDyConvertTime")
+      use iso_c_binding, only: c_int, c_ptr, c_double
+      integer(c_int), value, intent(in)  :: unit_from
+      real(c_double), value, intent(in)  :: t_from
+      integer(c_int), value, intent(in)  :: unit_to
+      real(c_double),        intent(out) :: t_to
     end function
 
     integer(c_int) function rdygetstep_(rdy, step) bind(c, name="RDyGetStep")
@@ -465,6 +473,15 @@ contains
     real(RDyDouble),      intent(out)   :: timestep
     integer,              intent(out)   :: ierr
     ierr = rdygettimestep_(rdy_%c_rdy, time_unit, timestep)
+  end subroutine
+
+  subroutine RDyConvertTime(unit_from, t_from, unit_to, t_to, ierr)
+    integer(RDyTimeUnit), intent(in)    :: unit_from
+    real(RDyDouble),      intent(in)    :: t_from
+    integer(RDyTimeUnit), intent(in)    :: unit_to
+    real(RDyDouble),      intent(out)   :: t_to
+    integer,              intent(out)   :: ierr
+    ierr = rdyconverttime_(unit_from, t_from, unit_to, t_to)
   end subroutine
 
   subroutine RDyGetCouplingInterval(rdy_, time_unit, interval, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -30,16 +30,16 @@ module rdycore
 
   ! Supported time units (must be synchronized with RDyTimeUnit in rdycore.h)
   integer, parameter :: RDyTimeUnit  = c_int
-  integer, parameter :: TIME_SECONDS = 0
-  integer, parameter :: TIME_MINUTES = 1
-  integer, parameter :: TIME_HOURS   = 2
-  integer, parameter :: TIME_DAYS    = 3
-  integer, parameter :: TIME_MONTHS  = 4
-  integer, parameter :: TIME_YEARS   = 5
+  integer, parameter :: RDY_TIME_SECONDS = 0
+  integer, parameter :: RDY_TIME_MINUTES = 1
+  integer, parameter :: RDY_TIME_HOURS   = 2
+  integer, parameter :: RDY_TIME_DAYS    = 3
+  integer, parameter :: RDY_TIME_MONTHS  = 4
+  integer, parameter :: RDY_TIME_YEARS   = 5
 
   type :: RDy
     ! C pointer to RDy type
-    type(c_ptr)                  :: c_rdy
+    type(c_ptr) :: c_rdy
   end type RDy
 
   interface

--- a/src/f90-mod/tests/test_coupling.F90
+++ b/src/f90-mod/tests/test_coupling.F90
@@ -81,6 +81,7 @@ contains
     ! !LOCAL VARIABLES:
     PetscScalar, pointer :: rain_p(:)
     PetscInt             :: t
+    integer(RDyTimeUnit) :: time_unit
     PetscReal            :: time_dn, time_up, cur_time, cur_rain
     PetscErrorCode       :: ierr
 
@@ -91,7 +92,8 @@ contains
     PetscCallA(RDySetWaterSourceForLocalCell(rdy_, num_cells_owned, rain_data, ierr))
 
     ! Set the coupling time step
-    PetscCallA(RDySetCouplingInterval(rdy_, dtime, ierr))
+    PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))
+    PetscCallA(RDySetCouplingInterval(rdy_, time_unit, dtime, ierr))
 
     ! Run the simulation to completion.
     PetscCallA(RDyAdvance(rdy_, ierr))

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -242,7 +242,7 @@ PetscErrorCode RDyAdvance(RDy rdy) {
   PetscReal time;
   PetscCall(TSGetTime(rdy->ts, &time));
 
-  PetscReal interval           = ConvertTimeToSeconds(rdy->config.time.coupling_interval, rdy->config.time.unit);
+  PetscReal interval           = rdy->config.time.coupling_interval;  // stored in seconds
   PetscReal next_coupling_time = time + interval;
   PetscCall(TSSetMaxTime(rdy->ts, next_coupling_time));
   PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
@@ -290,19 +290,26 @@ PetscBool RDyFinished(RDy rdy) {
   PetscFunctionReturn(finished);
 }
 
-/// Stores the simulation time (in config-specified units) in time.
-PetscErrorCode RDyGetTime(RDy rdy, PetscReal *time) {
+/// Retrieves the time units specified in the config file
+PetscErrorCode RDyGetTimeUnit(RDy rdy, RDyTimeUnit *unit) {
   PetscFunctionBegin;
-  PetscReal t;
-  PetscCall(TSGetTime(rdy->ts, &t));
-  *time = ConvertTimeFromSeconds(t, rdy->config.time.unit);
+  *unit = rdy->config.time.unit;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// Stores the internal time step size (in config-specified units) in time_step.
-PetscErrorCode RDyGetTimeStep(RDy rdy, PetscReal *time_step) {
+/// Retrieves the simulation time in the desired units
+PetscErrorCode RDyGetTime(RDy rdy, RDyTimeUnit units, PetscReal *time) {
   PetscFunctionBegin;
-  *time_step = ConvertTimeFromSeconds(rdy->dt, rdy->config.time.unit);
+  PetscReal t;
+  PetscCall(TSGetTime(rdy->ts, &t));
+  *time = ConvertTimeFromSeconds(t, units);
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Retrieves the internal time step size in the desired units
+PetscErrorCode RDyGetTimeStep(RDy rdy, RDyTimeUnit units, PetscReal *time_step) {
+  PetscFunctionBegin;
+  *time_step = ConvertTimeFromSeconds(rdy->dt, units);
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -313,16 +320,16 @@ PetscErrorCode RDyGetStep(RDy rdy, PetscInt *step) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// Stores the coupling interval (in config-specified units) in interval.
-PetscErrorCode RDyGetCouplingInterval(RDy rdy, PetscReal *interval) {
+/// Retrieves the coupling interval in the desired units
+PetscErrorCode RDyGetCouplingInterval(RDy rdy, RDyTimeUnit units, PetscReal *interval) {
   PetscFunctionBegin;
-  *interval = rdy->config.time.coupling_interval;
+  *interval = ConvertTimeFromSeconds(rdy->config.time.coupling_interval, units);
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// Sets the coupling interval (in config-specified units).
-PetscErrorCode RDySetCouplingInterval(RDy rdy, PetscReal interval) {
+/// Sets the coupling interval in the desired units
+PetscErrorCode RDySetCouplingInterval(RDy rdy, RDyTimeUnit units, PetscReal interval) {
   PetscFunctionBegin;
-  rdy->config.time.coupling_interval = interval;
+  rdy->config.time.coupling_interval = ConvertTimeToSeconds(interval, units);
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -313,6 +313,15 @@ PetscErrorCode RDyGetTimeStep(RDy rdy, RDyTimeUnit unit, PetscReal *time_step) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+/// Converts the time t_from, expressed in units unit_from, to the time t_to,
+/// expressed in units unit_to.
+PetscErrorCode RDyConvertTime(RDyTimeUnit unit_from, PetscReal t_from, RDyTimeUnit unit_to, PetscReal *t_to) {
+  PetscFunctionBegin;
+  *t_to = ConvertTimeToSeconds(t_from, unit_from);
+  *t_to = ConvertTimeFromSeconds(*t_to, unit_to);
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 /// Stores the step index in step.
 PetscErrorCode RDyGetStep(RDy rdy, PetscInt *step) {
   PetscFunctionBegin;
@@ -324,8 +333,7 @@ PetscErrorCode RDyGetStep(RDy rdy, PetscInt *step) {
 PetscErrorCode RDyGetCouplingInterval(RDy rdy, RDyTimeUnit unit, PetscReal *interval) {
   PetscFunctionBegin;
   // convert the coupling interval from config file units to desired units
-  *interval = ConvertTimeToSeconds(rdy->config.time.coupling_interval, rdy->config.time.unit);
-  *interval = ConvertTimeFromSeconds(*interval, unit);
+  PetscCall(RDyConvertTime(rdy->config.time.unit, rdy->config.time.coupling_interval, unit, interval));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -38,22 +38,22 @@ PetscReal ConvertTimeToSeconds(PetscReal time, RDyTimeUnit time_unit) {
 
   PetscReal time_in_sec;
   switch (time_unit) {
-    case TIME_SECONDS:
+    case RDY_TIME_SECONDS:
       time_in_sec = time;
       break;
-    case TIME_MINUTES:
+    case RDY_TIME_MINUTES:
       time_in_sec = time * secs_in_min;
       break;
-    case TIME_HOURS:
+    case RDY_TIME_HOURS:
       time_in_sec = time * mins_in_hr * secs_in_min;
       break;
-    case TIME_DAYS:
+    case RDY_TIME_DAYS:
       time_in_sec = time * hrs_in_day * mins_in_hr * secs_in_min;
       break;
-    case TIME_MONTHS:
+    case RDY_TIME_MONTHS:
       time_in_sec = time * days_in_mon * hrs_in_day * mins_in_hr * secs_in_min;
       break;
-    case TIME_YEARS:
+    case RDY_TIME_YEARS:
       time_in_sec = time * days_in_yr * hrs_in_day * mins_in_hr * secs_in_min;
       break;
     default:
@@ -71,22 +71,22 @@ PetscReal ConvertTimeFromSeconds(PetscReal time, RDyTimeUnit time_unit) {
   PetscFunctionBegin;
   PetscReal time_in_units;
   switch (time_unit) {
-    case TIME_SECONDS:
+    case RDY_TIME_SECONDS:
       time_in_units = time;
       break;
-    case TIME_MINUTES:
+    case RDY_TIME_MINUTES:
       time_in_units = time / secs_in_min;
       break;
-    case TIME_HOURS:
+    case RDY_TIME_HOURS:
       time_in_units = time / mins_in_hr / secs_in_min;
       break;
-    case TIME_DAYS:
+    case RDY_TIME_DAYS:
       time_in_units = time / hrs_in_day / mins_in_hr / secs_in_min;
       break;
-    case TIME_MONTHS:
+    case RDY_TIME_MONTHS:
       time_in_units = time / days_in_mon / hrs_in_day / mins_in_hr / secs_in_min;
       break;
-    case TIME_YEARS:
+    case RDY_TIME_YEARS:
       time_in_units = time / days_in_yr / hrs_in_day / mins_in_hr / secs_in_min;
       break;
     default:

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -119,12 +119,12 @@ static const cyaml_schema_field_t numerics_fields_schema[] = {
 
 // mapping of strings to time units
 static const cyaml_strval_t time_units[] = {
-    {"seconds", TIME_SECONDS},
-    {"minutes", TIME_MINUTES},
-    {"hours",   TIME_HOURS  },
-    {"days",    TIME_DAYS   },
-    {"months",  TIME_MONTHS },
-    {"years",   TIME_YEARS  },
+    {"seconds", RDY_TIME_SECONDS},
+    {"minutes", RDY_TIME_MINUTES},
+    {"hours",   RDY_TIME_HOURS  },
+    {"days",    RDY_TIME_DAYS   },
+    {"months",  RDY_TIME_MONTHS },
+    {"years",   RDY_TIME_YEARS  },
 };
 
 // mapping of time fields to members of RDyTimeSection


### PR DESCRIPTION
This PR adds `RDyTimeUnit` to `rdycore.h` and adds a unit parameter to `RDyGetTime`, `RDyGetTimestep`, and `RDy{Get,Set}CouplingInterval`. Time quantities are still stored in config units with the configuration schema, and internal time is still measured in seconds.

Closes #160