### PR TITLE
Mesh vertices are now snapped to z(x, y) even when unrefined.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,6 @@ Exascale Earth System Model (E3SM)](https://e3sm.org).
 
 RDycore is funded by the US Department of Energy's (DOE) [Scientific Discovery
 Through Advanced Computing (SciDAC)](https://www.scidac.gov/) program through a
-joint parternship between the DOE Office of Science's [Biological and
+joint partnership between the DOE Office of Science's [Biological and
 Environmental Research](https://science.osti.gov/ber) and [Advanced
 Scientific Computing Research](https://science/osti.gov/ascr) programs.

--- a/driver/tests/swe_roe/mms_dx1.yaml
+++ b/driver/tests/swe_roe/mms_dx1.yaml
@@ -37,7 +37,7 @@ mms:
     dvdy: -K * V * sin(K*x) * sin(K*y) * exp(t/T)
     dvdt:  V / T * sin(K*x) * cos(K*y) * exp(t/T)
 
-    # elevation as z(x, y)
+    # elevation as z(x, y) <-- overwrites mesh z coordinates
     z:     Z * sin(K*x) * sin(K*y)
     dzdx:  Z * K * cos(K*x) * sin(K*y)
     dzdy:  Z * K * sin(K*x) * cos(K*y)
@@ -51,17 +51,17 @@ mms:
       base_refinement: 1 # <-- start at this refinement level
       expected_rates:
         h:
-          L1: 0.92
-          L2: 0.92
-          Linf: 0.92
+          L1: 0.94
+          L2: 0.95
+          Linf: 0.94
         hu:
-          L1: 0.94
-          L2: 0.95
-          Linf: 0.79
+          L1: 0.91
+          L2: 0.93
+          Linf: 0.77
         hv:
-          L1: 0.94
-          L2: 0.95
-          Linf: 0.79
+          L1: 0.91
+          L2: 0.93
+          Linf: 0.77
 
 logging:
   level: none
@@ -77,7 +77,7 @@ output:
   interval: 500
 
 grid:
-  file: mms_triangles_dx1.exo
+  file: mms_triangles_dx1.exo # z coordinates overwritten by z(x, y) above
 
 # one region represents the whole domain
 regions:

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -77,7 +77,7 @@ static PetscErrorCode EvaluateTemporalSolution(void *expr, PetscInt n, PetscReal
 
 // sets the z coordinate of refined mesh vertices to match the analytic value
 // z(x, y)
-static PetscErrorCode SnapRefinedVerticesToBathymetry(RDy rdy) {
+static PetscErrorCode SnapVerticesToBathymetry(RDy rdy) {
   PetscFunctionBegin;
 
   Vec          coordinates;
@@ -153,8 +153,8 @@ PetscErrorCode RDyMMSSetup(RDy rdy) {
   PetscInt refine_level = 0;
   PetscOptionsGetInt(NULL, NULL, "-dm_refine", &refine_level, NULL);
   if (!refine_level) {
-    int  base_refinement = rdy->config.mms.swe.convergence.base_refinement;
-    char refinement[5];
+    PetscInt base_refinement = rdy->config.mms.swe.convergence.base_refinement;
+    char     refinement[5];
     snprintf(refinement, 4, "%" PetscInt_FMT, base_refinement);
     PetscOptionsSetValue(NULL, "-dm_refine", refinement);
     // the following line is apparently needed when we give -dm_refine above
@@ -167,10 +167,7 @@ PetscErrorCode RDyMMSSetup(RDy rdy) {
   PetscCall(CreateVectors(rdy));      // global and local vectors, residuals
 
   // adjust the vertices of a refined mesh to conform to our analytical z(x, y)
-  // (necessary because DMRefine linearly interpolates vertices by default)
-  if (refine_level > 0) {
-    PetscCall(SnapRefinedVerticesToBathymetry(rdy));
-  }
+  PetscCall(SnapVerticesToBathymetry(rdy));
 
   RDyLogDebug(rdy, "Initializing regions...");
   PetscCall(InitRegions(rdy));


### PR DESCRIPTION
Gautam and I discussed this morning that the z coordinates of the mesh should be overwritten by the analytic bathymetry `z(x, y)` in all cases. This PR implements this change and some other small fixes.