### PR TITLE
Removes one VecCopy and allocates another Vec at model initialization

### DIFF
--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -164,6 +164,9 @@ struct _p_RDy {
   // residual vector
   Vec R;
 
+  // vector to store fluxes through internal and boundary edges
+  Vec F_dup;
+
   // source-sink vector
   Vec swe_src;
 

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -160,7 +160,6 @@ struct _p_RDy {
 
   // solution vectors (global and local)
   Vec X, X_local;
-  Vec Soln;
 
   // residual vector
   Vec R;

--- a/include/private/rdymeshimpl.h
+++ b/include/private/rdymeshimpl.h
@@ -159,7 +159,7 @@ typedef struct RDyMesh {
   // number of cells in the mesh (across ghost cells owned by other processes)
   PetscInt num_cells;
   // number of cells in the mesh owned by the local process
-  PetscInt num_cells_local;
+  PetscInt num_owned_cells;
   // number of total cells in the global mesh
   PetscInt num_cells_global;
   // number of edges in the mesh attached to locally stored cells

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -154,6 +154,7 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   if ((*rdy)->R) VecDestroy(&((*rdy)->R));
   if ((*rdy)->X) VecDestroy(&((*rdy)->X));
   if ((*rdy)->X_local) VecDestroy(&((*rdy)->X_local));
+  if ((*rdy)->F_dup) VecDestroy(&((*rdy)->F_dup));
 
   // destroy time series
   PetscCall(DestroyTimeSeries(*rdy));

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -154,7 +154,6 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   if ((*rdy)->R) VecDestroy(&((*rdy)->R));
   if ((*rdy)->X) VecDestroy(&((*rdy)->X));
   if ((*rdy)->X_local) VecDestroy(&((*rdy)->X_local));
-  if ((*rdy)->Soln) VecDestroy(&((*rdy)->Soln));
 
   // destroy time series
   PetscCall(DestroyTimeSeries(*rdy));

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -10,7 +10,7 @@ PetscErrorCode RDyGetNumGlobalCells(RDy rdy, PetscInt *num_cells_global) {
 
 PetscErrorCode RDyGetNumLocalCells(RDy rdy, PetscInt *num_cells) {
   PetscFunctionBegin;
-  *num_cells = rdy->mesh.num_cells_local;
+  *num_cells = rdy->mesh.num_owned_cells;
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -44,7 +44,7 @@ static PetscErrorCode CheckBoundaryNumEdges(RDy rdy, const PetscInt boundary_ind
 
 static PetscErrorCode CheckNumLocalCells(RDy rdy, const PetscInt size) {
   PetscFunctionBegin;
-  PetscAssert(rdy->mesh.num_cells_local == size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ, "The size of array is not equal to the number of local cells");
+  PetscAssert(rdy->mesh.num_owned_cells == size, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ, "The size of array is not equal to the number of local cells");
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -121,7 +121,7 @@ static PetscErrorCode RDyGetPrognosticVariableOfLocalCell(RDy rdy, PetscInt idof
 
   PetscReal *x;
   PetscCall(VecGetArray(rdy->X, &x));
-  for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
+  for (PetscInt i = 0; i < rdy->mesh.num_owned_cells; ++i) {
     values[i] = x[3 * i + idof];
   }
   PetscCall(VecRestoreArray(rdy->X, &x));
@@ -163,7 +163,7 @@ PetscErrorCode RDySetSourceVecForLocalCells(RDy rdy, Vec src_vec, PetscInt idof,
 
   PetscReal *s;
   PetscCall(VecGetArray(src_vec, &s));
-  for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
+  for (PetscInt i = 0; i < rdy->mesh.num_owned_cells; ++i) {
     s[i * ndof + idof] = values[i];
   }
   PetscCall(VecRestoreArray(src_vec, &s));
@@ -381,7 +381,7 @@ PetscErrorCode RDyGetLocalCellManningsNs(RDy rdy, const PetscInt size, PetscReal
   if (rdy->ceed_resource[0]) {  // ceed
     PetscCall(SWESourceOperatorSetManningsN(rdy->ceed_rhs.op_src, n_values));
   } else {  // petsc
-    for (PetscInt icell = 0; icell < rdy->mesh.num_cells_local; ++icell) {
+    for (PetscInt icell = 0; icell < rdy->mesh.num_owned_cells; ++icell) {
       n_values[icell] = rdy->materials_by_cell[icell].manning;
     }
   }
@@ -397,7 +397,7 @@ PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscR
   if (rdy->ceed_resource[0]) {  // ceed
     PetscCall(SWESourceOperatorSetManningsN(rdy->ceed_rhs.op_src, n_values));
   } else {  // petsc
-    for (PetscInt icell = 0; icell < rdy->mesh.num_cells_local; ++icell) {
+    for (PetscInt icell = 0; icell < rdy->mesh.num_owned_cells; ++icell) {
       rdy->materials_by_cell[icell].manning = n_values[icell];
     }
   }

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -238,6 +238,7 @@ PetscErrorCode CreateVectors(RDy rdy) {
   PetscCall(DMCreateGlobalVector(rdy->dm, &rdy->X));
   PetscCall(VecDuplicate(rdy->X, &rdy->R));
   PetscCall(VecViewFromOptions(rdy->X, NULL, "-vec_view"));
+  PetscCall(VecDuplicate(rdy->X, &rdy->F_dup));
   PetscCall(DMCreateLocalVector(rdy->dm, &rdy->X_local));
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -237,7 +237,6 @@ PetscErrorCode CreateVectors(RDy rdy) {
 
   PetscCall(DMCreateGlobalVector(rdy->dm, &rdy->X));
   PetscCall(VecDuplicate(rdy->X, &rdy->R));
-  PetscCall(VecDuplicate(rdy->X, &rdy->Soln));
   PetscCall(VecViewFromOptions(rdy->X, NULL, "-vec_view"));
   PetscCall(DMCreateLocalVector(rdy->dm, &rdy->X_local));
 

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -429,7 +429,7 @@ PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_no
   memset(L1_norms, 0, ndof * sizeof(PetscReal));
   memset(L2_norms, 0, ndof * sizeof(PetscReal));
   memset(Linf_norms, 0, ndof * sizeof(PetscReal));
-  for (PetscInt i = 0; i < rdy->mesh.num_cells_local; ++i) {
+  for (PetscInt i = 0; i < rdy->mesh.num_owned_cells; ++i) {
     PetscReal area = rdy->mesh.cells.areas[i];
 
     for (PetscInt dof = 0; dof < ndof; ++dof) {
@@ -455,7 +455,7 @@ PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_no
   // obtain optional diagnostics
   if (num_global_cells) {
     PetscMPIInt ncells;
-    PetscCall(MPI_Reduce(&rdy->mesh.num_cells_local, &ncells, 1, MPI_INT, MPI_SUM, 0, PETSC_COMM_WORLD));
+    PetscCall(MPI_Reduce(&rdy->mesh.num_owned_cells, &ncells, 1, MPI_INT, MPI_SUM, 0, PETSC_COMM_WORLD));
     *num_global_cells = (PetscInt)ncells;
   }
   if (global_area) {

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -187,6 +187,21 @@ static PetscErrorCode RDyCeedOperatorApply(RDy rdy, PetscReal dt, Vec U_local, V
   }
 
   {
+    // The computation of fluxes across internal and boundary edges via CeedOperator is done
+    // in the following three stages:
+    //
+    // a) Pre-CeedOperatorApply stage:
+    //    - Set memory pointer of a CeedVector (u_local_ceed) is set to PETSc Vec (U_local)
+    //    - Ask DM to "get" a PETSc Vec (F_local), then set memory pointer of a CeedVector (f_ceed)
+    //      to the F_local PETSc Vec.
+    //
+    // b) CeedOperatorApply stage
+    //    - Apply the CeedOparator in which u_local_ceed is an input, while f_ceed is an output.
+    //
+    // c) Post-CeedOperatorApply stage:
+    //    - Add values in F_local to F via Local-to-Global scatter.
+    //    - Clean up memory
+
     PetscScalar *u_local, *f;
     PetscMemType mem_type;
     Vec          F_local;
@@ -194,35 +209,58 @@ static PetscErrorCode RDyCeedOperatorApply(RDy rdy, PetscReal dt, Vec U_local, V
     CeedVector u_local_ceed = rdy->ceed_rhs.u_local_ceed;
     CeedVector f_ceed       = rdy->ceed_rhs.f_ceed;
 
+    // 1. Sets the pointer of a CeedVector to a PETSc Vec: u_local_ceed --> U_local
     PetscCall(VecGetArrayAndMemType(U_local, &u_local, &mem_type));
     PetscCallCEED(CeedVectorSetArray(u_local_ceed, MemTypeP2C(mem_type), CEED_USE_POINTER, u_local));
 
+    // 2. Sets the pointer of a CeedVector to a PETSc Vec: f_ceed --> F_local
     PetscCall(DMGetLocalVector(rdy->dm, &F_local));
     PetscCall(VecGetArrayAndMemType(F_local, &f, &mem_type));
     PetscCallCEED(CeedVectorSetArray(f_ceed, MemTypeP2C(mem_type), CEED_USE_POINTER, f));
 
+    // 3. Apply the CeedOpeator associated with the internal and boundary edges
     PetscCall(PetscLogEventBegin(RDY_CeedOperatorApply, U_local, F, 0, 0));
     PetscCall(PetscLogGpuTimeBegin());
     PetscCallCEED(CeedOperatorApply(rdy->ceed_rhs.op_edges, u_local_ceed, f_ceed, CEED_REQUEST_IMMEDIATE));
     PetscCall(PetscLogGpuTimeEnd());
     PetscCall(PetscLogEventEnd(RDY_CeedOperatorApply, U_local, F, 0, 0));
 
+    // 4. Resets memory pointer of CeedVectors
+    PetscCallCEED(CeedVectorTakeArray(f_ceed, MemTypeP2C(mem_type), &f));
     PetscCallCEED(CeedVectorTakeArray(u_local_ceed, MemTypeP2C(mem_type), &u_local));
+
+    // 5. Restore pointers to the PETSc Vecs
+    PetscCall(VecRestoreArrayAndMemType(F_local, &f));
     PetscCall(VecRestoreArrayAndMemType(U_local, &u_local));
 
-    PetscCallCEED(CeedVectorTakeArray(f_ceed, MemTypeP2C(mem_type), &f));
-    PetscCall(VecRestoreArrayAndMemType(F_local, &f));
-
+    // 6. Zero out values in F and then add F_local to F via Local-to-Global scatter
     PetscCall(VecZeroEntries(F));
     PetscCall(DMLocalToGlobal(rdy->dm, F_local, ADD_VALUES, F));
+
+    // 7. Restor the F_local
     PetscCall(DMRestoreLocalVector(rdy->dm, &F_local));
   }
 
   {
-    CeedOperatorField riemannf_field;
-    SWESourceOperatorGetRiemannFlux(rdy->ceed_rhs.op_src, &riemannf_field);
+    // The computation of contribution of the source-sink term via CeedOperator is done
+    // in the following three stages:
+    //
+    // a) Pre-CeedOperatorApply stage:
+    //    - Set memory pointer of a CeedVector (u_local_ceed) is set to PETSc Vec (U_local)
+    //    - A copy of the PETSc Vec F is made as F_dup. Then, memory pointer of a CeedVector (riemannf_ceed)
+    //      to the F_dup.
+    //    - Set memory pointer of a CeedVector (s_ceed) is set to PETSc Vec (F)
+    //
+    // b) CeedOperatorApply stage
+    //    - Apply the CeedOparator in which u_local_ceed is an input, while s_ceed is an output.
+    //
+    // c) Post-CeedOperatorApply stage:
+    //    - Clean up memory
 
-    CeedVector riemannf_ceed;
+    // 1. Get the CeedVector associated with the "riemannf" CeedOperatorField
+    CeedOperatorField riemannf_field;
+    CeedVector        riemannf_ceed;
+    SWESourceOperatorGetRiemannFlux(rdy->ceed_rhs.op_src, &riemannf_field);
     PetscCallCEED(CeedOperatorFieldGetVector(riemannf_field, &riemannf_ceed));
 
     PetscScalar *u, *f, *f_dup;
@@ -230,29 +268,41 @@ static PetscErrorCode RDyCeedOperatorApply(RDy rdy, PetscReal dt, Vec U_local, V
     CeedVector   u_local_ceed = rdy->ceed_rhs.u_local_ceed;
     CeedVector   s_ceed       = rdy->ceed_rhs.s_ceed;
 
+    // 2. Sets the pointer of a CeedVector to a PETSc Vec: u_local_ceed --> U_local
     PetscCall(VecGetArrayAndMemType(U_local, &u, &mem_type));
     PetscCallCEED(CeedVectorSetArray(u_local_ceed, MemTypeP2C(mem_type), CEED_USE_POINTER, u));
 
+    // 3. Make a duplicate copy of the F as the values will be used as input for the CeedOperator
+    //    corresponding to the source-sink term
     Vec F_dup;
     PetscCall(VecDuplicate(F, &F_dup));
     PetscCall(VecCopy(F, F_dup));
+
+    // 4. Sets the pointer of a CeedVector to a PETSc Vec: F_dup --> riemannf_ceed
     PetscCall(VecGetArrayAndMemType(F_dup, &f_dup, &mem_type));
     PetscCallCEED(CeedVectorSetArray(riemannf_ceed, MemTypeP2C(mem_type), CEED_USE_POINTER, f_dup));
 
+    // 5. Sets the pointer of a CeedVector to a PETSc Vec: F --> s_ceed
     PetscCall(VecGetArrayAndMemType(F, &f, &mem_type));
     PetscCallCEED(CeedVectorSetArray(s_ceed, MemTypeP2C(mem_type), CEED_USE_POINTER, f));
 
+    // 6. Apply the source CeedOperator
     PetscCall(PetscLogEventBegin(RDY_CeedOperatorApply, U_local, F, 0, 0));
     PetscCall(PetscLogGpuTimeBegin());
     PetscCallCEED(CeedOperatorApply(rdy->ceed_rhs.op_src, u_local_ceed, s_ceed, CEED_REQUEST_IMMEDIATE));
     PetscCall(PetscLogGpuTimeEnd());
     PetscCall(PetscLogEventEnd(RDY_CeedOperatorApply, U_local, F, 0, 0));
 
-    PetscCallCEED(CeedVectorTakeArray(u_local_ceed, MemTypeP2C(mem_type), &u));
-    PetscCall(VecRestoreArrayAndMemType(U_local, &u));
-    PetscCallCEED(CeedVectorTakeArray(riemannf_ceed, MemTypeP2C(mem_type), &f_dup));
+    // 7. Reset memory pointer of CeedVectors
     PetscCallCEED(CeedVectorTakeArray(s_ceed, MemTypeP2C(mem_type), &f));
+    PetscCallCEED(CeedVectorTakeArray(riemannf_ceed, MemTypeP2C(mem_type), &f_dup));
+    PetscCallCEED(CeedVectorTakeArray(u_local_ceed, MemTypeP2C(mem_type), &u));
+
+    // 8. Restore pointers to the PETSc Vecs
+    PetscCall(VecRestoreArrayAndMemType(U_local, &u));
     PetscCall(VecRestoreArrayAndMemType(F, &f));
+
+    // 9. Clean up memory
     PetscCall(VecDestroy(&F_dup));
   }
 

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -138,8 +138,8 @@ static PetscErrorCode CreateOperators(RDy rdy) {
     int num_comp = 3;
     PetscCallCEED(CeedVectorCreate(rdy->ceed, rdy->mesh.num_cells * num_comp, &rdy->ceed_rhs.u_local_ceed));
     PetscCallCEED(CeedVectorCreate(rdy->ceed, rdy->mesh.num_cells * num_comp, &rdy->ceed_rhs.f_ceed));
-    PetscCallCEED(CeedVectorCreate(rdy->ceed, rdy->mesh.num_cells_local * num_comp, &rdy->ceed_rhs.s_ceed));
-    PetscCallCEED(CeedVectorCreate(rdy->ceed, rdy->mesh.num_cells_local * num_comp, &rdy->ceed_rhs.u_ceed));
+    PetscCallCEED(CeedVectorCreate(rdy->ceed, rdy->mesh.num_owned_cells * num_comp, &rdy->ceed_rhs.s_ceed));
+    PetscCallCEED(CeedVectorCreate(rdy->ceed, rdy->mesh.num_owned_cells * num_comp, &rdy->ceed_rhs.u_ceed));
 
     // reset the time step size
     rdy->ceed_rhs.dt = 0.0;

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -274,12 +274,10 @@ static PetscErrorCode RDyCeedOperatorApply(RDy rdy, PetscReal dt, Vec U_local, V
 
     // 3. Make a duplicate copy of the F as the values will be used as input for the CeedOperator
     //    corresponding to the source-sink term
-    Vec F_dup;
-    PetscCall(VecDuplicate(F, &F_dup));
-    PetscCall(VecCopy(F, F_dup));
+    PetscCall(VecCopy(F, rdy->F_dup));
 
     // 4. Sets the pointer of a CeedVector to a PETSc Vec: F_dup --> riemannf_ceed
-    PetscCall(VecGetArrayAndMemType(F_dup, &f_dup, &mem_type));
+    PetscCall(VecGetArrayAndMemType(rdy->F_dup, &f_dup, &mem_type));
     PetscCallCEED(CeedVectorSetArray(riemannf_ceed, MemTypeP2C(mem_type), CEED_USE_POINTER, f_dup));
 
     // 5. Sets the pointer of a CeedVector to a PETSc Vec: F --> s_ceed
@@ -301,9 +299,6 @@ static PetscErrorCode RDyCeedOperatorApply(RDy rdy, PetscReal dt, Vec U_local, V
     // 8. Restore pointers to the PETSc Vecs
     PetscCall(VecRestoreArrayAndMemType(U_local, &u));
     PetscCall(VecRestoreArrayAndMemType(F, &f));
-
-    // 9. Clean up memory
-    PetscCall(VecDestroy(&F_dup));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -426,7 +426,7 @@ PetscErrorCode CreateSWESourceOperator(Ceed ceed, RDyMesh *mesh, PetscInt num_ce
       CeedInt *offset_c, *offset_q;
       CeedScalar(*g)[num_comp_geom];
       CeedScalar(*n)[num_comp_mannings_n];
-      CeedInt num_owned_cells = mesh->num_cells_local;
+      CeedInt num_owned_cells = mesh->num_owned_cells;
       CeedInt num_cells       = mesh->num_cells;
 
       CeedInt strides_geom[] = {num_comp_geom, 1, num_comp_geom};

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -427,6 +427,7 @@ PetscErrorCode CreateSWESourceOperator(Ceed ceed, RDyMesh *mesh, PetscInt num_ce
       CeedScalar(*g)[num_comp_geom];
       CeedScalar(*n)[num_comp_mannings_n];
       CeedInt num_owned_cells = mesh->num_cells_local;
+      CeedInt num_cells       = mesh->num_cells;
 
       CeedInt strides_geom[] = {num_comp_geom, 1, num_comp_geom};
       PetscCallCEED(
@@ -471,8 +472,8 @@ PetscErrorCode CreateSWESourceOperator(Ceed ceed, RDyMesh *mesh, PetscInt num_ce
       }
       PetscCallCEED(CeedVectorRestoreArray(geom, (CeedScalar **)&g));
       PetscCallCEED(CeedVectorRestoreArray(mannings_n, (CeedScalar **)&n));
-      PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_cells, 1, num_comp, 1, num_owned_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES,
-                                              offset_q, &restrict_q));
+      PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_cells, 1, num_comp, 1, num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, offset_q,
+                                              &restrict_q));
       PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_cells, 1, num_comp, 1, num_owned_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES,
                                               offset_c, &restrict_c));
       PetscCall(PetscFree(offset_c));

--- a/src/tests/test_rdymesh.c
+++ b/src/tests/test_rdymesh.c
@@ -93,7 +93,7 @@ static void TestRDyMeshCreateFromDM(void **state) {
   assert_int_equal(0, RDyMeshCreateFromDM(dm, &mesh));
   // I expected the following statement to be true, but it's not (for nproc > 1)
   //  assert_int_equal(Nx * Ny, mesh.num_cells);
-  assert_true(mesh.num_cells_local <= Nx * Ny);  // (== iff nproc == 1)
+  assert_true(mesh.num_owned_cells <= Nx * Ny);  // (== iff nproc == 1)
 
   // Clean up.
   assert_int_equal(0, DMDestroy(&dm));


### PR DESCRIPTION
1. Previously, a copy of the `U` Vector was made that was sent by PETSc's TS to the RHSFunction. This copy of the `U` Vec (`rdy->Soln`) was then sent to the source-sink CeedOperator. However, we must do a `GlobalToLocal` of `U` to get `U_local`. The `U_local` Vec is needed for the CeedOperator associated with internal and boundary edges. The copy of `U` to `rdy->Soln` is now avoided by sending `U_local` (instead of `rdy->Soln`) to the source-sink CeedOperator  (476c7ac916486e3aec0998b16edff34224733c8f).
2. The unused `rdy->Soln` is now deleted.
3. Detailed comments describing how CeedOperators are applied are added.
4. Renames `num_cells_local` to `num_onwned_cells`.
5. The Vec `F_dup` is now allocated during model initialization.