### PR TITLE
Removes an unnecessary check

### DIFF
--- a/driver/tests/swe_roe/ex2b_ic_file.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file.yaml
@@ -14,10 +14,9 @@ logging:
   level: detail
 
 time:
-  time_step: 0.005
+  final_time: 0.005
   unit: hours
   max_step: 1000
-  coupling_interval: 0.005
 
 output:
   format: xdmf

--- a/src/rdymesh.c
+++ b/src/rdymesh.c
@@ -348,8 +348,6 @@ static PetscErrorCode RDyVerticesCreateFromDM(DM dm, PetscInt ncells_per_vertex,
         PetscInt ivertex = v - v_start;
         if (local) PetscCall(PetscFindInt(v, Nl, local, &v));
         PetscCheck(v >= 0, PETSC_COMM_SELF, PETSC_ERR_PLIB, "Vertex %" PetscInt_FMT " not found in migration SF", v);
-        PetscCheck(!natural[v].rank, PETSC_COMM_SELF, PETSC_ERR_PLIB,
-                   "Natural ID for vertex %" PetscInt_FMT " should come from rank 0 not %" PetscInt_FMT, v, natural[v].rank);
         vertices->global_ids[ivertex] = natural[v].index;
 
         if (v == v_start) {


### PR DESCRIPTION
1. An error check for natural ID, which is not valid when the mesh is read in parallel, is removed.
2. Updates the time settings for an example.