### PR TITLE
Method of Manufactured Solutions, part 2: convergence studies

### DIFF
--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -1,5 +1,6 @@
 # RDycore User Guide
 
-* [YAML input specification](input.md)
+* [Standalone YAML input specification](input.md)
+* [MMS driver YAML input specification](mms.md)
 
 More soon!

--- a/docs/user/mms.md
+++ b/docs/user/mms.md
@@ -104,12 +104,15 @@ every MMS driver input file, without developing code and rebuilding RDycore.
 
 ### Convergence studies
 
-The `convergence` sub-subsection is optional and contains the following
-parameters for performing convergence studies that determine whether the MMS
-problem has been solved successfully for each solution component:
+The optional `convergence` sub-subsection contains the following parameters for
+performing convergence studies that determine whether the MMS problem has been
+solved successfully for each solution component:
 
 * `num_refinements`: the number of times the domain (and timestep) are refined
-  uniformly to test the rate of convergence of the solution error
+  uniformly to test the rate of convergence of the solution error. This
+  parameter is required if your input file has a `convergence` section.
 * `expected_rates`: a sub-subsection with `L1`, `L2`, and `Linf`
-  entries giving the expected rates of convergence for the appropriate error
-  norms.
+  entries for each relevant component name giving the expected rates of
+  convergence for the appropriate error norms. Each of the component names and
+  expected rates are optional, so you can specify only those you want to use
+  as pass/fail criteria.

--- a/docs/user/mms.md
+++ b/docs/user/mms.md
@@ -63,6 +63,23 @@ mms:
 
     # Manning coefficient n(x,y)
     n:     N * (1 + sin(K*x) * sin(K*y))
