### PR TITLE
Adds adaptive time stepping based on CFL condition

### DIFF
--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -638,3 +638,26 @@ the following parameters:
 
 Exactly two of `final_time`, `max_step`, and `time_step` must be specified.
 The missing parameter is then computed from those parameters given.
+
+Additionally, RDycore can increase or decrease time step to meet a target Courant
+number via `adaptivity` sub-block within the `time` block as shown below.
+
+```yaml
+time:
+  final_time        : 0.005
+  coupling_interval : 0.001
+  unit              : hours
+  adaptivity:
+    enable                 : true     # false or true. The values below are only used if is enable=true
+    target_courant_number  : 0.6      # a target courant number
+    max_increase_factor    : 2        # At max, the dt can be doubled to meet the target Courant number
+    initial_time_step      : 0.00001  # initial timestep
+```
+
+The time step is increased/decreased used by `TS` at the coupling internal. The global
+Courant number during the last step of a `TSSolve` is used to either increase or
+decrease the time step for the next `TSSolve` to match the target Courant number
+(`target_cournant_number`). When time step adaptivity is enabled (via `enable: true`),
+the `max_step` and `time_step` entried within the `time` block cannot be specified.
+Instead, one need to specify an initial time step (`initial_time_step`) in the `adaptivity`
+sub-block.

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -640,14 +640,14 @@ Exactly two of `final_time`, `max_step`, and `time_step` must be specified.
 The missing parameter is then computed from those parameters given.
 
 Additionally, RDycore can increase or decrease time step to meet a target Courant
