### PR TITLE
Removed `bed_friction` parameter from YAML spec.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build-*/
 *.code-workspace
 compile_commands.json
 .cache/
+site/
 *.cgns

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -431,7 +431,6 @@ time series data (and excluding checkpoint data). Relevant parameters are
 physics:
   flow:
     mode: swe
-    bed_friction: false
     tiny: 1e-7
   sediment: false
   salinity: false
@@ -448,8 +447,6 @@ parameters in this subsection are:
    parameters are `swe` ([shallow water equations](https://en.wikipedia.org/wiki/Shallow_water_equations))
    and `diffusive` ([diffusive wave approximation](https://en.wikipedia.org/wiki/Shallow_water_equations#Diffusive_wave),
    not yet supported). This parameter is required and has no default value.
-* `bed_friction`, which can be set to `true` or `false` to enable/disable
-  riverbed friction. Default value: `false`
 * `tiny_h`, which is the water height below which a given point is assumed to
   be dry. Default value: `1e-7`
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -52,9 +52,8 @@ typedef enum {
 
 // physics flow parameters
 typedef struct {
-  RDyPhysicsFlowMode mode;          // flow mode
-  PetscBool          bed_friction;  // bed friction enabled?
-  PetscReal          tiny_h;        // depth below which no flow occurs
+  RDyPhysicsFlowMode mode;    // flow mode
+  PetscReal          tiny_h;  // depth below which no flow occurs
 } RDyPhysicsFlow;
 
 // all physics parameters

--- a/src/tests/test_yaml_input.c
+++ b/src/tests/test_yaml_input.c
@@ -63,7 +63,6 @@ static void TestFullSpec(void **state) {
       "physics:\n"
       "  flow:\n"
       "    mode: swe\n"
-      "    bed_friction: true\n"
       "  sediment: true\n"
       "  salinity: false\n\n"
       "numerics:\n"

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -46,7 +46,6 @@
 // physics:
 //   flow:
 //     mode: <swe|diffusion> # swe by default
-//     bed_friction: <true|false> # off by default
 //     tiny_h: <value> # 1e-7 by default
 //   sediment: <true|false> # off by default
 //   salinity: <true|false> # off by default
@@ -60,7 +59,6 @@ static const cyaml_strval_t physics_flow_modes[] = {
 // mapping of physics.flow fields to members of RDyPhysicsFlow
 static const cyaml_schema_field_t physics_flow_fields_schema[] = {
     CYAML_FIELD_ENUM("mode", CYAML_FLAG_DEFAULT, RDyPhysicsFlow, mode, physics_flow_modes, CYAML_ARRAY_LEN(physics_flow_modes)),
-    CYAML_FIELD(BOOL, "bed_friction", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, bed_friction, {.missing = false}),
     CYAML_FIELD(FLOAT, "tiny_h", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, tiny_h, {.missing = 1e-7}),
     CYAML_FIELD_END
 };
@@ -1257,7 +1255,6 @@ static PetscErrorCode PrintPhysics(RDy rdy) {
   PetscFunctionBegin;
   RDyLogDetail(rdy, "Physics:");
   RDyLogDetail(rdy, "  Flow:");
-  RDyLogDetail(rdy, "    Bed friction: %s", FlagString(rdy->config.physics.flow.bed_friction));
   RDyLogDetail(rdy, "  Sediment model: %s", FlagString(rdy->config.physics.sediment));
   RDyLogDetail(rdy, "  Salinity model: %s", FlagString(rdy->config.physics.salinity));
   PetscFunctionReturn(PETSC_SUCCESS);


### PR DESCRIPTION
This parameter wasn't actually being used, and we always want bed friction in any case.

Closes #191