+
+    # Convergence study parameters (optional)
+    convergence:
+      num_refinements: 3
+      expected_convergence_rates:
+        h:
+          L1: 1
+          L2: 1
+          Linf: 0.48
+        hu:
+          L1: 0.73
+          L2: 0.78
+          Linf: 0.62
+        hv:
+          L1: 0.73
+          L2: 0.78
+          Linf: 0.62
 ```
 
 The `mms` section defines the forms of the manufactured solutions for the
@@ -84,3 +101,15 @@ elevation function, and `n`, the Manning coefficient) are functions of `x` and
 These analytic forms are parsed and compiled at runtime so they can be evaluated
 as needed by the model. This means you can define a new manufactured solution in
 every MMS driver input file, without developing code and rebuilding RDycore.
+
+### Convergence studies
+
+The `convergence` sub-subsection is optional and contains the following
+parameters for performing convergence studies that determine whether the MMS
+problem has been solved successfully for each solution component:
+
+* `num_refinements`: the number of times the domain (and timestep) are refined
+  uniformly to test the rate of convergence of the solution error
+* `expected_convergence_rates`: a sub-subsection with `L1`, `L2`, and `Linf`
+  entries giving the expected rates of convergence for the appropriate error
+  norms.

--- a/docs/user/mms.md
+++ b/docs/user/mms.md
@@ -116,3 +116,8 @@ solved successfully for each solution component:
   convergence for the appropriate error norms. Each of the component names and
   expected rates are optional, so you can specify only those you want to use
   as pass/fail criteria.
+
+**NOTE: When the MMS driver performs a convergence study, it writes no output.
+If you need to write a mesh or solution data, you can always use an input file
+without the `convergence` section to compute error norms for a single spatial
+resolution, writing output as needed.**

--- a/docs/user/mms.md
+++ b/docs/user/mms.md
@@ -109,8 +109,13 @@ performing convergence studies that determine whether the MMS problem has been
 solved successfully for each solution component:
 
 * `num_refinements`: the number of times the domain (and timestep) are refined
-  uniformly to test the rate of convergence of the solution error. This
-  parameter is required if your input file has a `convergence` section.
+  uniformly from the base resolution to test the rate of convergence of the
+  solution error. This parameter is required.
+* `base_refinement`: this optional parameter specifies the number of times the
+  mesh should be refined to establish the coarsest resolution to be used in the
+  convergence study. For example, a `base_refinement` of 2 indicates that a
+  mesh loaded from a file should be refined twice before performing a
+  convergence study.
 * `expected_rates`: a sub-subsection with `L1`, `L2`, and `Linf`
   entries for each relevant component name giving the expected rates of
   convergence for the appropriate error norms. Each of the component names and

--- a/docs/user/mms.md
+++ b/docs/user/mms.md
@@ -67,7 +67,7 @@ mms:
     # Convergence study parameters (optional)
     convergence:
       num_refinements: 3
-      expected_convergence_rates:
+      expected_rates:
         h:
           L1: 1
           L2: 1
@@ -110,6 +110,6 @@ problem has been solved successfully for each solution component:
 
 * `num_refinements`: the number of times the domain (and timestep) are refined
   uniformly to test the rate of convergence of the solution error
-* `expected_convergence_rates`: a sub-subsection with `L1`, `L2`, and `Linf`
+* `expected_rates`: a sub-subsection with `L1`, `L2`, and `Linf`
   entries giving the expected rates of convergence for the appropriate error
   norms.

--- a/driver/mms.F90
+++ b/driver/mms.F90
@@ -47,37 +47,11 @@ program mms_f90
       PetscCallA(RDyCreate(PETSC_COMM_WORLD, config_file, rdy_, ierr))
       PetscCallA(RDyMMSSetup(rdy_, ierr))
 
-      ! run a convergence study
-      PetscCallA(RDyMMSEstimateConvergenceRates(rdy_, num_refinements, L1_conv_rates, L2_conv_rates, Linf_conv_rates, ierr))
-
-      if (myrank == 0) then
-        write(*,*) 'Convergence rates:'
-        write(*,*) '   h: L1 = ', L1_conv_rates(1), ', L2 = ', L2_conv_rates(1), ', Linf = ', Linf_conv_rates(1)
-        write(*,*) '  hu: L1 = ', L1_conv_rates(2), ', L2 = ', L2_conv_rates(2), ', Linf = ', Linf_conv_rates(2)
-        write(*,*) '  hv: L1 = ', L1_conv_rates(3), ', L2 = ', L2_conv_rates(3), ', Linf = ', Linf_conv_rates(3)
-      endif
-
-      ! run the problem to completion
-      !do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
-      !  PetscCallA(RDyAdvance(rdy_, ierr))
-      !enddo
-      !
-      ! compute error norms
-      !PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))
-      !PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
-      !PetscCallA(RDyMMSComputeErrorNorms(rdy_, cur_time, l1_norms, l2_norms, linf_norms, num_global_cells, global_area, ierr))
-      !
-      !if (myrank == 0) then
-      !  write(*,*)'Avg-cell-area    :', global_area/num_global_cells
-      !  write(*,*)'Avg-length-scale :', (global_area/num_global_cells) ** 0.5d0
-      !  write(*,*)'Error-Norm-1     :', l1_norms(:)
-      !  write(*,*)'Error-Norm-2     :', l2_norms(:)
-      !  write(*,*)'Error-Norm-Max   :', linf_norms(:)
-      !endif
-
+      ! run the problem according to the given configuration
+      PetscCallA(RDyMMSRun(rdy_, ierr));
+      PetscCallA(RDyDestroy(rdy_, ierr))
     endif
-    ! clean up and shut off
-    PetscCallA(RDyDestroy(rdy_, ierr))
+    ! shut off
     PetscCallA(RDyFinalize(ierr))
   endif
 

--- a/driver/mms.F90
+++ b/driver/mms.F90
@@ -28,9 +28,8 @@ program mms_f90
   PetscMPIInt          :: myrank
   integer(RDyTimeUnit) :: time_unit
   PetscReal            :: cur_time
-  PetscInt, parameter  :: ndof = 3
-  PetscReal, target    :: L1_norms(3), L2_norms(3), Linf_norms(3), global_area
-  PetscInt             :: num_global_cells
+  PetscInt, parameter  :: ndof = 3, num_refinements = 3
+  PetscReal, target    :: L1_conv_rates(3), L2_conv_rates(3), Linf_conv_rates(3)
   PetscErrorCode       :: ierr
 
   if (command_argument_count() < 1) then
@@ -48,27 +47,37 @@ program mms_f90
       PetscCallA(RDyCreate(PETSC_COMM_WORLD, config_file, rdy_, ierr))
       PetscCallA(RDyMMSSetup(rdy_, ierr))
 
-      ! run the problem to completion
-      do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
-        PetscCallA(RDyAdvance(rdy_, ierr))
-      enddo
-
-      ! compute error norms
-      PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))
-      PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
-      PetscCallA(RDyMMSComputeErrorNorms(rdy_, cur_time, l1_norms, l2_norms, linf_norms, num_global_cells, global_area, ierr))
+      ! run a convergence study
+      PetscCallA(RDyMMSEstimateConvergenceRates(rdy_, num_refinements, L1_conv_rates, L2_conv_rates, Linf_conv_rates, ierr))
 
       if (myrank == 0) then
-        write(*,*)'Avg-cell-area    :', global_area/num_global_cells
-        write(*,*)'Avg-length-scale :', (global_area/num_global_cells) ** 0.5d0
-        write(*,*)'Error-Norm-1     :', l1_norms(:)
-        write(*,*)'Error-Norm-2     :', l2_norms(:)
-        write(*,*)'Error-Norm-Max   :', linf_norms(:)
+        write(*,*) 'Convergence rates:'
+        write(*,*) '   h: L1 = ', L1_conv_rates(1), ', L2 = ', L2_conv_rates(1), ', Linf = ', Linf_conv_rates(1)
+        write(*,*) '  hu: L1 = ', L1_conv_rates(2), ', L2 = ', L2_conv_rates(2), ', Linf = ', Linf_conv_rates(2)
+        write(*,*) '  hv: L1 = ', L1_conv_rates(3), ', L2 = ', L2_conv_rates(3), ', Linf = ', Linf_conv_rates(3)
       endif
 
-      ! shut off
-      PetscCallA(RDyFinalize(ierr))
+      ! run the problem to completion
+      !do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
+      !  PetscCallA(RDyAdvance(rdy_, ierr))
+      !enddo
+      !
+      ! compute error norms
+      !PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))
+      !PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
+      !PetscCallA(RDyMMSComputeErrorNorms(rdy_, cur_time, l1_norms, l2_norms, linf_norms, num_global_cells, global_area, ierr))
+      !
+      !if (myrank == 0) then
+      !  write(*,*)'Avg-cell-area    :', global_area/num_global_cells
+      !  write(*,*)'Avg-length-scale :', (global_area/num_global_cells) ** 0.5d0
+      !  write(*,*)'Error-Norm-1     :', l1_norms(:)
+      !  write(*,*)'Error-Norm-2     :', l2_norms(:)
+      !  write(*,*)'Error-Norm-Max   :', linf_norms(:)
+      !endif
+
     endif
+    ! shut off
+    PetscCallA(RDyFinalize(ierr))
   endif
 
 end program

--- a/driver/mms.F90
+++ b/driver/mms.F90
@@ -25,11 +25,6 @@ program mms_f90
 
   character(len=1024)  :: config_file
   type(RDy)            :: rdy_
-  PetscMPIInt          :: myrank
-  integer(RDyTimeUnit) :: time_unit
-  PetscReal            :: cur_time
-  PetscInt, parameter  :: ndof = 3, num_refinements = 3
-  PetscReal, target    :: L1_conv_rates(3), L2_conv_rates(3), Linf_conv_rates(3)
   PetscErrorCode       :: ierr
 
   if (command_argument_count() < 1) then
@@ -39,8 +34,6 @@ program mms_f90
 
     ! initialize subsystems
     PetscCallA(RDyInit(ierr))
-
-    PetscCallMPIA(MPI_Comm_rank(PETSC_COMM_WORLD, myrank, ierr))
 
     if (trim(config_file) /= trim('-help')) then
       ! create rdycore and set it up with the given file

--- a/driver/mms.F90
+++ b/driver/mms.F90
@@ -48,14 +48,7 @@ program mms_f90
       PetscCallA(RDyCreate(PETSC_COMM_WORLD, config_file, rdy_, ierr))
       PetscCallA(RDyMMSSetup(rdy_, ierr))
 
-      PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))
       do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
-        PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
-
-        ! enforce dirichlet BCs and compute source terms at half steps
-        PetscCallA(RDyMMSEnforceBoundaryConditions(rdy_, cur_time, ierr))
-        PetscCallA(RDyMMSComputeSourceTerms(rdy_, cur_time, ierr))
-
         ! advance the solution by the coupling interval
         PetscCallA(RDyAdvance(rdy_, ierr))
       enddo

--- a/driver/mms.F90
+++ b/driver/mms.F90
@@ -76,7 +76,8 @@ program mms_f90
       !endif
 
     endif
-    ! shut off
+    ! clean up and shut off
+    PetscCallA(RDyDestroy(rdy_, ierr))
     PetscCallA(RDyFinalize(ierr))
   endif
 

--- a/driver/mms.F90
+++ b/driver/mms.F90
@@ -48,12 +48,13 @@ program mms_f90
       PetscCallA(RDyCreate(PETSC_COMM_WORLD, config_file, rdy_, ierr))
       PetscCallA(RDyMMSSetup(rdy_, ierr))
 
+      ! run the problem to completion
       do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
-        ! advance the solution by the coupling interval
         PetscCallA(RDyAdvance(rdy_, ierr))
       enddo
 
       ! compute error norms
+      PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))
       PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
       PetscCallA(RDyMMSComputeErrorNorms(rdy_, cur_time, l1_norms, l2_norms, linf_norms, num_global_cells, global_area, ierr))
 

--- a/driver/mms.c
+++ b/driver/mms.c
@@ -30,11 +30,12 @@ int main(int argc, char *argv[]) {
     MPI_Comm comm = PETSC_COMM_WORLD;
     RDy      rdy;
 
+    // set things up
     PetscCall(RDyCreate(comm, argv[1], &rdy));
     PetscCall(RDyMMSSetup(rdy));
 
+    // run the problem to completion
     while (!RDyFinished(rdy)) {
-      // advance the solution by the coupling interval specified in the config file
       PetscCall(RDyAdvance(rdy));
     }
 

--- a/driver/mms.c
+++ b/driver/mms.c
@@ -33,22 +33,15 @@ int main(int argc, char *argv[]) {
     PetscCall(RDyCreate(comm, argv[1], &rdy));
     PetscCall(RDyMMSSetup(rdy));
 
-    RDyTimeUnit time_unit;
-    PetscCall(RDyGetTimeUnit(rdy, &time_unit));
-    PetscReal dt, cur_time;
-    PetscCall(RDyGetTimeStep(rdy, time_unit, &dt));
     while (!RDyFinished(rdy)) {
-      PetscCall(RDyGetTime(rdy, time_unit, &cur_time));
-
-      // enforce dirichlet BCs and compute source terms at half steps
-      PetscCall(RDyMMSEnforceBoundaryConditions(rdy, cur_time + 0.5 * dt));
-      PetscCall(RDyMMSComputeSourceTerms(rdy, cur_time + 0.5 * dt));
-
       // advance the solution by the coupling interval specified in the config file
       PetscCall(RDyAdvance(rdy));
     }
 
     // compute error norms for the final solution
+    RDyTimeUnit time_unit;
+    PetscCall(RDyGetTimeUnit(rdy, &time_unit));
+    PetscReal cur_time;
     PetscCall(RDyGetTime(rdy, time_unit, &cur_time));
     PetscReal L1_norms[3], L2_norms[3], Linf_norms[3], global_area;
     PetscInt  num_global_cells;

--- a/driver/mms.c
+++ b/driver/mms.c
@@ -34,50 +34,9 @@ int main(int argc, char *argv[]) {
     PetscCall(RDyCreate(comm, argv[1], &rdy));
     PetscCall(RDyMMSSetup(rdy));
 
-    // run a convergence study
-    PetscInt  num_comps       = 3;
-    PetscInt  num_refinements = 3;
-    PetscReal L1_conv_rates[num_comps], L2_conv_rates[num_comps], Linf_conv_rates[num_comps];
-    PetscCall(RDyMMSEstimateConvergenceRates(rdy, num_refinements, L1_conv_rates, L2_conv_rates, Linf_conv_rates));
-
-    const char *comp_names[3] = {" h", "hu", "hv"};
-    PetscPrintf(comm, "Convergence rates:\n");
-    for (PetscInt idof = 0; idof < 3; idof++) {
-      PetscPrintf(comm, "  %s: L1 = %g, L2 = %g, Linf = %g\n", comp_names[idof], L1_conv_rates[idof], L2_conv_rates[idof], Linf_conv_rates[idof]);
-    }
-
+    // run the problem according to the given configuration
+    PetscCall(RDyMMSRun(rdy));
     PetscCall(RDyDestroy(&rdy));
-
-    /*
-    // run the problem to completion
-    while (!RDyFinished(rdy)) {
-      PetscCall(RDyAdvance(rdy));
-    }
-
-    // compute error norms for the final solution
-    RDyTimeUnit time_unit;
-    PetscCall(RDyGetTimeUnit(rdy, &time_unit));
-    PetscReal cur_time;
-    PetscCall(RDyGetTime(rdy, time_unit, &cur_time));
-    PetscReal L1_norms[3], L2_norms[3], Linf_norms[3], global_area;
-    PetscInt  num_global_cells;
-    PetscCall(RDyMMSComputeErrorNorms(rdy, cur_time, L1_norms, L2_norms, Linf_norms, &num_global_cells, &global_area));
-
-    PetscPrintf(comm, "Avg-cell-area    : %18.16f\n", global_area / num_global_cells);
-    PetscPrintf(comm, "Avg-length-scale : %18.16f\n", PetscSqrtReal(global_area / num_global_cells));
-
-    PetscPrintf(comm, "Error-Norm-1     : ");
-    for (PetscInt idof = 0; idof < 3; idof++) printf("%18.16f ", L1_norms[idof]);
-    PetscPrintf(comm, "\n");
-
-    PetscPrintf(comm, "Error-Norm-2     : ");
-    for (PetscInt idof = 0; idof < 3; idof++) printf("%18.16f ", L2_norms[idof]);
-    PetscPrintf(comm, "\n");
-
-    PetscPrintf(comm, "Error-Norm-Max   : ");
-    for (PetscInt idof = 0; idof < 3; idof++) printf("%18.16f ", Linf_norms[idof]);
-    PetscPrintf(comm, "\n");
-    */
   }
 
   PetscCall(RDyFinalize());

--- a/driver/mms.c
+++ b/driver/mms.c
@@ -34,6 +34,21 @@ int main(int argc, char *argv[]) {
     PetscCall(RDyCreate(comm, argv[1], &rdy));
     PetscCall(RDyMMSSetup(rdy));
 
+    // run a convergence study
+    PetscInt  num_comps       = 3;
+    PetscInt  num_refinements = 3;
+    PetscReal L1_conv_rates[num_comps], L2_conv_rates[num_comps], Linf_conv_rates[num_comps];
+    PetscCall(RDyMMSEstimateConvergenceRates(rdy, num_refinements, L1_conv_rates, L2_conv_rates, Linf_conv_rates));
+
+    const char *comp_names[3] = {" h", "hu", "hv"};
+    PetscPrintf(comm, "Convergence rates:\n");
+    for (PetscInt idof = 0; idof < 3; idof++) {
+      PetscPrintf(comm, "  %s: L1 = %g, L2 = %g, Linf = %g\n", comp_names[idof], L1_conv_rates[idof], L2_conv_rates[idof], Linf_conv_rates[idof]);
+    }
+
+    PetscCall(RDyDestroy(&rdy));
+
+    /*
     // run the problem to completion
     while (!RDyFinished(rdy)) {
       PetscCall(RDyAdvance(rdy));
@@ -62,6 +77,7 @@ int main(int argc, char *argv[]) {
     PetscPrintf(comm, "Error-Norm-Max   : ");
     for (PetscInt idof = 0; idof < 3; idof++) printf("%18.16f ", Linf_norms[idof]);
     PetscPrintf(comm, "\n");
+    */
   }
 
   PetscCall(RDyFinalize());

--- a/driver/tests/swe_roe/CMakeLists.txt
+++ b/driver/tests/swe_roe/CMakeLists.txt
@@ -143,6 +143,8 @@ foreach(np 1 2) # test on 1, 2 processes
   foreach(config basic)
     foreach(lang c f90)
       add_test(mms_file_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${mms_${lang}_driver} mms_dx1.yaml ${${config}_args})
+      set_tests_properties(mms_file_${lang}_np_${np}_${config}
+        PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
     endforeach()
   endforeach()
 endforeach()

--- a/driver/tests/swe_roe/CMakeLists.txt
+++ b/driver/tests/swe_roe/CMakeLists.txt
@@ -143,8 +143,6 @@ foreach(np 1 2) # test on 1, 2 processes
   foreach(config basic)
     foreach(lang c f90)
       add_test(mms_file_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${mms_${lang}_driver} mms_dx1.yaml ${${config}_args})
-      set_tests_properties(mms_file_${lang}_np_${np}_${config}
-        PROPERTIES PASS_REGULAR_EXPRESSION "PASS")
     endforeach()
   endforeach()
 endforeach()

--- a/driver/tests/swe_roe/mms_dx1.yaml
+++ b/driver/tests/swe_roe/mms_dx1.yaml
@@ -48,19 +48,20 @@ mms:
     # Convergence study parameters (optional)
     convergence:
       num_refinements: 3
-      expected_rates: # FIXME: we should be getting closer to 1st-order convergence
+      base_refinement: 1 # <-- start at this refinement level
+      expected_rates:
         h:
-          L1: 0.87
-          L2: 0.89
-          Linf: 0.90
+          L1: 0.92
+          L2: 0.92
+          Linf: 0.92
         hu:
-          L1: 0.86
-          L2: 0.90
-          Linf: 0.71
+          L1: 0.94
+          L2: 0.95
+          Linf: 0.79
         hv:
-          L1: 0.86
-          L2: 0.90
-          Linf: 0.71
+          L1: 0.94
+          L2: 0.95
+          Linf: 0.79
 
 logging:
   level: none

--- a/driver/tests/swe_roe/mms_dx1.yaml
+++ b/driver/tests/swe_roe/mms_dx1.yaml
@@ -48,7 +48,7 @@ mms:
     # Convergence study parameters (optional)
     convergence:
       num_refinements: 3
-      expected_convergence_rates:
+      expected_rates:
         h:
           L1: 1
           L2: 1

--- a/driver/tests/swe_roe/mms_dx1.yaml
+++ b/driver/tests/swe_roe/mms_dx1.yaml
@@ -45,6 +45,23 @@ mms:
     # Manning coefficient n(x,y)
     n:     N * (1 + sin(K*x) * sin(K*y))
 
+    # Convergence study parameters (optional)
+    convergence:
+      num_refinements: 3
+      expected_convergence_rates:
+        h:
+          L1: 1
+          L2: 1
+          Linf: 0.48
+        hu:
+          L1: 0.73
+          L2: 0.78
+          Linf: 0.62
+        hv:
+          L1: 0.73
+          L2: 0.78
+          Linf: 0.62
+
 logging:
   level: none
 

--- a/driver/tests/swe_roe/mms_dx1.yaml
+++ b/driver/tests/swe_roe/mms_dx1.yaml
@@ -48,19 +48,19 @@ mms:
     # Convergence study parameters (optional)
     convergence:
       num_refinements: 3
-      expected_rates:
+      expected_rates: # FIXME: we should be getting closer to 1st-order convergence
         h:
-          L1: 1
-          L2: 1
-          Linf: 0.48
+          L1: 0.87
+          L2: 0.89
+          Linf: 0.90
         hu:
-          L1: 0.73
-          L2: 0.78
-          Linf: 0.62
+          L1: 0.86
+          L2: 0.90
+          Linf: 0.71
         hv:
-          L1: 0.73
-          L2: 0.78
-          Linf: 0.62
+          L1: 0.86
+          L2: 0.90
+          Linf: 0.71
 
 logging:
   level: none

--- a/include/private/rdymmsconfigimpl.h
+++ b/include/private/rdymmsconfigimpl.h
@@ -32,7 +32,7 @@ typedef struct {
 
 typedef struct {
   PetscInt                  num_refinements;
-  RDyMMSSWEConvergenceRates expected_convergence_rates;
+  RDyMMSSWEConvergenceRates expected_rates;
 } RDyMMSSWEConvergence;
 
 // specification of a set of manufactured solutions for the

--- a/include/private/rdymmsconfigimpl.h
+++ b/include/private/rdymmsconfigimpl.h
@@ -22,6 +22,19 @@ typedef struct {
   PetscReal A, B, C, D, E, F, G, H, J, I_, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z;
 } RDyMMSConstants;
 
+typedef struct {
+  PetscReal L1, L2, Linf;
+} RDyMMSSWEErrorNorms;
+
+typedef struct {
+  RDyMMSSWEErrorNorms h, hu, hv;
+} RDyMMSSWEConvergenceRates;
+
+typedef struct {
+  PetscInt                  num_refinements;
+  RDyMMSSWEConvergenceRates expected_convergence_rates;
+} RDyMMSSWEConvergence;
+
 // specification of a set of manufactured solutions for the
 // shallow water equations (SWE)
 typedef struct {
@@ -37,6 +50,7 @@ typedef struct {
     // Manning's roughness coefficient n(x, y)
     MathExpression n;
   } expressions;
+
   struct {
     // water height h(x, y, t) and partial derivatives
     void *h, *dhdx, *dhdy, *dhdt;
@@ -49,6 +63,8 @@ typedef struct {
     // Manning's roughness coefficient n(x, y)
     void *n;
   } solutions;
+
+  RDyMMSSWEConvergence convergence;
 } RDyMMSSWESolutions;
 
 // constants and expressions for manufactured solutions

--- a/include/private/rdymmsconfigimpl.h
+++ b/include/private/rdymmsconfigimpl.h
@@ -32,6 +32,7 @@ typedef struct {
 
 typedef struct {
   PetscInt                  num_refinements;
+  PetscInt                  base_refinement;
   RDyMMSSWEConvergenceRates expected_rates;
 } RDyMMSSWEConvergence;
 

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -49,7 +49,7 @@ PETSC_EXTERN PetscErrorCode RDyMMSEnforceBoundaryConditions(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyMMSComputeSourceTerms(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyMMSUpdateMaterialProperties(RDy);
 PETSC_EXTERN PetscErrorCode RDyMMSComputeErrorNorms(RDy, PetscReal, PetscReal*, PetscReal*, PetscReal*, PetscInt*, PetscReal*);
-PETSC_EXTERN PetscErrorCode RDyMMSEstimateConvergenceRates(RDy, PetscInt, PetscReal*, PetscReal*, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyMMSEstimateConvergenceRates(RDy, PetscReal*, PetscReal*, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyMMSRun(RDy);
 
 // time integration

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -50,6 +50,7 @@ PETSC_EXTERN PetscErrorCode RDyMMSComputeSourceTerms(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyMMSUpdateMaterialProperties(RDy);
 PETSC_EXTERN PetscErrorCode RDyMMSComputeErrorNorms(RDy, PetscReal, PetscReal*, PetscReal*, PetscReal*, PetscInt*, PetscReal*);
 PETSC_EXTERN PetscErrorCode RDyMMSEstimateConvergenceRates(RDy, PetscInt, PetscReal*, PetscReal*, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyMMSRun(RDy);
 
 // time integration
 PETSC_EXTERN PetscErrorCode RDyAdvance(RDy);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -49,6 +49,7 @@ PETSC_EXTERN PetscErrorCode RDyMMSEnforceBoundaryConditions(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyMMSComputeSourceTerms(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyMMSUpdateMaterialProperties(RDy);
 PETSC_EXTERN PetscErrorCode RDyMMSComputeErrorNorms(RDy, PetscReal, PetscReal*, PetscReal*, PetscReal*, PetscInt*, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyMMSEstimateConvergenceRates(RDy, PetscReal, PetscInt, PetscReal*, PetscReal*, PetscReal*);
 
 // time integration
 PETSC_EXTERN PetscErrorCode RDyAdvance(RDy);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -49,7 +49,7 @@ PETSC_EXTERN PetscErrorCode RDyMMSEnforceBoundaryConditions(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyMMSComputeSourceTerms(RDy, PetscReal);
 PETSC_EXTERN PetscErrorCode RDyMMSUpdateMaterialProperties(RDy);
 PETSC_EXTERN PetscErrorCode RDyMMSComputeErrorNorms(RDy, PetscReal, PetscReal*, PetscReal*, PetscReal*, PetscInt*, PetscReal*);
-PETSC_EXTERN PetscErrorCode RDyMMSEstimateConvergenceRates(RDy, PetscReal, PetscInt, PetscReal*, PetscReal*, PetscReal*);
+PETSC_EXTERN PetscErrorCode RDyMMSEstimateConvergenceRates(RDy, PetscInt, PetscReal*, PetscReal*, PetscReal*);
 
 // time integration
 PETSC_EXTERN PetscErrorCode RDyAdvance(RDy);

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -13,7 +13,7 @@ module rdycore
             RDyCreate, RDySetup, RDyAdvance, RDyDestroy, &
             RDyMMSSetup, RDyMMSComputeSolution, RDyMMSEnforceBoundaryConditions, &
             RDyMMSComputeSourceTerms, RDyMMSUpdateMaterialProperties, &
-            RDyMMSComputeErrorNorms, RDyMMSEstimateConvergenceRates, &
+            RDyMMSComputeErrorNorms, RDyMMSEstimateConvergenceRates, RDyMMSRun, &
             RDyGetNumGlobalCells, RDyGetNumLocalCells, RDyGetNumBoundaryConditions, &
             RDyGetNumBoundaryEdges, RDyGetBoundaryConditionFlowType, &
             RDySetDirichletBoundaryValues, &
@@ -122,6 +122,11 @@ module rdycore
       type(c_ptr), value, intent(in)  :: rdy
       PetscInt,    value, intent(in)  :: num_refinements
       type(c_ptr), value, intent(in)  :: l1_rates, l2_rates, linf_rates
+    end function
+
+    integer(c_int) function rdymmsrun_(rdy) bind(c, name="RDyMMSRun")
+      use iso_c_binding, only: c_int, c_ptr, c_double
+      type(c_ptr), value, intent(in)  :: rdy
     end function
 
     integer(c_int) function rdygetnumglobalcells_(rdy, num_cells_global) bind(c, name="RDyGetNumGlobalCells")
@@ -511,6 +516,12 @@ contains
     integer,                  intent(out)   :: ierr
     ierr = rdymmsestimateconvergencerates_(rdy_%c_rdy, num_refinements, &
                                            c_loc(l1_conv_rates), c_loc(l2_conv_rates), c_loc(linf_conv_rates))
+  end subroutine
+
+  subroutine RDyMMSRun(rdy_, ierr)
+    type(RDy),                intent(inout) :: rdy_
+    integer,                  intent(out)   :: ierr
+    ierr = rdymmsrun_(rdy_%c_rdy)
   end subroutine
 
   subroutine RDyGetNumGlobalCells(rdy_, num_cells_global, ierr)

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -2,7 +2,6 @@
 // mainline RDycore (though it is built into the library).
 
 #include <muParserDLL.h>
-#include <petscconvest.h>
 #include <petscdmceed.h>
 #include <petscdmplex.h>
 #include <petscsys.h>

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -94,10 +94,14 @@ static PetscErrorCode MMSPreStep(TS ts) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+extern PetscErrorCode PauseIfRequested(RDy rdy);  // for -pause support
+
 // this can be used in place of RDySetup for the MMS driver, which uses a
 // modified YAML input schema (see ReadMMSConfigFile in yaml_input.c)
 PetscErrorCode RDyMMSSetup(RDy rdy) {
   PetscFunctionBegin;
+
+  PetscCall(PauseIfRequested(rdy));
 
   PetscCall(ReadMMSConfigFile(rdy));
 

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -357,14 +357,19 @@ PetscErrorCode RDyMMSUpdateMaterialProperties(RDy rdy) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode ComputeErrorNorms(RDy rdy, Vec solution, PetscReal time, PetscReal *L1_norms, PetscReal *L2_norms, PetscReal *Linf_norms,
-                                        PetscInt *num_global_cells, PetscReal *global_area) {
+// Computes the componentwise L1, L2, and Linf error norms for the relevant
+// manufactured solution at the given time. L1_norms, L2_norms, and Linf_norms
+// are all arrays large enough to store the number of dof. If non-NULL,
+// num_global_cells stores the number of distinct global cells and global_area
+// stores the total area covered by distinct global cells.
+PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_norms, PetscReal *L2_norms, PetscReal *Linf_norms,
+                                       PetscInt *num_global_cells, PetscReal *global_area) {
   PetscFunctionBegin;
   // compute the error vector
   Vec error;
   PetscCall(RDyCreatePrognosticVec(rdy, &error));
   PetscCall(RDyMMSComputeSolution(rdy, time, error));
-  PetscCall(VecAYPX(error, -1.0, solution));
+  PetscCall(VecAYPX(error, -1.0, rdy->X));
 
   PetscInt ndof;
   PetscCall(VecGetBlockSize(error, &ndof));
@@ -411,35 +416,16 @@ static PetscErrorCode ComputeErrorNorms(RDy rdy, Vec solution, PetscReal time, P
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-// Computes the componentwise L1, L2, and Linf error norms for the relevant
-// manufactured solution at the given time. L1_norms, L2_norms, and Linf_norms
-// are all arrays large enough to store the number of dof. If non-NULL,
-// num_global_cells stores the number of distinct global cells and global_area
-// stores the total area covered by distinct global cells.
-PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_norms, PetscReal *L2_norms, PetscReal *Linf_norms,
-                                       PetscInt *num_global_cells, PetscReal *global_area) {
-  PetscFunctionBegin;
-  PetscCall(ComputeErrorNorms(rdy, rdy->X, time, L1_norms, L2_norms, Linf_norms, num_global_cells, global_area));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
 // performs a temporo-spatial convergence study using the given instance of RDy
 // as a coarse grid, uniformly refining it the specified number of times,
 // evolving the solution to the given time, computing error norms for each
 // component, and calculating rates of convergence (and variances) with linear
 // regression
-PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal final_time, PetscInt num_refinements, PetscReal *L1_conv_rates,
-                                              PetscReal *L2_conv_rates, PetscReal *Linf_conv_rates) {
+PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscInt num_refinements, PetscReal *L1_conv_rates, PetscReal *L2_conv_rates,
+                                              PetscReal *Linf_conv_rates) {
   PetscFunctionBegin;
 
-  /*
-  PetscConvEst conv_est;
-  PetscCall(PetscConvEstCreate(rdy->comm, &conv_est));
-  PetscCall(PetscConvEstUseTS(conv_est, PETSC_FALSE)); // spatial convergence
-  PetscCall(PetscConvEstSetSolver(conv_est, rdy->ts));
-  */
-  TS        ts  = rdy->ts;
-  PetscReal dt0 = rdy->dt;
+  PetscReal final_time = rdy->config.time.final_time;
 
   PetscInt dim;
   PetscCall(DMGetDimension(rdy->dm, &dim));
@@ -448,73 +434,62 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal final_time, Pet
   PetscInt  num_comps = 3;  // SWE only!
   PetscReal L1_norms[num_refinements + 1][num_comps], L2_norms[num_refinements + 1][num_comps], Linf_norms[num_refinements + 1][num_comps];
 
-  DM dms[num_refinements + 1];
-  dms[0] = rdy->dm;
-  PetscCall(DMPlexSetRefinementUniform(dms[0], PETSC_TRUE));
-  for (PetscInt r = 0; r <= num_refinements; ++r) {
-    if (r > 0) {
-      // refine the next-coarser DM uniformly to create this one
-      PetscCall(DMRefine(dms[r - 1], MPI_COMM_NULL, &dms[r]));
-      PetscCall(DMSetCoarseDM(dms[r], dms[r - 1]));
-      PetscCall(DMCopyTransform(dms[r - 1], dms[r]));
+  // create refined RDy objects and set them up (dumb, but easy)
+  RDy rdys[num_refinements + 1];
+  rdys[0] = rdy;
+  for (PetscInt r = 1; r <= num_refinements; ++r) {
+    PetscCall(RDyCreate(rdy->comm, rdy->config_file, &rdys[r]));
+    char num_refinements[5];
+    snprintf(num_refinements, 4, "%" PetscInt_FMT, r);
+    PetscOptionsSetValue(NULL, "-dm_refine", num_refinements);
+    PetscCall(RDyMMSSetup(rdys[r]));
 
-      const char *dm_name;
-      PetscCall(PetscObjectGetName((PetscObject)dms[r - 1], &dm_name));
-      PetscCall(PetscObjectSetName((PetscObject)dms[r], dm_name));
-
-      PetscErrorCode (*rhs_func)(DM, PetscReal, Vec, Vec, void *);
-      void *rhs_ctx;
-      PetscCall(DMTSGetRHSFunctionLocal(dms[r - 1], &rhs_func, &rhs_ctx));
-      PetscCall(DMTSSetRHSFunctionLocal(dms[r], rhs_func, rhs_ctx));
-    }
-
-    // get the initial solution
-    Vec u;
-    PetscCall(DMCreateGlobalVector(dms[r], &u));
-    PetscCall(VecCopy(rdy->X, u));
-    PetscObject disc;
-    PetscCall(DMGetField(dms[r], 0, NULL, &disc));
-    const char *u_name;
-    PetscCall(PetscObjectGetName(disc, &u_name));
-    PetscCall(PetscObjectSetName((PetscObject)u, u_name));
-
-    // set up the solver
-    PetscCall(TSReset(ts));
-    PetscCall(TSSetDM(ts, dms[r]));
-    PetscCall(TSSetTime(ts, 0.0));
-    PetscCall(TSSetTimeStep(ts, dt0 * pow(2.0, -r)));
-    PetscCall(TSSetStepNumber(ts, 0));
-    PetscCall(TSSetMaxTime(ts, final_time));
-    PetscCall(TSSetSolution(ts, u));
-
-    // solve the thing
-    PetscCall(TSSolve(ts, NULL));
-
-    // compute error norms for this refinement level
-    PetscCall(RDyMMSComputeErrorNorms(rdy, final_time, L1_norms[r], L2_norms[r], Linf_norms[r], NULL, NULL));
+    // override timestepping info (no good way to do this currently)
+    rdys[r]->config.time.time_step = rdys[r - 1]->config.time.time_step / 2.0;
+    rdys[r]->config.time.max_step  = rdys[r - 1]->config.time.max_step * 2;
+    TSSetTimeStep(rdys[r]->ts, rdys[r]->config.time.time_step);
+    TSSetMaxSteps(rdys[r]->ts, rdys[r]->config.time.max_step);
   }
 
-  // clean up grids
-  for (PetscInt r = 1; r <= num_refinements; ++r) {
-    PetscCall(DMDestroy(&dms[r]));
+  for (PetscInt r = 0; r <= num_refinements; ++r) {
+    PetscPrintf(rdys[r]->comm, "Refinement level %" PetscInt_FMT ":\n", r);
+
+    // run the problem to completion
+    while (!RDyFinished(rdys[r])) {
+      PetscCall(RDyAdvance(rdys[r]));
+    }
+
+    // compute error norms for this refinement level
+    PetscCall(RDyMMSComputeErrorNorms(rdys[r], final_time, L1_norms[r], L2_norms[r], Linf_norms[r], NULL, NULL));
+    PetscPrintf(rdys[r]->comm, "  Error norms at t = %g:\n", final_time);
+    const char *comp_names[3] = {" h", "hu", "hv"};
+    for (PetscInt c = 0; c < num_comps; ++c) {
+      PetscPrintf(rdys[r]->comm, "    %s: L1 = %g, L2 = %g, Linf = %g\n", comp_names[c], L1_norms[r][c], L2_norms[r][c], Linf_norms[r][c]);
+    }
+    PetscPrintf(rdys[r]->comm, "\n");
   }
 
   // fit convergence rates
   PetscReal x[num_refinements + 1], y1[num_refinements + 1], y2[num_refinements + 1], yinf[num_refinements + 1];
   for (PetscInt c = 0; c < num_comps; ++c) {
     for (PetscInt r = 0; r <= num_refinements; ++r) {
-      x[r]    = PetscLog10Real(dt0 * pow(2.0, -r));
+      x[r]    = PetscLog10Real(rdys[r]->config.time.time_step);
       y1[r]   = PetscLog10Real(L1_norms[c][r]);
       y2[r]   = PetscLog10Real(L2_norms[c][r]);
       yinf[r] = PetscLog10Real(Linf_norms[c][r]);
     }
     PetscReal slope, intercept;
     PetscCall(PetscLinearRegression(num_refinements + 1, x, y1, &slope, &intercept));
-    L1_conv_rates[c] = -slope * dim;
+    L1_conv_rates[c] = slope;  // -slope * dim;
     PetscCall(PetscLinearRegression(num_refinements + 1, x, y2, &slope, &intercept));
-    L2_conv_rates[c] = -slope * dim;
+    L2_conv_rates[c] = slope;  // -slope * dim;
     PetscCall(PetscLinearRegression(num_refinements + 1, x, yinf, &slope, &intercept));
-    Linf_conv_rates[c] = -slope * dim;
+    Linf_conv_rates[c] = slope;  //-slope * dim;
+  }
+
+  // clean up
+  for (PetscInt r = 1; r <= num_refinements; ++r) {
+    PetscCall(RDyDestroy(&rdys[r]));
   }
 
   // PetscCall(PetscConvEstDestroy(&convEst));

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -521,7 +521,7 @@ PetscErrorCode RDyMMSRun(RDy rdy) {
   if (rdy->config.mms.swe.convergence.num_refinements) {
     // run a convergence study
     PetscInt  num_comps       = 3;
-    PetscInt  num_refinements = 3;
+    PetscInt  num_refinements = rdy->config.mms.swe.convergence.num_refinements;
     PetscReal L1_conv_rates[num_comps], L2_conv_rates[num_comps], Linf_conv_rates[num_comps];
     PetscCall(RDyMMSEstimateConvergenceRates(rdy, num_refinements, L1_conv_rates, L2_conv_rates, Linf_conv_rates));
 

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -401,7 +401,7 @@ PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_no
   // obtain global error norms
   PetscCall(MPI_Allreduce(MPI_IN_PLACE, L1_norms, ndof, MPI_DOUBLE, MPI_SUM, PETSC_COMM_WORLD));
   PetscCall(MPI_Allreduce(MPI_IN_PLACE, L2_norms, ndof, MPI_DOUBLE, MPI_SUM, PETSC_COMM_WORLD));
-  PetscCall(MPI_Allreduce(MPI_IN_PLACE, Linf_norms, ndof, MPI_DOUBLE, MPI_SUM, PETSC_COMM_WORLD));
+  PetscCall(MPI_Allreduce(MPI_IN_PLACE, Linf_norms, ndof, MPI_DOUBLE, MPI_MAX, PETSC_COMM_WORLD));
 
   for (PetscInt dof = 0; dof < ndof; ++dof) {
     L2_norms[dof] = PetscSqrtReal(L2_norms[dof]);

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -391,7 +391,7 @@ PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_no
       PetscReal e_dof = e[ndof * i + dof];
       L1_norms[dof] += PetscAbsReal(e_dof) * area;
       L2_norms[dof] += e_dof * e_dof * area;
-      Linf_norms[dof] = PetscMax(e_dof, Linf_norms[dof]);
+      Linf_norms[dof] = PetscMax(PetscAbsReal(e_dof), Linf_norms[dof]);
     }
     area_sum += area;
   }

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -75,6 +75,36 @@ static PetscErrorCode EvaluateTemporalSolution(void *expr, PetscInt n, PetscReal
 #undef SET_SPATIAL_VARIABLES
 #undef SET_SPATIOTEMPORAL_VARIABLES
 
+// sets the z coordinate of refined mesh vertices to match the analytic value
+// z(x, y)
+static PetscErrorCode SnapRefinedVerticesToBathymetry(RDy rdy) {
+  PetscFunctionBegin;
+
+  Vec          coordinates;
+  PetscSection coordSection;
+  PetscScalar *coords;
+  PetscInt     v, vStart, vEnd, offset;
+  PetscReal    x, y, z;
+
+  PetscCall(DMGetCoordinateSection(rdy->dm, &coordSection));
+  PetscCall(DMGetCoordinatesLocal(rdy->dm, &coordinates));
+  PetscCall(DMPlexGetDepthStratum(rdy->dm, 0, &vStart, &vEnd));
+
+  PetscCall(VecGetArray(coordinates, &coords));
+  for (v = vStart; v < vEnd; v++) {
+    PetscCall(PetscSectionGetOffset(coordSection, v, &offset));
+    x = coords[offset];
+    y = coords[offset + 1];
+    mupDefineVar(rdy->config.mms.swe.solutions.z, "x", &x);
+    mupDefineVar(rdy->config.mms.swe.solutions.z, "y", &y);
+    z                  = mupEval(rdy->config.mms.swe.solutions.z);
+    coords[offset + 2] = z;
+  }
+  PetscCall(VecRestoreArray(coordinates, &coords));
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 // this function gets called at the beginning of each time step, updating
 // source terms and boundary conditions at a properly centered time
 static PetscErrorCode MMSPreStep(TS ts) {
@@ -123,6 +153,14 @@ PetscErrorCode RDyMMSSetup(RDy rdy) {
   PetscCall(CreateDM(rdy));           // for mesh and solution vector
   PetscCall(CreateAuxiliaryDM(rdy));  // for diagnostics
   PetscCall(CreateVectors(rdy));      // global and local vectors, residuals
+
+  // adjust the vertices of a refined mesh to conform to our analytical z(x, y)
+  // (necessary because DMRefine linearly interpolates vertices by default)
+  PetscInt refine_level = 0;
+  PetscOptionsGetInt(NULL, NULL, "-dm_refine", &refine_level, NULL);
+  if (refine_level > 0) {
+    PetscCall(SnapRefinedVerticesToBathymetry(rdy));
+  }
 
   RDyLogDebug(rdy, "Initializing regions...");
   PetscCall(InitRegions(rdy));
@@ -419,34 +457,6 @@ PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_no
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode SnapRefinedVerticesToBathymetry(RDy rdy) {
-  PetscFunctionBegin;
-
-  Vec          coordinates;
-  PetscSection coordSection;
-  PetscScalar *coords;
-  PetscInt     v, vStart, vEnd, offset;
-  PetscReal    x, y, z;
-
-  PetscCall(DMGetCoordinateSection(rdy->dm, &coordSection));
-  PetscCall(DMGetCoordinatesLocal(rdy->dm, &coordinates));
-  PetscCall(DMPlexGetDepthStratum(rdy->dm, 0, &vStart, &vEnd));
-
-  PetscCall(VecGetArray(coordinates, &coords));
-  for (v = vStart; v < vEnd; v++) {
-    PetscCall(PetscSectionGetOffset(coordSection, v, &offset));
-    x = coords[offset];
-    y = coords[offset + 1];
-    mupDefineVar(rdy->config.mms.swe.solutions.z, "x", &x);
-    mupDefineVar(rdy->config.mms.swe.solutions.z, "y", &y);
-    z                  = mupEval(rdy->config.mms.swe.solutions.z);
-    coords[offset + 2] = z;
-  }
-  PetscCall(VecRestoreArray(coordinates, &coords));
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
 // performs a temporo-spatial convergence study using the given instance of RDy
 // as a coarse grid, uniformly refining it the specified number of times,
 // evolving the solution to the given time, computing error norms for each
@@ -474,10 +484,6 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscInt num_refinements,
     snprintf(num_refinements, 4, "%" PetscInt_FMT, r);
     PetscOptionsSetValue(NULL, "-dm_refine", num_refinements);
     PetscCall(RDyMMSSetup(rdys[r]));
-
-    // adjust the vertices of the mesh to conform to our analytical z(x, y)
-    // (necessary because DMRefine linearly interpolates vertices by default)
-    PetscCall(SnapRefinedVerticesToBathymetry(rdys[r]));
 
     // override timestepping info (no good way to do this currently)
     rdys[r]->config.time.time_step = rdys[r - 1]->config.time.time_step;

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -458,9 +458,7 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscInt num_refinements,
     PetscPrintf(rdys[r]->comm, "Refinement level %" PetscInt_FMT ":\n", r);
 
     // run the problem to completion
-    while (!RDyFinished(rdys[r])) {
-      PetscCall(RDyAdvance(rdys[r]));
-    }
+    PetscCall(TSSolve(rdys[r]->ts, rdys[r]->X));
 
     // compute error norms for this refinement level
     PetscCall(RDyMMSComputeErrorNorms(rdys[r], final_time, L1_norms[r], L2_norms[r], Linf_norms[r], NULL, NULL));

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -448,8 +448,8 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscInt num_refinements,
     PetscCall(RDyMMSSetup(rdys[r]));
 
     // override timestepping info (no good way to do this currently)
-    rdys[r]->config.time.time_step = rdys[r - 1]->config.time.time_step / 2.0;
-    rdys[r]->config.time.max_step  = rdys[r - 1]->config.time.max_step * 2;
+    rdys[r]->config.time.time_step = rdys[r - 1]->config.time.time_step;
+    rdys[r]->config.time.max_step  = rdys[r - 1]->config.time.max_step;
     TSSetTimeStep(rdys[r]->ts, rdys[r]->config.time.time_step);
     TSSetMaxSteps(rdys[r]->ts, rdys[r]->config.time.max_step);
   }

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -891,7 +891,7 @@ PetscErrorCode RDySetLogFile(RDy rdy, const char *filename) {
 
 // checks for the -pause option, which pauses RDycore and prints out the PIDs
 // of the MPI processes so that a debugger may be attached
-static PetscErrorCode PauseIfRequested(RDy rdy) {
+PetscErrorCode PauseIfRequested(RDy rdy) {
   PetscFunctionBegin;
 
   static PetscBool already_paused = PETSC_FALSE;

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -97,6 +97,7 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
       break;
   }
   PetscCall(TSSetDM(rdy->ts, rdy->dm));
+  PetscCall(TSSetApplicationContext(rdy->ts, rdy));
 
   PetscCheck(rdy->config.physics.flow.mode == FLOW_SWE, rdy->comm, PETSC_ERR_USER, "Only the 'swe' flow mode is currently supported.");
   PetscCall(TSSetRHSFunction(rdy->ts, rdy->R, RHSFunctionSWE, rdy));

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -47,23 +47,29 @@ static void DestroyCourantNumberDiagnostics(void) {
 static PetscErrorCode InitMPITypesAndOps(void) {
   PetscFunctionBegin;
 
-  // create an MPI data type for the CourantNumberDiagnostics struct
-  const int      num_blocks             = 3;
-  const int      block_lengths[3]       = {1, 1, 1};
-  const MPI_Aint block_displacements[3] = {
-      offsetof(CourantNumberDiagnostics, max_courant_num),
-      offsetof(CourantNumberDiagnostics, global_edge_id),
-      offsetof(CourantNumberDiagnostics, global_cell_id),
-  };
-  MPI_Datatype block_types[3] = {MPI_DOUBLE, MPI_INT, MPI_INT};
-  MPI_Type_create_struct(num_blocks, block_lengths, block_displacements, block_types, &courant_num_diags_type);
-  MPI_Type_commit(&courant_num_diags_type);
+  static PetscBool initialized = PETSC_FALSE;
 
-  // create a corresponding reduction operator for the new type
-  MPI_Op_create(FindCourantNumberDiagnostics, 1, &courant_num_diags_op);
+  if (!initialized) {
+    // create an MPI data type for the CourantNumberDiagnostics struct
+    const int      num_blocks             = 3;
+    const int      block_lengths[3]       = {1, 1, 1};
+    const MPI_Aint block_displacements[3] = {
+        offsetof(CourantNumberDiagnostics, max_courant_num),
+        offsetof(CourantNumberDiagnostics, global_edge_id),
+        offsetof(CourantNumberDiagnostics, global_cell_id),
+    };
+    MPI_Datatype block_types[3] = {MPI_DOUBLE, MPI_INT, MPI_INT};
+    MPI_Type_create_struct(num_blocks, block_lengths, block_displacements, block_types, &courant_num_diags_type);
+    MPI_Type_commit(&courant_num_diags_type);
 
-  // make sure the operator and the type are destroyed upon exit
-  PetscCall(RDyOnFinalize(DestroyCourantNumberDiagnostics));
+    // create a corresponding reduction operator for the new type
+    MPI_Op_create(FindCourantNumberDiagnostics, 1, &courant_num_diags_op);
+
+    // make sure the operator and the type are destroyed upon exit
+    PetscCall(RDyOnFinalize(DestroyCourantNumberDiagnostics));
+
+    initialized = PETSC_TRUE;
+  }
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -580,6 +580,7 @@ static const cyaml_schema_field_t mms_swe_convergence_rates_fields_schema[] = {
 
 static const cyaml_schema_field_t mms_swe_convergence_fields_schema[] = {
     CYAML_FIELD_INT("num_refinements", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergence, num_refinements),
+    CYAML_FIELD_INT("base_refinement", CYAML_FLAG_OPTIONAL, RDyMMSSWEConvergence, base_refinement),
     CYAML_FIELD_MAPPING("expected_rates", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergence,
                         expected_rates, mms_swe_convergence_rates_fields_schema),
     CYAML_FIELD_END

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -565,23 +565,23 @@ static const cyaml_schema_field_t mms_constants_fields_schema[] = {
 };
 
 static const cyaml_schema_field_t mms_swe_error_norms_fields_schema[] = {
-    CYAML_FIELD_FLOAT("L1", CYAML_FLAG_DEFAULT, RDyMMSSWEErrorNorms, L1),
-    CYAML_FIELD_FLOAT("L2", CYAML_FLAG_DEFAULT, RDyMMSSWEErrorNorms, L2),
-    CYAML_FIELD_FLOAT("Linf", CYAML_FLAG_DEFAULT, RDyMMSSWEErrorNorms, Linf),
+    CYAML_FIELD_FLOAT("L1", CYAML_FLAG_OPTIONAL, RDyMMSSWEErrorNorms, L1),
+    CYAML_FIELD_FLOAT("L2", CYAML_FLAG_OPTIONAL, RDyMMSSWEErrorNorms, L2),
+    CYAML_FIELD_FLOAT("Linf", CYAML_FLAG_OPTIONAL, RDyMMSSWEErrorNorms, Linf),
     CYAML_FIELD_END
 };
 
 static const cyaml_schema_field_t mms_swe_convergence_rates_fields_schema[] = {
-    CYAML_FIELD_MAPPING("h", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergenceRates, h, mms_swe_error_norms_fields_schema),
-    CYAML_FIELD_MAPPING("hu", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergenceRates, hu, mms_swe_error_norms_fields_schema),
-    CYAML_FIELD_MAPPING("hv", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergenceRates, hv, mms_swe_error_norms_fields_schema),
+    CYAML_FIELD_MAPPING("h", CYAML_FLAG_OPTIONAL, RDyMMSSWEConvergenceRates, h, mms_swe_error_norms_fields_schema),
+    CYAML_FIELD_MAPPING("hu", CYAML_FLAG_OPTIONAL, RDyMMSSWEConvergenceRates, hu, mms_swe_error_norms_fields_schema),
+    CYAML_FIELD_MAPPING("hv", CYAML_FLAG_OPTIONAL, RDyMMSSWEConvergenceRates, hv, mms_swe_error_norms_fields_schema),
     CYAML_FIELD_END
 };
 
 static const cyaml_schema_field_t mms_swe_convergence_fields_schema[] = {
     CYAML_FIELD_INT("num_refinements", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergence, num_refinements),
-    CYAML_FIELD_MAPPING("expected_convergence_rates", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergence,
-                        expected_convergence_rates, mms_swe_convergence_rates_fields_schema),
+    CYAML_FIELD_MAPPING("expected_rates", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergence,
+                        expected_rates, mms_swe_convergence_rates_fields_schema),
     CYAML_FIELD_END
 };
 

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -564,6 +564,27 @@ static const cyaml_schema_field_t mms_constants_fields_schema[] = {
     CYAML_FIELD_END
 };
 
+static const cyaml_schema_field_t mms_swe_error_norms_fields_schema[] = {
+    CYAML_FIELD_FLOAT("L1", CYAML_FLAG_DEFAULT, RDyMMSSWEErrorNorms, L1),
+    CYAML_FIELD_FLOAT("L2", CYAML_FLAG_DEFAULT, RDyMMSSWEErrorNorms, L2),
+    CYAML_FIELD_FLOAT("Linf", CYAML_FLAG_DEFAULT, RDyMMSSWEErrorNorms, Linf),
+    CYAML_FIELD_END
+};
+
+static const cyaml_schema_field_t mms_swe_convergence_rates_fields_schema[] = {
+    CYAML_FIELD_MAPPING("h", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergenceRates, h, mms_swe_error_norms_fields_schema),
+    CYAML_FIELD_MAPPING("hu", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergenceRates, hu, mms_swe_error_norms_fields_schema),
+    CYAML_FIELD_MAPPING("hv", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergenceRates, hv, mms_swe_error_norms_fields_schema),
+    CYAML_FIELD_END
+};
+
+static const cyaml_schema_field_t mms_swe_convergence_fields_schema[] = {
+    CYAML_FIELD_INT("num_refinements", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergence, num_refinements),
+    CYAML_FIELD_MAPPING("expected_convergence_rates", CYAML_FLAG_DEFAULT, RDyMMSSWEConvergence,
+                        expected_convergence_rates, mms_swe_convergence_rates_fields_schema),
+    CYAML_FIELD_END
+};
+
 static const cyaml_schema_field_t mms_swe_fields_schema[] = {
     CYAML_FIELD_STRING("h", CYAML_FLAG_DEFAULT, RDyMMSSWESolutions, expressions.h, 1),
     CYAML_FIELD_STRING("dhdx", CYAML_FLAG_DEFAULT, RDyMMSSWESolutions, expressions.dhdx, 1),
@@ -581,6 +602,7 @@ static const cyaml_schema_field_t mms_swe_fields_schema[] = {
     CYAML_FIELD_STRING("dzdx", CYAML_FLAG_DEFAULT, RDyMMSSWESolutions, expressions.dzdx, 1),
     CYAML_FIELD_STRING("dzdy", CYAML_FLAG_DEFAULT, RDyMMSSWESolutions, expressions.dzdy, 1),
     CYAML_FIELD_STRING("n", CYAML_FLAG_DEFAULT, RDyMMSSWESolutions, expressions.n, 1),
+    CYAML_FIELD_MAPPING("convergence", CYAML_FLAG_OPTIONAL, RDyMMSSWESolutions, convergence, mms_swe_convergence_fields_schema),
     CYAML_FIELD_END
 };
 

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -901,7 +901,7 @@ static PetscErrorCode ParseSWEManufacturedSolutions(MPI_Comm comm, RDyMMSConstan
   DEFINE_FUNCTION(swe, constants, dvdy);
   DEFINE_FUNCTION(swe, constants, dvdt);
 
-  DEFINE_FUNCTION(swe, constants, u);
+  DEFINE_FUNCTION(swe, constants, z);
   DEFINE_FUNCTION(swe, constants, dzdx);
   DEFINE_FUNCTION(swe, constants, dzdy);
 

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -1161,8 +1161,9 @@ static PetscErrorCode ReadAndBroadcastConfigFile(RDy rdy, char **config_str) {
     MPI_Bcast(&config_size, 1, MPI_INT, 0, rdy->comm);
 
     // recreate the configuration string.
-    PetscCall(PetscCalloc1(config_size, config_str));
+    PetscCall(PetscCalloc1(config_size + 1, config_str));
     MPI_Bcast(*config_str, config_size, MPI_CHAR, 0, rdy->comm);
+    (*config_str)[config_size] = 0;
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }


### PR DESCRIPTION
This PR brings in a new capability for our MMS driver: convergence studies. See the updated MMS section of the user guide for a description of how this works. The summary is this: you specify a `convergence` section in your MMS input file giving the number of refinements to your problem and the expected rates of convergence you want from whatever error norms of whatever solution components you attach to PASS/FAIL criteria.

For some reason, some convergence rates differ on multiple processes, so this is still under investigation, but this is how things are looking.

Closes #104 