### PR TITLE
submodules: use https to avoid clone failures when people aren't using ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "external/cmocka"]
 	path = external/cmocka
-	url = git@github.com:clibs/cmocka.git
+	url = https://github.com/clibs/cmocka.git
 [submodule "external/libyaml"]
 	path = external/libyaml
-	url = git@github.com:yaml/libyaml.git
+	url = https://github.com/yaml/libyaml.git
 [submodule "external/libcyaml"]
 	path = external/libcyaml
-	url = git@github.com:tlsa/libcyaml.git
+	url = https://github.com/tlsa/libcyaml.git


### PR DESCRIPTION
We don't need to push directly to these submodules and developers can always change the path for those submodules (e.g., by editing `.git/config`). It's pretty widely recommended (e.g., [github's blog](https://github.blog/open-source/git/working-with-submodules/)) to use https for submodules.