-number via `adaptivity` sub-block within the `time` block as shown below.
+number via `adaptive` sub-block within the `time` block as shown below.
 
 ```yaml
 time:
   final_time        : 0.005
   coupling_interval : 0.001
   unit              : hours
-  adaptivity:
+  adaptive:
     enable                 : true     # false or true. The values below are only used if is enable=true
     target_courant_number  : 0.6      # a target courant number
     max_increase_factor    : 2        # At max, the dt can be doubled to meet the target Courant number
@@ -657,7 +657,7 @@ time:
 The time step is increased/decreased used by `TS` at the coupling internal. The global
 Courant number during the last step of a `TSSolve` is used to either increase or
 decrease the time step for the next `TSSolve` to match the target Courant number
-(`target_cournant_number`). When time step adaptivity is enabled (via `enable: true`),
+(`target_cournant_number`). When time step adaptive is enabled (via `enable: true`),
 the `max_step` and `time_step` entried within the `time` block cannot be specified.
-Instead, one need to specify an initial time step (`initial_time_step`) in the `adaptivity`
+Instead, one need to specify an initial time step (`initial_time_step`) in the `adaptive`
 sub-block.

--- a/driver/tests/swe_roe/CMakeLists.txt
+++ b/driver/tests/swe_roe/CMakeLists.txt
@@ -90,7 +90,7 @@ foreach(np 1 2) # test on 1, 2 processes
   endforeach()
 endforeach()
 
-# ex2b with ICs specified by a file
+# ex2b with ICs specified by a file and adaptive time step
 file(COPY
      ${CMAKE_CURRENT_SOURCE_DIR}/ex2b_ic_file_with_adapt.yaml
      ${MESH_DIR}/DamBreak_grid5x10.exo

--- a/driver/tests/swe_roe/CMakeLists.txt
+++ b/driver/tests/swe_roe/CMakeLists.txt
@@ -90,6 +90,21 @@ foreach(np 1 2) # test on 1, 2 processes
   endforeach()
 endforeach()
 
+# ex2b with ICs specified by a file
+file(COPY
+     ${CMAKE_CURRENT_SOURCE_DIR}/ex2b_ic_file_with_adapt.yaml
+     ${MESH_DIR}/DamBreak_grid5x10.exo
+     ${CONDITION_DIR}/DamBreak_grid5x10_wetdownstream.ic.${PETSC_ID_TYPE}.bin
+     ${MATERIALS_DIR}/manning_grid5x10.${PETSC_ID_TYPE}.bin
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+foreach(np 1 2) # test on 1, 2 processes
+  foreach(config basic ceed preload)
+    foreach(lang c f90)
+      add_test(swe_roe_ex2b_ic_file_with_adapt_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} ex2b_ic_file_with_adapt.yaml ${${config}_args})
+    endforeach()
+  endforeach()
+endforeach()
+
 # ex2b ensemble test -- (file copy only for now)
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ex2b-ensemble.yaml
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
@@ -17,7 +17,7 @@ time:
   final_time        : 0.005
   coupling_interval : 0.001
   unit              : hours
-  adaptivity:
+  adaptive:
     enable                 : true     # false or true. The values below are only used if is enable=true
     target_courant_number  : 0.6      # CFL
     max_increase_factor    : 2        # At max, the dt can be doubled while still allowing CFL be less than 0.8

--- a/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
@@ -1,0 +1,60 @@
+# This test input corresponds to toy-problems/swe_roe/ex2b.c, but uses a file
+# to specify the initial conditions (and a corresponding Exodus mesh).
+
+physics:
+  flow:
+    mode: swe
+
+numerics:
+  spatial: fv
+  temporal: euler
+  riemann: roe
+
+logging:
+  level: debug
+
+time:
+  final_time        : 0.005
+  coupling_interval : 0.001
+  unit              : hours
+  max_step          : 240
+  adaptivity:
+    enable              : true  # false or true. The values below are only used if is enable=true
+    max_courant_number  : 0.6   #
+    max_increase_factor : 2     # At max, the dt can be doubled while still allowing CFL be less than 0.8
+
+output:
+  format: xdmf
+  interval: 100
+
+grid:
+  file: DamBreak_grid5x10.exo
+
+# one region represents the whole domain
+regions:
+  - name: domain
+    grid_region_id: 1
+
+surface_composition:
+  - region: domain
+    material: smooth
+
+materials:
+  - name: smooth
+    properties:
+      manning:
+        file: manning_grid5x10.${PETSC_ID_TYPE}.bin
+        format: binary
+
+initial_conditions:
+  - region: domain
+    flow: domain_flow_ic
+
+flow_conditions:
+  - name: domain_flow_ic
+    type: dirichlet
+    file: DamBreak_grid5x10_wetdownstream.ic.${PETSC_ID_TYPE}.bin
+    format: binary
+
+# we don't specify boundaries or boundary conditions, so all boundaries are
+# reflecting

--- a/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
@@ -17,11 +17,11 @@ time:
   final_time        : 0.005
   coupling_interval : 0.001
   unit              : hours
-  max_step          : 240
   adaptivity:
-    enable              : true  # false or true. The values below are only used if is enable=true
-    target_courant_number  : 0.6   #
-    max_increase_factor : 2     # At max, the dt can be doubled while still allowing CFL be less than 0.8
+    enable                 : true     # false or true. The values below are only used if is enable=true
+    target_courant_number  : 0.6      # CFL
+    max_increase_factor    : 2        # At max, the dt can be doubled while still allowing CFL be less than 0.8
+    initial_time_step      : 0.00001  # initial timestep
 
 output:
   format: xdmf

--- a/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file_with_adapt.yaml
@@ -20,7 +20,7 @@ time:
   max_step          : 240
   adaptivity:
     enable              : true  # false or true. The values below are only used if is enable=true
-    max_courant_number  : 0.6   #
+    target_courant_number  : 0.6   #
     max_increase_factor : 2     # At max, the dt can be doubled while still allowing CFL be less than 0.8
 
 output:

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -97,20 +97,20 @@ typedef struct {
 // time section
 // ------------
 
-typedef struct{
-  PetscBool enable;              // true = use timestep adaptivity
-  PetscReal max_courant_number;  // max courant number to target for adaptivity
-  PetscReal max_increase_factor; // max allowable increase in timestep
+typedef struct {
+  PetscBool enable;               // true = use timestep adaptivity
+  PetscReal max_courant_number;   // max courant number to target for adaptivity
+  PetscReal max_increase_factor;  // max allowable increase in timestep
 } RDyTimeAdaptivitySection;
 
 // all time parameters
 typedef struct {
-  PetscReal   final_time;              // final simulation time [unit]
-  RDyTimeUnit unit;                    // unit in which time is expressed
-  PetscInt    max_step;                // maximum number of simulation time steps
-  PetscReal   time_step;               // minimum internal time step [unit]
-  PetscReal   coupling_interval;       // time interval spanned by RDyAdvance [unit]
-  RDyTimeAdaptivitySection adaptivity; // timestep adaptivity for explicity time integration
+  PetscReal                final_time;         // final simulation time [unit]
+  RDyTimeUnit              unit;               // unit in which time is expressed
+  PetscInt                 max_step;           // maximum number of simulation time steps
+  PetscReal                time_step;          // minimum internal time step [unit]
+  PetscReal                coupling_interval;  // time interval spanned by RDyAdvance [unit]
+  RDyTimeAdaptivitySection adaptivity;         // timestep adaptivity for explicity time integration
 } RDyTimeSection;
 
 // ---------------

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -98,20 +98,20 @@ typedef struct {
 // ------------
 
 typedef struct {
-  PetscBool enable;                 // true = use timestep adaptivity
+  PetscBool enable;                 // true = use adaptive time step
   PetscReal target_courant_number;  // target courant number
   PetscReal max_increase_factor;    // max allowable increase in timestep
-  PetscReal initial_time_step;      // initial timestep for adaptivity
-} RDyTimeAdaptivitySection;
+  PetscReal initial_time_step;      // initial timestep
+} RDyTimeAdaptiveSection;
 
 // all time parameters
 typedef struct {
-  PetscReal                final_time;         // final simulation time [unit]
-  RDyTimeUnit              unit;               // unit in which time is expressed
-  PetscInt                 max_step;           // maximum number of simulation time steps
-  PetscReal                time_step;          // minimum internal time step [unit]
-  PetscReal                coupling_interval;  // time interval spanned by RDyAdvance [unit]
-  RDyTimeAdaptivitySection adaptivity;         // timestep adaptivity for explicity time integration
+  PetscReal              final_time;         // final simulation time [unit]
+  RDyTimeUnit            unit;               // unit in which time is expressed
+  PetscInt               max_step;           // maximum number of simulation time steps
+  PetscReal              time_step;          // minimum internal time step [unit]
+  PetscReal              coupling_interval;  // time interval spanned by RDyAdvance [unit]
+  RDyTimeAdaptiveSection adaptive;           // adaptive time step for explicity time integration
 } RDyTimeSection;
 
 // ---------------

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -97,13 +97,20 @@ typedef struct {
 // time section
 // ------------
 
+typedef struct{
+  PetscBool enable;              // true = use timestep adaptivity
+  PetscReal max_courant_number;  // max courant number to target for adaptivity
+  PetscReal max_increase_factor; // max allowable increase in timestep
+} RDyTimeAdaptivitySection;
+
 // all time parameters
 typedef struct {
-  PetscReal   final_time;         // final simulation time [unit]
-  RDyTimeUnit unit;               // unit in which time is expressed
-  PetscInt    max_step;           // maximum number of simulation time steps
-  PetscReal   time_step;          // minimum internal time step [unit]
-  PetscReal   coupling_interval;  // time interval spanned by RDyAdvance [unit]
+  PetscReal   final_time;              // final simulation time [unit]
+  RDyTimeUnit unit;                    // unit in which time is expressed
+  PetscInt    max_step;                // maximum number of simulation time steps
+  PetscReal   time_step;               // minimum internal time step [unit]
+  PetscReal   coupling_interval;       // time interval spanned by RDyAdvance [unit]
+  RDyTimeAdaptivitySection adaptivity; // timestep adaptivity for explicity time integration
 } RDyTimeSection;
 
 // ---------------

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -98,9 +98,9 @@ typedef struct {
 // ------------
 
 typedef struct {
-  PetscBool enable;               // true = use timestep adaptivity
-  PetscReal max_courant_number;   // max courant number to target for adaptivity
-  PetscReal max_increase_factor;  // max allowable increase in timestep
+  PetscBool enable;                 // true = use timestep adaptivity
+  PetscReal target_courant_number;  // target courant number
+  PetscReal max_increase_factor;    // max allowable increase in timestep
 } RDyTimeAdaptivitySection;
 
 // all time parameters

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -101,6 +101,7 @@ typedef struct {
   PetscBool enable;                 // true = use timestep adaptivity
   PetscReal target_courant_number;  // target courant number
   PetscReal max_increase_factor;    // max allowable increase in timestep
+  PetscReal initial_time_step;      // initial timestep for adaptivity
 } RDyTimeAdaptivitySection;
 
 // all time parameters

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -80,7 +80,7 @@ typedef struct {
       PetscReal water_mass;
       PetscReal x_momentum;
       PetscReal y_momentum;
-    } *fluxes;
+    } * fluxes;
   } boundary_fluxes;
 } RDyTimeSeriesData;
 

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -80,7 +80,7 @@ typedef struct {
       PetscReal water_mass;
       PetscReal x_momentum;
       PetscReal y_momentum;
-    } * fluxes;
+    } *fluxes;
   } boundary_fluxes;
 } RDyTimeSeriesData;
 

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -8,6 +8,15 @@
 #include <private/rdymeshimpl.h>
 #include <rdycore.h>
 
+// Diagnostic structure that captures information about the conditions under
+// which the maximum courant number is encountered. If you change this struct,
+// update the call to MPI_Type_create_struct in InitMPITypesAndOps below.
+typedef struct {
+  PetscReal max_courant_num;  // maximum courant number
+  PetscInt  global_edge_id;   // edge at which the max courant number was encountered
+  PetscInt  global_cell_id;   // cell in which the max courant number was encountered
+} CourantNumberDiagnostics;
+
 // This type defines a material with specific properties.
 // (undefined properties are set to INVALID_INT/INVALID_REAL)
 typedef struct {
@@ -172,6 +181,8 @@ struct _p_RDy {
 
   // time series bookkeeping
   RDyTimeSeriesData time_series;
+
+  CourantNumberDiagnostics courant_num_diags;
 
   //-------------------
   // Simulatіon output

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -15,6 +15,7 @@ typedef struct {
   PetscReal max_courant_num;  // maximum courant number
   PetscInt  global_edge_id;   // edge at which the max courant number was encountered
   PetscInt  global_cell_id;   // cell in which the max courant number was encountered
+  PetscBool is_set;           // true if max_courant_num is set, otherwise false
 } CourantNumberDiagnostics;
 
 // This type defines a material with specific properties.

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -41,4 +41,5 @@ PETSC_INTERN PetscErrorCode CreatePetscSWESource(RDyMesh *, void *);
 PETSC_INTERN PetscErrorCode InitPetscSWEBoundaryFlux(void *, RDyCells *, RDyEdges *, PetscInt n, RDyBoundary[n], RDyCondition[n], PetscReal);
 PETSC_INTERN PetscErrorCode GetPetscSWEDirichletBoundaryValues(void *, PetscInt, RiemannDataSWE *);
 
+PETSC_INTERN PetscErrorCode SWEFindMaxCourantNumber(RDy);
 #endif

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -18,15 +18,6 @@ typedef struct {
   RiemannDataSWE  data_cells;
 } PetscRiemannDataSWE;
 
-// Diagnostic structure that captures information about the conditions under
-// which the maximum courant number is encountered. If you change this struct,
-// update the call to MPI_Type_create_struct in InitMPITypesAndOps below.
-typedef struct {
-  PetscReal max_courant_num;  // maximum courant number
-  PetscInt  global_edge_id;   // edge at which the max courant number was encountered
-  PetscInt  global_cell_id;   // cell in which the max courant number was encountered
-} CourantNumberDiagnostics;
-
 PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, CeedInt n, RDyBoundary[n], RDyCondition[n], PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetBoundaryFlux(CeedOperator, RDyBoundary, CeedOperatorField *);

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -258,9 +258,9 @@ PetscErrorCode RDyAdvance(RDy rdy) {
       // get current timestep
       PetscReal dt = rdy->dt;
 
-      if (cnum_diags->max_courant_num < time_adap->max_courant_number) {
+      if (cnum_diags->max_courant_num < time_adap->target_courant_number) {
         // timestep can be increased, so find the factor by which timestep can be increased
-        PetscReal factor = PetscMin(time_adap->max_courant_number / cnum_diags->max_courant_num, time_adap->max_increase_factor);
+        PetscReal factor = PetscMin(time_adap->target_courant_number / cnum_diags->max_courant_num, time_adap->max_increase_factor);
 
         // increase the timestep
         dt *= factor;
@@ -278,7 +278,7 @@ PetscErrorCode RDyAdvance(RDy rdy) {
 
       } else {
         // decrease the timestep
-        PetscReal factor = time_adap->max_courant_number / cnum_diags->max_courant_num;
+        PetscReal factor = time_adap->target_courant_number / cnum_diags->max_courant_num;
 
         // decrease the timestep
         dt *= factor;

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -249,8 +249,8 @@ PetscErrorCode RDyAdvance(RDy rdy) {
   RDyLogDetail(rdy, "Advancing from t = %g to %g...", ConvertTimeFromSeconds(time, rdy->config.time.unit),
                ConvertTimeFromSeconds(next_coupling_time, rdy->config.time.unit));
 
-  // if time adaptivity is enabled, try to increase the dt
-  RDyTimeAdaptivitySection *time_adap = &rdy->config.time.adaptivity;
+  // if adaptive time is enabled, try to increase the dt
+  RDyTimeAdaptiveSection *time_adap = &rdy->config.time.adaptive;
   if (time_adap->enable) {
     CourantNumberDiagnostics *cnum_diags = &rdy->courant_num_diags;
 

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -288,7 +288,6 @@ PetscErrorCode RDyAdvance(RDy rdy) {
 
       // update the timestep
       rdy->dt = dt;
-
     }
   }
 

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -269,9 +269,11 @@ PetscErrorCode RDyAdvance(RDy rdy) {
         if (dt > interval) dt = interval;
 
         if (rdy->config.logging.level >= LOG_DEBUG) {
-          RDyLogDebug(rdy, "Increasing dt from %f to %f", rdy->dt, dt);
+          const char *units  = TimeUnitAsString(rdy->config.time.unit);
+          PetscReal   dt_old = ConvertTimeFromSeconds(rdy->dt, rdy->config.time.unit);
+          PetscReal   dt_new = ConvertTimeFromSeconds(dt, rdy->config.time.unit);
+          RDyLogDebug(rdy, "Increasing dt from %f [%s] to %f [%s]", dt_old, units, dt_new, units);
         }
-        printf("Increasing dt from %f to %f", rdy->dt, dt);
 
         // update the timestep
         rdy->dt = dt;
@@ -284,9 +286,11 @@ PetscErrorCode RDyAdvance(RDy rdy) {
         dt *= factor;
 
         if (rdy->config.logging.level >= LOG_DEBUG) {
-          RDyLogDebug(rdy, "Decreasing dt from %f to %f", rdy->dt, dt);
+          const char *units  = TimeUnitAsString(rdy->config.time.unit);
+          PetscReal   dt_old = ConvertTimeFromSeconds(rdy->dt, rdy->config.time.unit);
+          PetscReal   dt_new = ConvertTimeFromSeconds(dt, rdy->config.time.unit);
+          RDyLogDebug(rdy, "Decreasing dt from %f [%s] to %f [%s]", dt_old, units, dt_new, units);
         }
-        printf("Decreasing dt from %f to %f", rdy->dt, dt);
 
         // update the timestep
         rdy->dt = dt;

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -64,9 +64,9 @@ static PetscErrorCode CreateSectionForSWE(RDy rdy, PetscSection *sec) {
   PetscInt n_field                             = 1;
   PetscInt n_field_comps[1]                    = {3};
   char     comp_names[3][MAX_COMP_NAME_LENGTH] = {
-          "Height",
-          "MomentumX",
-          "MomentumY",
+      "Height",
+      "MomentumX",
+      "MomentumY",
   };
 
   PetscFunctionBeginUser;

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -64,9 +64,9 @@ static PetscErrorCode CreateSectionForSWE(RDy rdy, PetscSection *sec) {
   PetscInt n_field                             = 1;
   PetscInt n_field_comps[1]                    = {3};
   char     comp_names[3][MAX_COMP_NAME_LENGTH] = {
-      "Height",
-      "MomentumX",
-      "MomentumY",
+          "Height",
+          "MomentumX",
+          "MomentumY",
   };
 
   PetscFunctionBeginUser;

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -963,6 +963,12 @@ PetscErrorCode RDySetup(RDy rdy) {
   RDyLogDebug(rdy, "Initializing checkpoints...");
   PetscCall(InitCheckpoints(rdy));
 
+  RDyLogDebug(rdy, "Initializing courant number diagnostics...");
+  CourantNumberDiagnostics *courant_num_diags = &rdy->courant_num_diags;
+  courant_num_diags->max_courant_num = 0.0;
+  courant_num_diags->global_edge_id = -1;
+  courant_num_diags->global_cell_id = -1;
+
   // if a restart has been requested, read the specified checkpoint file
   // and overwrite the necessary data
   if (rdy->config.restart.file[0]) {

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -965,9 +965,9 @@ PetscErrorCode RDySetup(RDy rdy) {
 
   RDyLogDebug(rdy, "Initializing courant number diagnostics...");
   CourantNumberDiagnostics *courant_num_diags = &rdy->courant_num_diags;
-  courant_num_diags->max_courant_num = 0.0;
-  courant_num_diags->global_edge_id = -1;
-  courant_num_diags->global_cell_id = -1;
+  courant_num_diags->max_courant_num          = 0.0;
+  courant_num_diags->global_edge_id           = -1;
+  courant_num_diags->global_cell_id           = -1;
 
   // if a restart has been requested, read the specified checkpoint file
   // and overwrite the necessary data

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -968,6 +968,7 @@ PetscErrorCode RDySetup(RDy rdy) {
   courant_num_diags->max_courant_num          = 0.0;
   courant_num_diags->global_edge_id           = -1;
   courant_num_diags->global_cell_id           = -1;
+  courant_num_diags->is_set                   = PETSC_FALSE;
 
   // if a restart has been requested, read the specified checkpoint file
   // and overwrite the necessary data

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -59,7 +59,7 @@ static PetscErrorCode InitMPITypesAndOps(void) {
         offsetof(CourantNumberDiagnostics, global_cell_id),
         offsetof(CourantNumberDiagnostics, is_set),
     };
-    MPI_Datatype block_types[4] = {MPI_DOUBLE, MPI_INT, MPI_INT, MPIU_BOOL};
+    MPI_Datatype block_types[4] = {MPIU_REAL, MPI_INT, MPI_INT, MPIU_BOOL};
     MPI_Type_create_struct(num_blocks, block_lengths, block_displacements, block_types, &courant_num_diags_type);
     MPI_Type_commit(&courant_num_diags_type);
 

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -108,7 +108,7 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   PetscCheck(rdy->config.physics.flow.mode == FLOW_SWE, rdy->comm, PETSC_ERR_USER, "Only the 'swe' flow mode is currently supported.");
   PetscCall(TSSetRHSFunction(rdy->ts, rdy->R, RHSFunctionSWE, rdy));
 
-  PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.time.max_step));
+  //PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.time.max_step));
   PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
   PetscCall(TSSetSolution(rdy->ts, rdy->X));
   PetscCall(TSSetTime(rdy->ts, 0.0));

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -376,8 +376,9 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
     PetscInt  stepnum;
     PetscCall(TSGetTime(ts, &time));
     PetscCall(TSGetStepNumber(ts, &stepnum));
-    RDyLogDebug(rdy, "[%" PetscInt_FMT "] Time = %f Max courant number %g encountered at edge %" PetscInt_FMT " of cell %" PetscInt_FMT " is %f",
-                stepnum, time, courant_num_diags->max_courant_num, courant_num_diags->global_edge_id, courant_num_diags->global_cell_id,
+    const char *units = TimeUnitAsString(rdy->config.time.unit);
+    RDyLogDebug(rdy, "[%" PetscInt_FMT "] Time = %f [%s] Max courant number %g encountered at edge %" PetscInt_FMT " of cell %" PetscInt_FMT " is %f",
+                stepnum, ConvertTimeFromSeconds(time, rdy->config.time.unit), units, courant_num_diags->max_courant_num, courant_num_diags->global_edge_id, courant_num_diags->global_cell_id,
                 courant_num_diags->max_courant_num);
   }
 

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -329,6 +329,7 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
 
   // get courant number diagnostics
   CourantNumberDiagnostics *courant_num_diags = &rdy->courant_num_diags;
+  courant_num_diags->max_courant_num = 0.0;
 
   // compute the right hand side
   if (rdy->ceed_resource[0]) {
@@ -364,9 +365,13 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
     }
   }
 
+  // find maximum courant number
+  if (rdy->config.logging.level >= LOG_DEBUG || rdy->config.time.adaptivity.enable) {
+    MPI_Allreduce(MPI_IN_PLACE, courant_num_diags, 1, courant_num_diags_type, courant_num_diags_op, rdy->comm);
+  }
+
   // write out debugging info for maximum courant number
   if (rdy->config.logging.level >= LOG_DEBUG) {
-    MPI_Allreduce(MPI_IN_PLACE, courant_num_diags, 1, courant_num_diags_type, courant_num_diags_op, rdy->comm);
     PetscReal time;
     PetscInt  stepnum;
     PetscCall(TSGetTime(ts, &time));

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -108,7 +108,9 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   PetscCheck(rdy->config.physics.flow.mode == FLOW_SWE, rdy->comm, PETSC_ERR_USER, "Only the 'swe' flow mode is currently supported.");
   PetscCall(TSSetRHSFunction(rdy->ts, rdy->R, RHSFunctionSWE, rdy));
 
-  // PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.time.max_step));
+  if (!rdy->config.time.adaptivity.enable) {
+    PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.time.max_step));
+  }
   PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
   PetscCall(TSSetSolution(rdy->ts, rdy->X));
   PetscCall(TSSetTime(rdy->ts, 0.0));

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -59,7 +59,7 @@ static PetscErrorCode InitMPITypesAndOps(void) {
         offsetof(CourantNumberDiagnostics, global_cell_id),
         offsetof(CourantNumberDiagnostics, is_set),
     };
-    MPI_Datatype block_types[4] = {MPI_DOUBLE, MPI_INT, MPI_INT, MPI_C_BOOL};
+    MPI_Datatype block_types[4] = {MPI_DOUBLE, MPI_INT, MPI_INT, MPIU_BOOL};
     MPI_Type_create_struct(num_blocks, block_lengths, block_displacements, block_types, &courant_num_diags_type);
     MPI_Type_commit(&courant_num_diags_type);
 
@@ -490,7 +490,8 @@ PetscErrorCode RHSFunctionSWE(TS ts, PetscReal t, Vec X, Vec F, void *ctx) {
     }
   }
 
-  // find the maximum courant number and write out the debugging info
+  // if debug-level logging is enabled, find the latest global maximum Courant number
+  // and log it.
   if (rdy->config.logging.level >= LOG_DEBUG) {
     PetscCall(SWEFindMaxCourantNumber(rdy));
 

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -109,7 +109,7 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   PetscCheck(rdy->config.physics.flow.mode == FLOW_SWE, rdy->comm, PETSC_ERR_USER, "Only the 'swe' flow mode is currently supported.");
   PetscCall(TSSetRHSFunction(rdy->ts, rdy->R, RHSFunctionSWE, rdy));
 
-  if (!rdy->config.time.adaptivity.enable) {
+  if (!rdy->config.time.adaptive.enable) {
     PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.time.max_step));
   }
   PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -799,7 +799,8 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
   if (config->time.adaptivity.enable) {
     PetscCheck(config->time.adaptivity.max_courant_number > 0.0, comm, PETSC_ERR_USER, "time.adaptivity.max_courant_number must be greater than 0.0");
     PetscCheck(config->time.adaptivity.max_courant_number < 1.0, comm, PETSC_ERR_USER, "time.adaptivity.max_courant_number must be less than 1.0");
-    PetscCheck(config->time.adaptivity.max_increase_factor > 1.0, comm, PETSC_ERR_USER, "time.adaptivity.max_increase_factor must be greater than 1.0");
+    PetscCheck(config->time.adaptivity.max_increase_factor > 1.0, comm, PETSC_ERR_USER,
+               "time.adaptivity.max_increase_factor must be greater than 1.0");
   }
 
   // we need initial conditions and material properties specified for each

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -773,10 +773,8 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
   if (config->time.adaptive.enable) {
     PetscCheck(config->time.adaptive.target_courant_number > 0.0, comm, PETSC_ERR_USER,
                "time.adaptive.target_courant_number must be greater than 0.0");
-    PetscCheck(config->time.adaptive.target_courant_number < 1.0, comm, PETSC_ERR_USER,
-               "time.adaptive.target_courant_number must be less than 1.0");
-    PetscCheck(config->time.adaptive.max_increase_factor > 1.0, comm, PETSC_ERR_USER,
-               "time.adaptive.max_increase_factor must be greater than 1.0");
+    PetscCheck(config->time.adaptive.target_courant_number < 1.0, comm, PETSC_ERR_USER, "time.adaptive.target_courant_number must be less than 1.0");
+    PetscCheck(config->time.adaptive.max_increase_factor > 1.0, comm, PETSC_ERR_USER, "time.adaptive.max_increase_factor must be greater than 1.0");
     PetscCheck(config->time.adaptive.initial_time_step > 0.0, comm, PETSC_ERR_USER, "time.adaptive.initial_time_step must be greater than 0.0");
 
     // ensure that max_step and time_step is not specified

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -124,11 +124,11 @@ static const cyaml_strval_t enable_units[] = {
     {"false", PETSC_FALSE},
 };
 
-static const cyaml_schema_field_t adaptivity_fields_schema[] = {
-    CYAML_FIELD_ENUM("enable", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, enable, enable_units, CYAML_ARRAY_LEN(enable_units)),
-    CYAML_FIELD_FLOAT("target_courant_number", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, target_courant_number),
-    CYAML_FIELD_FLOAT("max_increase_factor", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, max_increase_factor),
-    CYAML_FIELD_FLOAT("initial_time_step", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, initial_time_step),
+static const cyaml_schema_field_t adaptive_fields_schema[] = {
+    CYAML_FIELD_ENUM("enable", CYAML_FLAG_DEFAULT, RDyTimeAdaptiveSection, enable, enable_units, CYAML_ARRAY_LEN(enable_units)),
+    CYAML_FIELD_FLOAT("target_courant_number", CYAML_FLAG_DEFAULT, RDyTimeAdaptiveSection, target_courant_number),
+    CYAML_FIELD_FLOAT("max_increase_factor", CYAML_FLAG_DEFAULT, RDyTimeAdaptiveSection, max_increase_factor),
+    CYAML_FIELD_FLOAT("initial_time_step", CYAML_FLAG_DEFAULT, RDyTimeAdaptiveSection, initial_time_step),
     CYAML_FIELD_END
 };
 
@@ -140,7 +140,7 @@ static const cyaml_schema_field_t time_fields_schema[] = {
     CYAML_FIELD_INT("max_step", CYAML_FLAG_OPTIONAL, RDyTimeSection, max_step),
     CYAML_FIELD_FLOAT("time_step", CYAML_FLAG_OPTIONAL, RDyTimeSection, time_step),
     CYAML_FIELD_FLOAT( "coupling_interval", CYAML_FLAG_OPTIONAL, RDyTimeSection, coupling_interval),
-    CYAML_FIELD_MAPPING("adaptivity", CYAML_FLAG_OPTIONAL, RDyTimeSection, adaptivity, adaptivity_fields_schema),
+    CYAML_FIELD_MAPPING("adaptive", CYAML_FLAG_OPTIONAL, RDyTimeSection, adaptive, adaptive_fields_schema),
     CYAML_FIELD_END
 };
 
@@ -769,22 +769,22 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
 
   PetscCheck(strlen(config->grid.file), comm, PETSC_ERR_USER, "grid.file not specified!");
 
-  // check timestep adaptivity setting
-  if (config->time.adaptivity.enable) {
-    PetscCheck(config->time.adaptivity.target_courant_number > 0.0, comm, PETSC_ERR_USER,
-               "time.adaptivity.target_courant_number must be greater than 0.0");
-    PetscCheck(config->time.adaptivity.target_courant_number < 1.0, comm, PETSC_ERR_USER,
-               "time.adaptivity.target_courant_number must be less than 1.0");
-    PetscCheck(config->time.adaptivity.max_increase_factor > 1.0, comm, PETSC_ERR_USER,
-               "time.adaptivity.max_increase_factor must be greater than 1.0");
-    PetscCheck(config->time.adaptivity.initial_time_step > 0.0, comm, PETSC_ERR_USER, "time.adaptivity.initial_time_step must be greater than 0.0");
+  // check adaptive time step setting
+  if (config->time.adaptive.enable) {
+    PetscCheck(config->time.adaptive.target_courant_number > 0.0, comm, PETSC_ERR_USER,
+               "time.adaptive.target_courant_number must be greater than 0.0");
+    PetscCheck(config->time.adaptive.target_courant_number < 1.0, comm, PETSC_ERR_USER,
+               "time.adaptive.target_courant_number must be less than 1.0");
+    PetscCheck(config->time.adaptive.max_increase_factor > 1.0, comm, PETSC_ERR_USER,
+               "time.adaptive.max_increase_factor must be greater than 1.0");
+    PetscCheck(config->time.adaptive.initial_time_step > 0.0, comm, PETSC_ERR_USER, "time.adaptive.initial_time_step must be greater than 0.0");
 
     // ensure that max_step and time_step is not specified
-    PetscCheck(config->time.max_step == INVALID_INT, comm, PETSC_ERR_USER, "max_step cannot be specified with time adaptivity enabled");
-    PetscCheck(config->time.time_step == INVALID_REAL, comm, PETSC_ERR_USER, "time_step cannot be specified with time adaptivity enabled");
+    PetscCheck(config->time.max_step == INVALID_INT, comm, PETSC_ERR_USER, "max_step cannot be specified with adaptive time step enabled");
+    PetscCheck(config->time.time_step == INVALID_REAL, comm, PETSC_ERR_USER, "time_step cannot be specified with adaptive time step enabled");
 
     // set time step
-    config->time.time_step = config->time.adaptivity.initial_time_step;
+    config->time.time_step = config->time.adaptive.initial_time_step;
   }
 
   // check time settings

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -126,8 +126,9 @@ static const cyaml_strval_t enable_units[] = {
 
 static const cyaml_schema_field_t adaptivity_fields_schema[] = {
     CYAML_FIELD_ENUM("enable", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, enable, enable_units, CYAML_ARRAY_LEN(enable_units)),
-    CYAML_FIELD_FLOAT("target_courant_number", CYAML_FLAG_OPTIONAL, RDyTimeAdaptivitySection, target_courant_number),
-    CYAML_FIELD_FLOAT("max_increase_factor", CYAML_FLAG_OPTIONAL, RDyTimeAdaptivitySection, max_increase_factor),
+    CYAML_FIELD_FLOAT("target_courant_number", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, target_courant_number),
+    CYAML_FIELD_FLOAT("max_increase_factor", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, max_increase_factor),
+    CYAML_FIELD_FLOAT("initial_time_step", CYAML_FLAG_DEFAULT, RDyTimeAdaptivitySection, initial_time_step),
     CYAML_FIELD_END
 };
 
@@ -776,6 +777,14 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
                "time.adaptivity.target_courant_number must be less than 1.0");
     PetscCheck(config->time.adaptivity.max_increase_factor > 1.0, comm, PETSC_ERR_USER,
                "time.adaptivity.max_increase_factor must be greater than 1.0");
+    PetscCheck(config->time.adaptivity.initial_time_step > 0.0, comm, PETSC_ERR_USER, "time.adaptivity.initial_time_step must be greater than 0.0");
+
+    // ensure that max_step and time_step is not specified
+    PetscCheck(config->time.max_step == INVALID_INT, comm, PETSC_ERR_USER, "max_step cannot be specified with time adaptivity enabled");
+    PetscCheck(config->time.time_step == INVALID_REAL, comm, PETSC_ERR_USER, "time_step cannot be specified with time adaptivity enabled");
+
+    // set time step
+    config->time.time_step = config->time.adaptivity.initial_time_step;
   }
 
   // check time settings


### PR DESCRIPTION
- Adds a timestep adaptivity block in the `.yaml` as:

```yaml
time:
  final_time        : 0.005
  coupling_interval : 0.001
  unit              : hours
  adaptivity:
    enable                 : true     # false or true. The values below are only used if is enable=true
    target_courant_number  : 0.6      # a target courant number
    max_increase_factor    : 2        # At max, the dt can be doubled to meet the target Courant number
    initial_time_step      : 0.00001  # initial timestep
```

- The time step for `TSSolve` is increased or decreased to match the `target_courant_number`.
- The time step is changed only at the coupling interval and **not within** the `TSSolve`.
- New tests for time step adaptivity are added.