### PR TITLE
Removing VLA allocations from code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ option(ENABLE_TESTS    "Enable unit and driver tests" ON)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(ENABLE_ASAN     "Enable Address Sanitizer (if available)" OFF)
 
+set(MAX_NAME_LEN 128 CACHE STRING "Maximum allowable length of field/variable names")
+
 # CMake files live in the cmake/ directory.
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
@@ -70,6 +72,7 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fmax-errors=10")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-value")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-truncation")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=vla")
 elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ferror-limit=10")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,9 +72,12 @@ if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fmax-errors=10")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-value")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-truncation")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=vla")
 elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ferror-limit=10")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=vla")
 
   # emit compile_commands.json for use with clangd
   set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -31,9 +31,6 @@
 // simulation
 #define MAX_NUM_CONDITIONS 32
 
-// the maximum length of a string referring to a name in the config file
-#define MAX_NAME_LEN 128
-
 // The data structures below are intermediate representations of the sections
 // in the YAML configuration file. We parse this file with a YAML parser that
 // populates these data structures using a YAML schema. The parser is implemented

--- a/include/private/rdydmimpl.h
+++ b/include/private/rdydmimpl.h
@@ -4,8 +4,18 @@
 #include <petsc.h>
 #include <rdycore.h>
 
-PETSC_INTERN PetscErrorCode CloneAndCreateCellCenteredDM(DM dm, PetscInt n_aux_field, PetscInt n_aux_field_dof[n_aux_field], PetscInt m,
-                                                         char aux_field_names[n_aux_field][m], DM *aux_dm);
+// maximum number of supported fields in a DM section
+#define MAX_NUM_SECTION_FIELDS 5
+
+// this struct specifies the number, degrees of freedom, and names of fields in
+// a section within a DM
+typedef struct {
+  PetscInt num_fields; // number of fields
+  PetscInt num_field_dof[MAX_NUM_SECTION_FIELDS]; // number of degrees of freedom for fields
+  const char field_names[MAX_NUM_SECTION_FIELDS][MAX_NAME_LEN+1]; // names of fields
+} SectionFieldSpec;
+
+PETSC_INTERN PetscErrorCode CloneAndCreateCellCenteredDM(DM dm, const SectionFieldSpec cc_spec, DM *cc_dm);
 PETSC_INTERN PetscErrorCode CreateDM(RDy rdy);
 PETSC_INTERN PetscErrorCode CreateAuxiliaryDM(RDy rdy);
 PETSC_INTERN PetscErrorCode CreateVectors(RDy rdy);

--- a/include/private/rdydmimpl.h
+++ b/include/private/rdydmimpl.h
@@ -10,9 +10,9 @@
 // this struct specifies the number, degrees of freedom, and names of fields in
 // a section within a DM
 typedef struct {
-  PetscInt num_fields; // number of fields
-  PetscInt num_field_dof[MAX_NUM_SECTION_FIELDS]; // number of degrees of freedom for fields
-  const char field_names[MAX_NUM_SECTION_FIELDS][MAX_NAME_LEN+1]; // names of fields
+  PetscInt   num_fields;                                             // number of fields
+  PetscInt   num_field_dof[MAX_NUM_SECTION_FIELDS];                  // number of degrees of freedom for fields
+  const char field_names[MAX_NUM_SECTION_FIELDS][MAX_NAME_LEN + 1];  // names of fields
 } SectionFieldSpec;
 
 PETSC_INTERN PetscErrorCode CloneAndCreateCellCenteredDM(DM dm, const SectionFieldSpec cc_spec, DM *cc_dm);

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -27,13 +27,13 @@ typedef struct {
   RiemannDataSWE      data_cells;
 } PetscRiemannDataSWE;
 
-PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, CeedInt n, RDyBoundary[n], RDyCondition[n], PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, CeedInt n, RDyBoundary*, RDyCondition*, PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetBoundaryFlux(CeedOperator, RDyBoundary, CeedOperatorField *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetDirichletBoundaryValues(CeedOperator, RDyBoundary, CeedOperatorField *);
-PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyMesh *, RDyBoundary boundary, PetscInt size, PetscReal[size]);
+PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyMesh *, RDyBoundary boundary, PetscInt size, PetscReal*);
 
-PETSC_INTERN PetscErrorCode CreateSWESourceOperator(Ceed, RDyMesh *mesh, PetscInt num_cells, RDyMaterial[num_cells], PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWESourceOperator(Ceed, RDyMesh *mesh, PetscInt num_cells, RDyMaterial*, PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWESourceOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWESourceOperatorGetWaterSource(CeedOperator, const char *, CeedOperatorField *);
 PETSC_INTERN PetscErrorCode SWESourceOperatorGetRiemannFlux(CeedOperator, CeedOperatorField *);
@@ -48,10 +48,10 @@ PETSC_INTERN PetscErrorCode RiemannEdgeDataSWECreate(PetscInt, PetscInt, Riemann
 PETSC_INTERN PetscErrorCode RiemannEdgeDataSWEDestroy(RiemannEdgeDataSWE);
 
 PETSC_INTERN PetscErrorCode CreatePetscSWEFluxForInternalEdges(RDyEdges *edges, PetscInt num_comp, PetscInt num_internal_edges, void **);
-PETSC_INTERN PetscErrorCode CreatePetscSWEFluxForBoundaryEdges(RDyEdges *edges, PetscInt num_comp, PetscInt n, RDyBoundary[n], PetscBool, void **);
+PETSC_INTERN PetscErrorCode CreatePetscSWEFluxForBoundaryEdges(RDyEdges *edges, PetscInt num_comp, PetscInt n, RDyBoundary*, PetscBool, void **);
 PETSC_INTERN PetscErrorCode DestroyPetscSWEFlux(void *, PetscBool, PetscInt);
 PETSC_INTERN PetscErrorCode CreatePetscSWESource(RDyMesh *, void *);
-PETSC_INTERN PetscErrorCode InitPetscSWEBoundaryFlux(void *, RDyCells *, RDyEdges *, PetscInt n, RDyBoundary[n], RDyCondition[n], PetscReal);
+PETSC_INTERN PetscErrorCode InitPetscSWEBoundaryFlux(void *, RDyCells *, RDyEdges *, PetscInt n, RDyBoundary*, RDyCondition*, PetscReal);
 PETSC_INTERN PetscErrorCode GetPetscSWEDirichletBoundaryValues(void *, PetscInt, RiemannDataSWE *);
 
 PETSC_INTERN PetscErrorCode SWEFindMaxCourantNumber(RDy);

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -27,13 +27,13 @@ typedef struct {
   RiemannDataSWE      data_cells;
 } PetscRiemannDataSWE;
 
-PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, CeedInt n, RDyBoundary*, RDyCondition*, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, CeedInt n, RDyBoundary *, RDyCondition *, PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetBoundaryFlux(CeedOperator, RDyBoundary, CeedOperatorField *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetDirichletBoundaryValues(CeedOperator, RDyBoundary, CeedOperatorField *);
-PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyMesh *, RDyBoundary boundary, PetscInt size, PetscReal*);
+PETSC_INTERN PetscErrorCode SWEFluxOperatorSetDirichletBoundaryValues(CeedOperator, RDyMesh *, RDyBoundary boundary, PetscInt size, PetscReal *);
 
-PETSC_INTERN PetscErrorCode CreateSWESourceOperator(Ceed, RDyMesh *mesh, PetscInt num_cells, RDyMaterial*, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWESourceOperator(Ceed, RDyMesh *mesh, PetscInt num_cells, RDyMaterial *, PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWESourceOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWESourceOperatorGetWaterSource(CeedOperator, const char *, CeedOperatorField *);
 PETSC_INTERN PetscErrorCode SWESourceOperatorGetRiemannFlux(CeedOperator, CeedOperatorField *);
@@ -48,10 +48,10 @@ PETSC_INTERN PetscErrorCode RiemannEdgeDataSWECreate(PetscInt, PetscInt, Riemann
 PETSC_INTERN PetscErrorCode RiemannEdgeDataSWEDestroy(RiemannEdgeDataSWE);
 
 PETSC_INTERN PetscErrorCode CreatePetscSWEFluxForInternalEdges(RDyEdges *edges, PetscInt num_comp, PetscInt num_internal_edges, void **);
-PETSC_INTERN PetscErrorCode CreatePetscSWEFluxForBoundaryEdges(RDyEdges *edges, PetscInt num_comp, PetscInt n, RDyBoundary*, PetscBool, void **);
+PETSC_INTERN PetscErrorCode CreatePetscSWEFluxForBoundaryEdges(RDyEdges *edges, PetscInt num_comp, PetscInt n, RDyBoundary *, PetscBool, void **);
 PETSC_INTERN PetscErrorCode DestroyPetscSWEFlux(void *, PetscBool, PetscInt);
 PETSC_INTERN PetscErrorCode CreatePetscSWESource(RDyMesh *, void *);
-PETSC_INTERN PetscErrorCode InitPetscSWEBoundaryFlux(void *, RDyCells *, RDyEdges *, PetscInt n, RDyBoundary*, RDyCondition*, PetscReal);
+PETSC_INTERN PetscErrorCode InitPetscSWEBoundaryFlux(void *, RDyCells *, RDyEdges *, PetscInt n, RDyBoundary *, RDyCondition *, PetscReal);
 PETSC_INTERN PetscErrorCode GetPetscSWEDirichletBoundaryValues(void *, PetscInt, RiemannDataSWE *);
 
 PETSC_INTERN PetscErrorCode SWEFindMaxCourantNumber(RDy);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -21,6 +21,9 @@
 // with 64-bit indices
 #define PETSC_ID_TYPE "@PETSC_ID_TYPE@"
 
+// maximum length of names of fields stored in DM sections
+#define MAX_NAME_LEN @MAX_NAME_LEN@
+
 //-------------------
 // RDycore Interface
 //-------------------
@@ -76,31 +79,31 @@ PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryConditions(RDy, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetNumBoundaryEdges(RDy, const PetscInt, PetscInt*);
 PETSC_EXTERN PetscErrorCode RDyGetBoundaryConditionFlowType(RDy, const PetscInt, PetscInt*);
 
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellHeights(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellXMomentums(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellYMomentums(RDy rdy, const PetscInt size, PetscReal values[size]);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellHeights(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellXMomentums(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellYMomentums(RDy rdy, const PetscInt size, PetscReal *values);
 
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellXCentroids(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellYCentroids(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellZCentroids(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellAreas(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellManningsNs(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetLocalCellNaturalIDs(RDy rdy, const PetscInt size, PetscInt values[size]);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellXCentroids(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellYCentroids(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellZCentroids(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellAreas(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellManningsNs(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetLocalCellNaturalIDs(RDy rdy, const PetscInt size, PetscInt *values);
 
-PETSC_EXTERN PetscErrorCode RDyGetBoundaryEdgeXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetBoundaryEdgeYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetBoundaryEdgeZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryEdgeXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryEdgeYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryEdgeZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values);
 
-PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscInt values[size]);
+PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscInt *values);
 
-PETSC_EXTERN PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_index, const PetscInt num_edges, const PetscInt ndof, PetscReal values[ndof * num_edges]);
-PETSC_EXTERN PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDySetYMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal values[size]);
-PETSC_EXTERN PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscReal values[size]);
+PETSC_EXTERN PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_index, const PetscInt num_edges, const PetscInt ndof, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetYMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
 PETSC_EXTERN PetscErrorCode RDySetInitialConditions(RDy rdy, Vec ic);
 
 PETSC_EXTERN PetscErrorCode RDyCreatePrognosticVec(RDy rdy, Vec *prog_vec);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -21,7 +21,7 @@
 // with 64-bit indices
 #define PETSC_ID_TYPE "@PETSC_ID_TYPE@"
 
-// maximum length of names of fields stored in DM sections
+// maximum length of names (config parameters, fields in DM sections, etc)
 #define MAX_NAME_LEN @MAX_NAME_LEN@
 
 //-------------------

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -84,8 +84,7 @@ PetscErrorCode GenerateIndexedFilename(const char *directory, const char *prefix
 PetscErrorCode DetermineOutputFile(RDy rdy, PetscInt step, PetscReal time, const char *suffix, char *filename) {
   PetscFunctionBegin;
 
-  size_t config_len = strlen(rdy->config_file);
-  char   prefix[config_len + 1];
+  char prefix[PETSC_MAX_PATH_LEN];
   PetscCall(DetermineConfigPrefix(rdy, prefix));
 
   // encode specific information into the filename based on its format

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -159,7 +159,7 @@ static PetscErrorCode CreateOutputViewer(RDy rdy) {
 
     if (rdy->config.output.time_interval) {
       const char *units = TimeUnitAsString(rdy->config.output.time_unit);
-      RDyLogDebug(rdy, "Writing output every %d %s", rdy->config.output.time_interval, units);
+      RDyLogDebug(rdy, "Writing output every %" PetscInt_FMT " %s", rdy->config.output.time_interval, units);
     }
 
     switch (rdy->config.output.format) {

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -64,8 +64,10 @@ PetscErrorCode RDyGetBoundaryConditionFlowType(RDy rdy, const PetscInt boundary_
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+// sets Dirichlet boundary values using the data in the strided array
+// values[num_edges * ndof]
 PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_index, const PetscInt num_edges, const PetscInt ndof,
-                                             PetscReal values[num_edges * ndof]) {
+                                             PetscReal *values) {
   PetscFunctionBegin;
 
   PetscCall(CheckBoundaryConditionIndex(rdy, boundary_index));
@@ -128,7 +130,10 @@ static PetscErrorCode RDyGetPrognosticVariableOfLocalCell(RDy rdy, PetscInt idof
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellHeights(RDy rdy, const PetscInt size, PetscReal values[size]) {
+// The following functions retrieve single-component solution data on local
+// cells, placing them into the values array (of length size)
+
+PetscErrorCode RDyGetLocalCellHeights(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscCall(CheckNumLocalCells(rdy, size));
   PetscInt idof = 0;
@@ -136,7 +141,7 @@ PetscErrorCode RDyGetLocalCellHeights(RDy rdy, const PetscInt size, PetscReal va
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellXMomentums(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetLocalCellXMomentums(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscCall(CheckNumLocalCells(rdy, size));
   PetscInt idof = 1;
@@ -144,7 +149,7 @@ PetscErrorCode RDyGetLocalCellXMomentums(RDy rdy, const PetscInt size, PetscReal
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellYMomentums(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetLocalCellYMomentums(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscCall(CheckNumLocalCells(rdy, size));
   PetscInt idof = 2;
@@ -171,7 +176,7 @@ PetscErrorCode RDySetSourceVecForLocalCells(RDy rdy, Vec src_vec, PetscInt idof,
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
 
   PetscCall(CheckNumLocalCells(rdy, size));
@@ -186,7 +191,7 @@ PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, Pets
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
 
   PetscCall(CheckNumLocalCells(rdy, size));
@@ -200,7 +205,7 @@ PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDySetYMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDySetYMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
 
   PetscCall(CheckNumLocalCells(rdy, size));
@@ -230,28 +235,28 @@ static PetscErrorCode RDyGetIDimCentroidOfLocalCell(RDy rdy, PetscInt idim, Pets
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellXCentroids(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetLocalCellXCentroids(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscInt idim = 0;  // x-dim
   PetscCall(RDyGetIDimCentroidOfLocalCell(rdy, idim, size, values));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellYCentroids(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetLocalCellYCentroids(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscInt idim = 1;  // y-dim
   PetscCall(RDyGetIDimCentroidOfLocalCell(rdy, idim, size, values));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellZCentroids(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetLocalCellZCentroids(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscInt idim = 2;  // z-dim
   PetscCall(RDyGetIDimCentroidOfLocalCell(rdy, idim, size, values));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellAreas(RDy rdy, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetLocalCellAreas(RDy rdy, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscCall(CheckNumLocalCells(rdy, size));
 
@@ -266,7 +271,7 @@ PetscErrorCode RDyGetLocalCellAreas(RDy rdy, const PetscInt size, PetscReal valu
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellNaturalIDs(RDy rdy, const PetscInt size, PetscInt values[size]) {
+PetscErrorCode RDyGetLocalCellNaturalIDs(RDy rdy, const PetscInt size, PetscInt *values) {
   PetscFunctionBegin;
 
   PetscCall(CheckNumLocalCells(rdy, size));
@@ -308,7 +313,7 @@ static PetscErrorCode RDyGetIDimCentroidOfBoundaryEdgeOrCell(RDy rdy, const Pets
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetBoundaryEdgeXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetBoundaryEdgeXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscBool data_for_edge = PETSC_TRUE;
   PetscInt  idim          = 0;  // x-dim
@@ -316,7 +321,7 @@ PetscErrorCode RDyGetBoundaryEdgeXCentroids(RDy rdy, const PetscInt boundary_ind
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetBoundaryEdgeYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetBoundaryEdgeYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscBool data_for_edge = PETSC_TRUE;
   PetscInt  idim          = 1;  // y-dim
@@ -324,7 +329,7 @@ PetscErrorCode RDyGetBoundaryEdgeYCentroids(RDy rdy, const PetscInt boundary_ind
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetBoundaryEdgeZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetBoundaryEdgeZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscBool data_for_edge = PETSC_TRUE;
   PetscInt  idim          = 2;  // z-dim
@@ -332,7 +337,7 @@ PetscErrorCode RDyGetBoundaryEdgeZCentroids(RDy rdy, const PetscInt boundary_ind
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetBoundaryCellXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetBoundaryCellXCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscBool data_for_edge = PETSC_FALSE;
   PetscInt  idim          = 0;  // x-dim
@@ -340,7 +345,7 @@ PetscErrorCode RDyGetBoundaryCellXCentroids(RDy rdy, const PetscInt boundary_ind
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetBoundaryCellYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetBoundaryCellYCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscBool data_for_edge = PETSC_FALSE;
   PetscInt  idim          = 1;  // y-dim
@@ -348,7 +353,7 @@ PetscErrorCode RDyGetBoundaryCellYCentroids(RDy rdy, const PetscInt boundary_ind
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetBoundaryCellZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal values[size]) {
+PetscErrorCode RDyGetBoundaryCellZCentroids(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscBool data_for_edge = PETSC_FALSE;
   PetscInt  idim          = 2;  // z-dim
@@ -356,7 +361,7 @@ PetscErrorCode RDyGetBoundaryCellZCentroids(RDy rdy, const PetscInt boundary_ind
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscInt values[size]) {
+PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscInt *values) {
   PetscFunctionBegin;
   PetscCall(CheckBoundaryConditionIndex(rdy, boundary_index));
   PetscCall(CheckBoundaryNumEdges(rdy, boundary_index, size));
@@ -373,7 +378,7 @@ PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt boundary_ind
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDyGetLocalCellManningsNs(RDy rdy, const PetscInt size, PetscReal n_values[size]) {
+PetscErrorCode RDyGetLocalCellManningsNs(RDy rdy, const PetscInt size, PetscReal *n_values) {
   PetscFunctionBegin;
 
   PetscCall(CheckNumLocalCells(rdy, size));
@@ -389,7 +394,7 @@ PetscErrorCode RDyGetLocalCellManningsNs(RDy rdy, const PetscInt size, PetscReal
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscReal n_values[size]) {
+PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscReal *n_values) {
   PetscFunctionBegin;
 
   PetscCall(CheckNumLocalCells(rdy, size));

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -224,9 +224,9 @@ PetscErrorCode CreateAuxiliaryDM(RDy rdy) {
 
   // create an auxiliary section with a diagnostic parameter.
   SectionFieldSpec cc_spec = {
-    .num_fields = 1,
-    .num_field_dof = {1},
-    .field_names = {"Parameter"},
+      .num_fields    = 1,
+      .num_field_dof = {1},
+      .field_names   = {"Parameter"},
   };
   PetscCall(CloneAndCreateCellCenteredDM(rdy->dm, cc_spec, &rdy->aux_dm));
 

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -43,6 +43,7 @@ PetscErrorCode CloneAndCreateCellCenteredDM(DM dm, const SectionFieldSpec cc_spe
   PetscCall(PetscSectionSetUp(cc_section));
   PetscCall(DMSetLocalSection(*cc_dm, cc_section));
   PetscCall(PetscSectionViewFromOptions(cc_section, NULL, "-aux_layout_view"));
+  PetscCall(PetscSectionDestroy(&cc_section));
 
   PetscInt refine_level;
   DMGetRefineLevel(dm, &refine_level);
@@ -56,7 +57,6 @@ PetscErrorCode CloneAndCreateCellCenteredDM(DM dm, const SectionFieldSpec cc_spe
     PetscCall(PetscSFDestroy(&sf_natural));
   }
 
-  PetscCall(PetscSectionDestroy(&cc_section));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/rdymesh.c
+++ b/src/rdymesh.c
@@ -109,7 +109,7 @@ static PetscErrorCode RDyCellsCreateFromDM(DM dm, PetscInt nvertices_per_cell, P
   PetscInt num_owned_cells = 0;
   for (PetscInt c = c_start; c < c_end; c++) {
     PetscInt  icell = c - c_start;
-    PetscReal centroid[dim], normal[dim];
+    PetscReal centroid[3], normal[3];
     DMPlexComputeCellGeometryFVM(dm, c, &cells->areas[icell], &centroid[0], &normal[0]);
 
     for (PetscInt idim = 0; idim < dim; idim++) {
@@ -459,7 +459,7 @@ static PetscErrorCode RDyEdgesCreateFromDM(DM dm, RDyEdges *edges) {
 
   for (PetscInt e = e_start; e < e_end; e++) {
     PetscInt  iedge = e - e_start;
-    PetscReal centroid[dim], normal[dim];
+    PetscReal centroid[3], normal[3];
     DMPlexComputeCellGeometryFVM(dm, e, &edges->lengths[iedge], &centroid[0], &normal[0]);
 
     for (PetscInt idim = 0; idim < dim; idim++) {
@@ -916,8 +916,13 @@ static PetscErrorCode CreateCoordinatesVectorInNaturalOrder(MPI_Comm comm, RDyMe
   PetscCall(VecDuplicate(xcoord_nat, &zcoord_nat));
 
   PetscInt  num_vertices = mesh->num_vertices;
-  PetscInt  indices[num_vertices];
-  PetscReal x[num_vertices], y[num_vertices], z[num_vertices];
+  PetscInt  *indices;
+  PetscReal *x, *y, *z;
+
+  PetscCall(PetscCalloc1(num_vertices, &indices));
+  PetscCall(PetscCalloc1(num_vertices, &x));
+  PetscCall(PetscCalloc1(num_vertices, &y));
+  PetscCall(PetscCalloc1(num_vertices, &z));
 
   RDyVertices *vertices = &mesh->vertices;
   for (PetscInt v = 0; v < num_vertices; v++) {
@@ -935,6 +940,11 @@ static PetscErrorCode CreateCoordinatesVectorInNaturalOrder(MPI_Comm comm, RDyMe
   PetscCall(VecSetValues(xcoord_nat, num_vertices, indices, x, INSERT_VALUES));
   PetscCall(VecSetValues(ycoord_nat, num_vertices, indices, y, INSERT_VALUES));
   PetscCall(VecSetValues(zcoord_nat, num_vertices, indices, z, INSERT_VALUES));
+
+  PetscCall(PetscFree(indices));
+  PetscCall(PetscFree(x));
+  PetscCall(PetscFree(y));
+  PetscCall(PetscFree(z));
 
   PetscCall(VecAssemblyBegin(xcoord_nat));
   PetscCall(VecAssemblyEnd(xcoord_nat));
@@ -999,11 +1009,12 @@ static PetscErrorCode CreateCellConnectionVector(DM dm, RDyMesh *mesh) {
   // create a local DM
   DM       local_dm;
   PetscInt max_num_vertices       = 4;
-  PetscInt n_aux_field            = 1;
-  PetscInt n_aux_field_dof[1]     = {max_num_vertices};
-  char     aux_field_names[1][20] = {"Cell Connections"};
-
-  PetscCall(CloneAndCreateCellCenteredDM(dm, n_aux_field, n_aux_field_dof, 20, &aux_field_names[0], &local_dm));
+  SectionFieldSpec aux_spec = {
+    .num_fields = 1,
+    .num_field_dof = {max_num_vertices},
+    .field_names = {"Cell Connections"},
+  };
+  PetscCall(CloneAndCreateCellCenteredDM(dm, aux_spec, &local_dm));
 
   Vec          global_vec, natural_vec;
   PetscScalar *vec_ptr;
@@ -1115,11 +1126,13 @@ static PetscErrorCode CreateCellCentroidVectors(DM dm, RDyMesh *mesh) {
 
   // create a local DM
   DM       local_dm;
-  PetscInt n_aux_field            = 1;
-  PetscInt n_aux_field_dof[1]     = {1};
-  char     aux_field_names[1][20] = {"Cell Coordinates"};
+  SectionFieldSpec local_spec = {
+    .num_fields = 1,
+    .num_field_dof = {1},
+    .field_names = {"Cell Coordinates"},
+  };
 
-  PetscCall(CloneAndCreateCellCenteredDM(dm, n_aux_field, n_aux_field_dof, 20, &aux_field_names[0], &local_dm));
+  PetscCall(CloneAndCreateCellCenteredDM(dm, local_spec, &local_dm));
 
   Vec global_vec, natural_vec;
   PetscCall(DMCreateGlobalVector(local_dm, &global_vec));

--- a/src/rdymesh.c
+++ b/src/rdymesh.c
@@ -915,7 +915,7 @@ static PetscErrorCode CreateCoordinatesVectorInNaturalOrder(MPI_Comm comm, RDyMe
   PetscCall(VecDuplicate(xcoord_nat, &ycoord_nat));
   PetscCall(VecDuplicate(xcoord_nat, &zcoord_nat));
 
-  PetscInt  num_vertices = mesh->num_vertices;
+  PetscInt   num_vertices = mesh->num_vertices;
   PetscInt  *indices;
   PetscReal *x, *y, *z;
 
@@ -1007,12 +1007,12 @@ static PetscErrorCode CreateCellConnectionVector(DM dm, RDyMesh *mesh) {
   PetscFunctionBegin;
 
   // create a local DM
-  DM       local_dm;
-  PetscInt max_num_vertices       = 4;
-  SectionFieldSpec aux_spec = {
-    .num_fields = 1,
-    .num_field_dof = {max_num_vertices},
-    .field_names = {"Cell Connections"},
+  DM               local_dm;
+  PetscInt         max_num_vertices = 4;
+  SectionFieldSpec aux_spec         = {
+              .num_fields    = 1,
+              .num_field_dof = {max_num_vertices},
+              .field_names   = {"Cell Connections"},
   };
   PetscCall(CloneAndCreateCellCenteredDM(dm, aux_spec, &local_dm));
 
@@ -1125,11 +1125,11 @@ static PetscErrorCode CreateCellCentroidVectors(DM dm, RDyMesh *mesh) {
   PetscFunctionBegin;
 
   // create a local DM
-  DM       local_dm;
+  DM               local_dm;
   SectionFieldSpec local_spec = {
-    .num_fields = 1,
-    .num_field_dof = {1},
-    .field_names = {"Cell Coordinates"},
+      .num_fields    = 1,
+      .num_field_dof = {1},
+      .field_names   = {"Cell Coordinates"},
   };
 
   PetscCall(CloneAndCreateCellCenteredDM(dm, local_spec, &local_dm));

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -217,7 +217,7 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
     PetscCall(PetscCalloc(region.num_cells, &cell_x));
     PetscCall(PetscCalloc(region.num_cells, &cell_y));
 
-    PetscInt  N = 0;  // number of bulk evaluations
+    PetscInt N = 0;  // number of bulk evaluations
     for (PetscInt c = 0; c < region.num_cells; ++c) {
       PetscInt cell_id = region.cell_ids[c];
       if (3 * cell_id < n_local) {
@@ -396,7 +396,7 @@ PetscErrorCode RDyMMSEnforceBoundaryConditions(RDy rdy, PetscReal time) {
     // fetch x, y for each edge (and set t = time)
     RDyBoundary boundary  = rdy->boundaries[b];
     PetscInt    num_edges = boundary.num_edges;
-    PetscReal   *x, *y;
+    PetscReal  *x, *y;
     PetscCall(PetscCalloc1(num_edges, &x));
     PetscCall(PetscCalloc1(num_edges, &y));
     for (PetscInt e = 0; e < num_edges; ++e) {
@@ -455,7 +455,7 @@ PetscErrorCode RDyMMSUpdateMaterialProperties(RDy rdy) {
     PetscCall(PetscCalloc1(region.num_cells, &cell_x));
     PetscCall(PetscCalloc1(region.num_cells, &cell_y));
 
-    PetscInt  N = 0;  // number of bulk evaluations
+    PetscInt N = 0;  // number of bulk evaluations
     for (PetscInt c = 0; c < region.num_cells; ++c) {
       PetscInt cell_id = region.cell_ids[c];
       if (3 * cell_id < n_local) {
@@ -539,8 +539,8 @@ PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_no
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode PrintErrorNorms(MPI_Comm comm, PetscReal time, int num_comps, const char **comp_names, PetscReal *L1_norms,
-                                      PetscReal *L2_norms, PetscReal *Linf_norms) {
+static PetscErrorCode PrintErrorNorms(MPI_Comm comm, PetscReal time, int num_comps, const char **comp_names, PetscReal *L1_norms, PetscReal *L2_norms,
+                                      PetscReal *Linf_norms) {
   PetscFunctionBegin;
   PetscPrintf(comm, "  Error norms at t = %g:\n", time);
   for (PetscInt c = 0; c < num_comps; ++c) {
@@ -567,15 +567,14 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal *L1_conv_rates,
   int base_refinement = rdy->config.mms.swe.convergence.base_refinement;
 
 #define MAX_NUM_REFINEMENTS 8
-  PetscCheck(num_refinements <= MAX_NUM_REFINEMENTS, rdy->comm, PETSC_ERR_USER,
-      "Number of refinements (%d) exceeds maximum (%d)", num_refinements, MAX_NUM_REFINEMENTS);
+  PetscCheck(num_refinements <= MAX_NUM_REFINEMENTS, rdy->comm, PETSC_ERR_USER, "Number of refinements (%d) exceeds maximum (%d)", num_refinements,
+             MAX_NUM_REFINEMENTS);
 
   // error norm storage
-#define MAX_NUM_COMPONENTS 3 // FIXME: SWE only
-  int num_comps = MAX_NUM_COMPONENTS;
-  PetscReal L1_norms[MAX_NUM_REFINEMENTS+1][MAX_NUM_COMPONENTS],
-            L2_norms[MAX_NUM_REFINEMENTS+1][MAX_NUM_COMPONENTS],
-            Linf_norms[MAX_NUM_REFINEMENTS+1][MAX_NUM_COMPONENTS];
+#define MAX_NUM_COMPONENTS 3  // FIXME: SWE only
+  int       num_comps = MAX_NUM_COMPONENTS;
+  PetscReal L1_norms[MAX_NUM_REFINEMENTS + 1][MAX_NUM_COMPONENTS], L2_norms[MAX_NUM_REFINEMENTS + 1][MAX_NUM_COMPONENTS],
+      Linf_norms[MAX_NUM_REFINEMENTS + 1][MAX_NUM_COMPONENTS];
   const char *comp_names[MAX_NUM_COMPONENTS] = {" h", "hu", "hv"};
 
   // create refined RDy objects and set them up (dumb, but easy)
@@ -651,9 +650,9 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal *L1_conv_rates,
 PetscErrorCode RDyMMSRun(RDy rdy) {
   PetscFunctionBegin;
 
-#define MAX_NUM_COMPONENTS 3 // FIXME: SWE only!
-  PetscReal L1_conv_rates[MAX_NUM_COMPONENTS], L2_conv_rates[MAX_NUM_COMPONENTS], Linf_conv_rates[MAX_NUM_COMPONENTS],
-            L1_norms[MAX_NUM_COMPONENTS], L2_norms[MAX_NUM_COMPONENTS], Linf_norms[MAX_NUM_COMPONENTS];
+#define MAX_NUM_COMPONENTS 3  // FIXME: SWE only!
+  PetscReal L1_conv_rates[MAX_NUM_COMPONENTS], L2_conv_rates[MAX_NUM_COMPONENTS], Linf_conv_rates[MAX_NUM_COMPONENTS], L1_norms[MAX_NUM_COMPONENTS],
+      L2_norms[MAX_NUM_COMPONENTS], Linf_norms[MAX_NUM_COMPONENTS];
   const char *comp_names[MAX_NUM_COMPONENTS] = {" h", "hu", "hv"};
   if (rdy->config.mms.swe.convergence.num_refinements) {
     // run a convergence study

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -47,7 +47,7 @@ static PetscErrorCode SetSWEAnalyticBoundaryCondition(RDy rdy) {
   mupDefineBulkVar(func, "y", y)
 
 // evaluates the given expression at all given x, y, placing the results into values
-static PetscErrorCode EvaluateSpatialSolution(void *expr, PetscInt n, PetscReal x[n], PetscReal y[n], PetscReal values[n]) {
+static PetscErrorCode EvaluateSpatialSolution(void *expr, PetscInt n, PetscReal *x, PetscReal *y, PetscReal *values) {
   PetscFunctionBegin;
 
   SET_SPATIAL_VARIABLES(expr);
@@ -61,13 +61,15 @@ static PetscErrorCode EvaluateSpatialSolution(void *expr, PetscInt n, PetscReal 
   mupDefineBulkVar(func, "t", t)
 
 // evaluates the given expression at all given x, y, t, placing the results into values
-static PetscErrorCode EvaluateTemporalSolution(void *expr, PetscInt n, PetscReal x[n], PetscReal y[n], PetscReal time, PetscReal values[n]) {
+static PetscErrorCode EvaluateTemporalSolution(void *expr, PetscInt n, PetscReal *x, PetscReal *y, PetscReal time, PetscReal *values) {
   PetscFunctionBegin;
 
-  PetscReal t[n];
+  PetscReal *t;
+  PetscCalloc1(n, &t);
   for (PetscInt i = 0; i < n; ++i) t[i] = time;
   SET_SPATIOTEMPORAL_VARIABLES(expr);
   mupEvalBulk(expr, values, n);
+  PetscCall(PetscFree(t));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -211,7 +213,10 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
     RDyRegion region = rdy->regions[r];
 
     // Create vectorized (x, y, t) triples for bulk expression evaluation
-    PetscReal cell_x[region.num_cells], cell_y[region.num_cells];
+    PetscReal *cell_x, *cell_y;
+    PetscCall(PetscCalloc(region.num_cells, &cell_x));
+    PetscCall(PetscCalloc(region.num_cells, &cell_y));
+
     PetscInt  N = 0;  // number of bulk evaluations
     for (PetscInt c = 0; c < region.num_cells; ++c) {
       PetscInt cell_id = region.cell_ids[c];
@@ -226,7 +231,10 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
       PetscCheck(ndof == 3, rdy->comm, PETSC_ERR_USER, "SWE solution vector has %" PetscInt_FMT " DOF (should have 3)", ndof);
 
       // evaluate the manufactured ѕolutions at all (x, y, t)
-      PetscReal h[N], u[N], v[N];
+      PetscReal *h, *u, *v;
+      PetscCall(PetscCalloc(region.num_cells, &h));
+      PetscCall(PetscCalloc(region.num_cells, &u));
+      PetscCall(PetscCalloc(region.num_cells, &v));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.h, N, cell_x, cell_y, time, h));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.u, N, cell_x, cell_y, time, u));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.v, N, cell_x, cell_y, time, v));
@@ -243,7 +251,12 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
           ++l;
         }
       }
+      PetscCall(PetscFree(h));
+      PetscCall(PetscFree(u));
+      PetscCall(PetscFree(v));
     }
+    PetscCall(PetscFree(cell_x));
+    PetscCall(PetscFree(cell_y));
   }
 
   PetscCall(VecRestoreArray(solution, &x_ptr));
@@ -259,7 +272,9 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
 
   PetscInt N;
   PetscCall(RDyGetNumLocalCells(rdy, &N));
-  PetscReal cell_x[N], cell_y[N];
+  PetscReal *cell_x, *cell_y;
+  PetscCall(PetscCalloc(N, &cell_x));
+  PetscCall(PetscCalloc(N, &cell_y));
 
   PetscInt l = 0;
   for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
@@ -272,34 +287,53 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
 
   if (rdy->config.physics.flow.mode == FLOW_SWE) {
     // evaluate the manufactured ѕolutions at all (x, y, t)
-    PetscReal h[N], u[N], v[N];
+
+    PetscReal *h, *u, *v;
+    PetscCall(PetscCalloc1(N, &h));
+    PetscCall(PetscCalloc1(N, &u));
+    PetscCall(PetscCalloc1(N, &v));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.h, N, cell_x, cell_y, time, h));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.u, N, cell_x, cell_y, time, u));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.v, N, cell_x, cell_y, time, v));
 
-    PetscReal dhdx[N], dhdy[N], dhdt[N];
+    PetscReal *dhdx, *dhdy, *dhdt;
+    PetscCall(PetscCalloc1(N, &dhdx));
+    PetscCall(PetscCalloc1(N, &dhdy));
+    PetscCall(PetscCalloc1(N, &dhdt));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dhdx, N, cell_x, cell_y, time, dhdx));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dhdy, N, cell_x, cell_y, time, dhdy));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dhdt, N, cell_x, cell_y, time, dhdt));
 
-    PetscReal dudx[N], dudy[N], dudt[N];
+    PetscReal *dudx, *dudy, *dudt;
+    PetscCall(PetscCalloc1(N, &dudx));
+    PetscCall(PetscCalloc1(N, &dudy));
+    PetscCall(PetscCalloc1(N, &dudt));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dudx, N, cell_x, cell_y, time, dudx));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dudy, N, cell_x, cell_y, time, dudy));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dudt, N, cell_x, cell_y, time, dudt));
 
-    PetscReal dvdx[N], dvdy[N], dvdt[N];
+    PetscReal *dvdx, *dvdy, *dvdt;
+    PetscCall(PetscCalloc1(N, &dvdx));
+    PetscCall(PetscCalloc1(N, &dvdy));
+    PetscCall(PetscCalloc1(N, &dvdt));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dvdx, N, cell_x, cell_y, time, dvdx));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dvdy, N, cell_x, cell_y, time, dvdy));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dvdt, N, cell_x, cell_y, time, dvdt));
 
-    PetscReal n[N];
+    PetscReal *n;
+    PetscCall(PetscCalloc1(N, &n));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.n, N, cell_x, cell_y, time, n));
 
-    PetscReal dzdx[N], dzdy[N];
+    PetscReal *dzdx, *dzdy;
+    PetscCall(PetscCalloc1(N, &dzdx));
+    PetscCall(PetscCalloc1(N, &dzdy));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dzdx, N, cell_x, cell_y, time, dzdx));
     PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.dzdy, N, cell_x, cell_y, time, dzdy));
 
-    PetscReal h_source[N], hu_source[N], hv_source[N];
+    PetscReal *h_source, *hu_source, *hv_source;
+    PetscCall(PetscCalloc1(N, &h_source));
+    PetscCall(PetscCalloc1(N, &hu_source));
+    PetscCall(PetscCalloc1(N, &hv_source));
 
     l = 0;
     for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
@@ -326,7 +360,28 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
     PetscCall(RDySetWaterSourceForLocalCells(rdy, N, h_source));
     PetscCall(RDySetXMomentumSourceForLocalCells(rdy, N, hu_source));
     PetscCall(RDySetYMomentumSourceForLocalCells(rdy, N, hv_source));
+
+    PetscCall(PetscFree(h));
+    PetscCall(PetscFree(u));
+    PetscCall(PetscFree(v));
+    PetscCall(PetscFree(dhdx));
+    PetscCall(PetscFree(dhdy));
+    PetscCall(PetscFree(dhdt));
+    PetscCall(PetscFree(dudx));
+    PetscCall(PetscFree(dudy));
+    PetscCall(PetscFree(dudt));
+    PetscCall(PetscFree(dvdx));
+    PetscCall(PetscFree(dvdy));
+    PetscCall(PetscFree(dvdt));
+    PetscCall(PetscFree(n));
+    PetscCall(PetscFree(dzdx));
+    PetscCall(PetscFree(dzdy));
+    PetscCall(PetscFree(h_source));
+    PetscCall(PetscFree(hu_source));
+    PetscCall(PetscFree(hv_source));
   }
+  PetscCall(PetscFree(cell_x));
+  PetscCall(PetscFree(cell_y));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -341,7 +396,9 @@ PetscErrorCode RDyMMSEnforceBoundaryConditions(RDy rdy, PetscReal time) {
     // fetch x, y for each edge (and set t = time)
     RDyBoundary boundary  = rdy->boundaries[b];
     PetscInt    num_edges = boundary.num_edges;
-    PetscReal   x[num_edges], y[num_edges];
+    PetscReal   *x, *y;
+    PetscCall(PetscCalloc1(num_edges, &x));
+    PetscCall(PetscCalloc1(num_edges, &y));
     for (PetscInt e = 0; e < num_edges; ++e) {
       PetscInt edge_id       = boundary.edge_ids[e];
       RDyPoint edge_centroid = rdy->mesh.edges.centroids[edge_id];
@@ -351,20 +408,31 @@ PetscErrorCode RDyMMSEnforceBoundaryConditions(RDy rdy, PetscReal time) {
 
     // compute h, hu, hv on each edge (SWE-specific)
     RDyFlowCondition *flow_bc = rdy->boundary_conditions[b].flow;
-    PetscReal         h[num_edges], u[num_edges], v[num_edges];
+    PetscReal        *h, *u, *v;
+    PetscCall(PetscCalloc1(num_edges, &h));
+    PetscCall(PetscCalloc1(num_edges, &u));
+    PetscCall(PetscCalloc1(num_edges, &v));
     PetscCall(EvaluateTemporalSolution(flow_bc->height, num_edges, x, y, time, h));
     PetscCall(EvaluateTemporalSolution(flow_bc->x_momentum, num_edges, x, y, time, u));
     PetscCall(EvaluateTemporalSolution(flow_bc->y_momentum, num_edges, x, y, time, v));
 
     // set the boundary values (SWE-specific)
     // NOTE: ndof == 3 for SWE
-    PetscReal boundary_values[3 * num_edges];
+    PetscReal *boundary_values;
+    PetscCall(PetscCalloc1(3 * num_edges, &boundary_values));
     for (PetscInt e = 0; e < num_edges; ++e) {
       boundary_values[3 * e]     = h[e];
       boundary_values[3 * e + 1] = h[e] * u[e];
       boundary_values[3 * e + 2] = h[e] * v[e];
     }
     PetscCall(RDySetDirichletBoundaryValues(rdy, b, num_edges, 3, boundary_values));
+
+    PetscCall(PetscFree(x));
+    PetscCall(PetscFree(y));
+    PetscCall(PetscFree(h));
+    PetscCall(PetscFree(u));
+    PetscCall(PetscFree(v));
+    PetscCall(PetscFree(boundary_values));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -383,7 +451,10 @@ PetscErrorCode RDyMMSUpdateMaterialProperties(RDy rdy) {
     RDyRegion region = rdy->regions[r];
 
     // create vectorized (x, y) pairs for bulk expression evaluation
-    PetscReal cell_x[region.num_cells], cell_y[region.num_cells];
+    PetscReal *cell_x, *cell_y;
+    PetscCall(PetscCalloc1(region.num_cells, &cell_x));
+    PetscCall(PetscCalloc1(region.num_cells, &cell_y));
+
     PetscInt  N = 0;  // number of bulk evaluations
     for (PetscInt c = 0; c < region.num_cells; ++c) {
       PetscInt cell_id = region.cell_ids[c];
@@ -396,10 +467,14 @@ PetscErrorCode RDyMMSUpdateMaterialProperties(RDy rdy) {
 
     // evaluate and set material properties
     if (rdy->config.physics.flow.mode == FLOW_SWE) {
-      PetscReal manning[N];
+      PetscReal *manning;
+      PetscCall(PetscCalloc1(N, &manning));
       PetscCall(EvaluateSpatialSolution(rdy->config.mms.swe.solutions.n, N, cell_x, cell_y, manning));
       PetscCall(RDySetManningsNForLocalCells(rdy, N, manning));
+      PetscCall(PetscFree(manning));
     }
+    PetscCall(PetscFree(cell_x));
+    PetscCall(PetscFree(cell_y));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -464,8 +539,8 @@ PetscErrorCode RDyMMSComputeErrorNorms(RDy rdy, PetscReal time, PetscReal *L1_no
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode PrintErrorNorms(MPI_Comm comm, PetscReal time, int num_comps, const char *comp_names[num_comps], PetscReal L1_norms[num_comps],
-                                      PetscReal L2_norms[num_comps], PetscReal Linf_norms[num_comps]) {
+static PetscErrorCode PrintErrorNorms(MPI_Comm comm, PetscReal time, int num_comps, const char **comp_names, PetscReal *L1_norms,
+                                      PetscReal *L2_norms, PetscReal *Linf_norms) {
   PetscFunctionBegin;
   PetscPrintf(comm, "  Error norms at t = %g:\n", time);
   for (PetscInt c = 0; c < num_comps; ++c) {
@@ -491,12 +566,20 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal *L1_conv_rates,
   int num_refinements = rdy->config.mms.swe.convergence.num_refinements;
   int base_refinement = rdy->config.mms.swe.convergence.base_refinement;
 
+#define MAX_NUM_REFINEMENTS 8
+  PetscCheck(num_refinements <= MAX_NUM_REFINEMENTS, rdy->comm, PETSC_ERR_USER,
+      "Number of refinements (%d) exceeds maximum (%d)", num_refinements, MAX_NUM_REFINEMENTS);
+
   // error norm storage
-  PetscInt  num_comps = 3;  // SWE only!
-  PetscReal L1_norms[num_refinements + 1][num_comps], L2_norms[num_refinements + 1][num_comps], Linf_norms[num_refinements + 1][num_comps];
+#define MAX_NUM_COMPONENTS 3 // FIXME: SWE only
+  int num_comps = MAX_NUM_COMPONENTS;
+  PetscReal L1_norms[MAX_NUM_REFINEMENTS+1][MAX_NUM_COMPONENTS],
+            L2_norms[MAX_NUM_REFINEMENTS+1][MAX_NUM_COMPONENTS],
+            Linf_norms[MAX_NUM_REFINEMENTS+1][MAX_NUM_COMPONENTS];
+  const char *comp_names[MAX_NUM_COMPONENTS] = {" h", "hu", "hv"};
 
   // create refined RDy objects and set them up (dumb, but easy)
-  RDy rdys[num_refinements + 1];
+  RDy rdys[MAX_NUM_REFINEMENTS + 1];
   rdys[0] = rdy;
   for (PetscInt r = 1; r <= num_refinements; ++r) {
     PetscCall(RDyCreate(rdy->comm, rdy->config_file, &rdys[r]));
@@ -520,19 +603,18 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal *L1_conv_rates,
 
     // compute error norms for this refinement level
     PetscCall(RDyMMSComputeErrorNorms(rdys[r], final_time, L1_norms[r], L2_norms[r], Linf_norms[r], NULL, NULL));
-    const char *comp_names[3] = {" h", "hu", "hv"};
-    PrintErrorNorms(rdys[r]->comm, final_time, 3, comp_names, L1_norms[r], L2_norms[r], Linf_norms[r]);
+    PrintErrorNorms(rdys[r]->comm, final_time, num_comps, comp_names, L1_norms[r], L2_norms[r], Linf_norms[r]);
   }
 
   // calculate the spatial discretization parameter N, where h^{-dim} = N.
-  PetscReal x[num_refinements + 1];
+  PetscReal x[MAX_NUM_REFINEMENTS + 1];
   for (PetscInt r = 0; r <= num_refinements; ++r) {
     PetscInt N = rdys[r]->mesh.num_cells_global;
     x[r]       = PetscLog10Real(N);
   }
 
   // fit convergence rates
-  PetscReal y1[num_refinements + 1], y2[num_refinements + 1], yinf[num_refinements + 1];
+  PetscReal y1[MAX_NUM_REFINEMENTS + 1], y2[MAX_NUM_REFINEMENTS + 1], yinf[MAX_NUM_REFINEMENTS + 1];
   for (PetscInt c = 0; c < num_comps; ++c) {
     for (PetscInt r = 0; r <= num_refinements; ++r) {
       y1[r]   = PetscLog10Real(L1_norms[r][c]);
@@ -554,6 +636,7 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal *L1_conv_rates,
   for (PetscInt r = 1; r <= num_refinements; ++r) {
     PetscCall(RDyDestroy(&rdys[r]));
   }
+#undef MAX_NUM_COMPONENTS
 
   // PetscCall(PetscConvEstDestroy(&convEst));
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -568,16 +651,16 @@ PetscErrorCode RDyMMSEstimateConvergenceRates(RDy rdy, PetscReal *L1_conv_rates,
 PetscErrorCode RDyMMSRun(RDy rdy) {
   PetscFunctionBegin;
 
-  // FIXME: SWE only at the moment
+#define MAX_NUM_COMPONENTS 3 // FIXME: SWE only!
+  PetscReal L1_conv_rates[MAX_NUM_COMPONENTS], L2_conv_rates[MAX_NUM_COMPONENTS], Linf_conv_rates[MAX_NUM_COMPONENTS],
+            L1_norms[MAX_NUM_COMPONENTS], L2_norms[MAX_NUM_COMPONENTS], Linf_norms[MAX_NUM_COMPONENTS];
+  const char *comp_names[MAX_NUM_COMPONENTS] = {" h", "hu", "hv"};
   if (rdy->config.mms.swe.convergence.num_refinements) {
     // run a convergence study
-    PetscInt  num_comps = 3;
-    PetscReal L1_conv_rates[num_comps], L2_conv_rates[num_comps], Linf_conv_rates[num_comps];
     PetscCall(RDyMMSEstimateConvergenceRates(rdy, L1_conv_rates, L2_conv_rates, Linf_conv_rates));
 
-    const char *comp_names[3] = {" h", "hu", "hv"};
     PetscPrintf(rdy->comm, "Convergence rates:\n");
-    for (PetscInt idof = 0; idof < 3; idof++) {
+    for (PetscInt idof = 0; idof < MAX_NUM_COMPONENTS; idof++) {
       PetscPrintf(rdy->comm, "  %s: L1 = %g, L2 = %g, Linf = %g\n", comp_names[idof], L1_conv_rates[idof], L2_conv_rates[idof],
                   Linf_conv_rates[idof]);
     }
@@ -604,16 +687,16 @@ PetscErrorCode RDyMMSRun(RDy rdy) {
     PetscCall(RDyGetTimeUnit(rdy, &time_unit));
     PetscReal cur_time;
     PetscCall(RDyGetTime(rdy, time_unit, &cur_time));
-    PetscReal L1_norms[3], L2_norms[3], Linf_norms[3], global_area;
+    PetscReal global_area;
     PetscInt  num_global_cells;
     PetscCall(RDyMMSComputeErrorNorms(rdy, cur_time, L1_norms, L2_norms, Linf_norms, &num_global_cells, &global_area));
 
-    const char *comp_names[3] = {" h", "hu", "hv"};
-    PrintErrorNorms(rdy->comm, cur_time, 3, comp_names, L1_norms, L2_norms, Linf_norms);
+    PrintErrorNorms(rdy->comm, cur_time, MAX_NUM_COMPONENTS, comp_names, L1_norms, L2_norms, Linf_norms);
 
     PetscPrintf(rdy->comm, "  Avg-cell-area    : %18.16f\n", global_area / num_global_cells);
     PetscPrintf(rdy->comm, "  Avg-length-scale : %18.16f\n", PetscSqrtReal(global_area / num_global_cells));
   }
+#undef MAX_NUM_COMPONENTS
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -214,8 +214,8 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
 
     // Create vectorized (x, y, t) triples for bulk expression evaluation
     PetscReal *cell_x, *cell_y;
-    PetscCall(PetscCalloc(region.num_cells, &cell_x));
-    PetscCall(PetscCalloc(region.num_cells, &cell_y));
+    PetscCall(PetscCalloc1(region.num_cells, &cell_x));
+    PetscCall(PetscCalloc1(region.num_cells, &cell_y));
 
     PetscInt N = 0;  // number of bulk evaluations
     for (PetscInt c = 0; c < region.num_cells; ++c) {
@@ -232,9 +232,9 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
 
       // evaluate the manufactured ѕolutions at all (x, y, t)
       PetscReal *h, *u, *v;
-      PetscCall(PetscCalloc(region.num_cells, &h));
-      PetscCall(PetscCalloc(region.num_cells, &u));
-      PetscCall(PetscCalloc(region.num_cells, &v));
+      PetscCall(PetscCalloc1(region.num_cells, &h));
+      PetscCall(PetscCalloc1(region.num_cells, &u));
+      PetscCall(PetscCalloc1(region.num_cells, &v));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.h, N, cell_x, cell_y, time, h));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.u, N, cell_x, cell_y, time, u));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.v, N, cell_x, cell_y, time, v));
@@ -273,8 +273,8 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
   PetscInt N;
   PetscCall(RDyGetNumLocalCells(rdy, &N));
   PetscReal *cell_x, *cell_y;
-  PetscCall(PetscCalloc(N, &cell_x));
-  PetscCall(PetscCalloc(N, &cell_y));
+  PetscCall(PetscCalloc1(N, &cell_x));
+  PetscCall(PetscCalloc1(N, &cell_y));
 
   PetscInt l = 0;
   for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -877,14 +877,14 @@ PetscErrorCode PauseIfRequested(RDy rdy) {
       PetscFPrintf(rdy->comm, stderr, "Pausing... press Enter to resume.\n");
       if (rdy->nproc > 1) {
         pid_t *pids;
-        char *hostnames;
+        char  *hostnames;
         PetscCall(PetscCalloc1(rdy->nproc, &pids));
-        PetscCall(PetscCalloc1(rdy->nproc * (MAX_NAME_LEN+1), &hostnames));
+        PetscCall(PetscCalloc1(rdy->nproc * (MAX_NAME_LEN + 1), &hostnames));
         MPI_Gather(&pid, 1, MPI_INT, pids, 1, MPI_INT, 0, rdy->comm);
-        MPI_Gather(hostname, MAX_NAME_LEN+1, MPI_CHAR, hostnames, MAX_NAME_LEN+1, MPI_CHAR, 0, rdy->comm);
+        MPI_Gather(hostname, MAX_NAME_LEN + 1, MPI_CHAR, hostnames, MAX_NAME_LEN + 1, MPI_CHAR, 0, rdy->comm);
         PetscFPrintf(rdy->comm, stderr, "  PIDs (host):\n");
         for (PetscMPIInt p = 0; p < rdy->nproc; ++p) {
-          PetscFPrintf(rdy->comm, stderr, "    rank %d (%s): %d:\n", p, &hostnames[p * (MAX_NAME_LEN+1)], pids[p]);
+          PetscFPrintf(rdy->comm, stderr, "    rank %d (%s): %d:\n", p, &hostnames[p * (MAX_NAME_LEN + 1)], pids[p]);
         }
         PetscCall(PetscFree(pids));
         PetscCall(PetscFree(hostnames));

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -334,8 +334,7 @@ static PetscErrorCode CeedFindMaxCourantNumberInternalEdges(CeedOperator op_edge
   CeedVector courant_num_vec;
   PetscCallCEED(CeedOperatorFieldGetVector(courant_num, &courant_num_vec));
 
-  int num_comp = 2;  // values left and right of an edge
-  CeedScalar(*courant_num_data)[num_comp];
+  CeedScalar(*courant_num_data)[2]; // values to the left/right of an edge
   PetscCallCEED(CeedVectorGetArray(courant_num_vec, CEED_MEM_HOST, (CeedScalar **)&courant_num_data));
 
   // RDyMesh  *mesh  = &rdy->mesh;
@@ -361,7 +360,7 @@ static PetscErrorCode CeedFindMaxCourantNumberInternalEdges(CeedOperator op_edge
 /// @param [in] boundaries A RDyBoundary object
 /// @param [in] *max_courant_number Local maximum value of courant number
 /// @return 0 on sucess, or a non-zero error code on failure
-static PetscErrorCode CeedFindMaxCourantNumberBoundaryEdges(CeedOperator op_edges, PetscInt num_boundaries, RDyBoundary boundaries[num_boundaries],
+static PetscErrorCode CeedFindMaxCourantNumberBoundaryEdges(CeedOperator op_edges, PetscInt num_boundaries, RDyBoundary *boundaries,
                                                             PetscReal *max_courant_number) {
   PetscFunctionBegin;
 
@@ -381,8 +380,7 @@ static PetscErrorCode CeedFindMaxCourantNumberBoundaryEdges(CeedOperator op_edge
     // get access to the data
     CeedVector courant_num_vec;
     PetscCallCEED(CeedOperatorFieldGetVector(courant_num, &courant_num_vec));
-    int num_comp = 1;
-    CeedScalar(*courant_num_data)[num_comp];
+    CeedScalar(*courant_num_data)[1];
     PetscCallCEED(CeedVectorGetArray(courant_num_vec, CEED_MEM_HOST, (CeedScalar **)&courant_num_data));
 
     // find the maximum value
@@ -404,7 +402,7 @@ static PetscErrorCode CeedFindMaxCourantNumberBoundaryEdges(CeedOperator op_edge
 /// @param [in] comm A MPI_Comm object
 /// @param [out] *max_courant_number Global maximum value of courant number
 /// @return 0 on sucess, or a non-zero error code on failure
-static PetscErrorCode CeedFindMaxCourantNumber(CeedOperator op_edges, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary boundaries[num_boundaries],
+static PetscErrorCode CeedFindMaxCourantNumber(CeedOperator op_edges, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary *boundaries,
                                                MPI_Comm comm, PetscReal *max_courant_number) {
   PetscFunctionBegin;
 

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -334,7 +334,7 @@ static PetscErrorCode CeedFindMaxCourantNumberInternalEdges(CeedOperator op_edge
   CeedVector courant_num_vec;
   PetscCallCEED(CeedOperatorFieldGetVector(courant_num, &courant_num_vec));
 
-  CeedScalar(*courant_num_data)[2]; // values to the left/right of an edge
+  CeedScalar(*courant_num_data)[2];  // values to the left/right of an edge
   PetscCallCEED(CeedVectorGetArray(courant_num_vec, CEED_MEM_HOST, (CeedScalar **)&courant_num_data));
 
   // RDyMesh  *mesh  = &rdy->mesh;
@@ -402,8 +402,8 @@ static PetscErrorCode CeedFindMaxCourantNumberBoundaryEdges(CeedOperator op_edge
 /// @param [in] comm A MPI_Comm object
 /// @param [out] *max_courant_number Global maximum value of courant number
 /// @return 0 on sucess, or a non-zero error code on failure
-static PetscErrorCode CeedFindMaxCourantNumber(CeedOperator op_edges, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary *boundaries,
-                                               MPI_Comm comm, PetscReal *max_courant_number) {
+static PetscErrorCode CeedFindMaxCourantNumber(CeedOperator op_edges, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary *boundaries, MPI_Comm comm,
+                                               PetscReal *max_courant_number) {
   PetscFunctionBegin;
 
   PetscCall(CeedFindMaxCourantNumberInternalEdges(op_edges, mesh, max_courant_number));

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -5,7 +5,7 @@
 
 // this value stores the maximum number of components needed (between solution
 // vector components, source vector components, geometric components, etc)
-#define MAX_NUM_COMPONENTS 4
+#define MAX_NUM_COMPONENTS 4 // determined by num_comp_geom in CreateInteriorFluxOperator
 
 // frees a data context allocated using PETSc, returning a libCEED error code
 static int FreeContextPetsc(void *data) {

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -101,6 +101,14 @@ CEED_QFUNCTION_HELPER void SWERiemannFlux_Roe(const CeedScalar gravity, const Ce
   *amax = chat + fabs(uperp);
 }
 
+// The following Q functions use C99 VLA features for shaping multidimensional
+// arrays, which don't have the same drawbacks as VLA allocations.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
+
 CEED_QFUNCTION(SWEFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L, weight_R
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
@@ -274,5 +282,8 @@ CEED_QFUNCTION(SWESourceTerm)(void *ctx, CeedInt Q, const CeedScalar *const in[]
   }
   return 0;
 }
+
+#pragma GCC diagnostic   pop
+#pragma clang diagnostic pop
 
 #endif

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -5,11 +5,13 @@
 static PetscErrorCode GatherBoundaryFluxMetadata(RDy rdy) {
   PetscFunctionBegin;
 
-  PetscInt num_md = 3;
+  // allocate storage for local metadata
+  PetscInt  num_md          = 3;
+  PetscInt  num_local_edges = rdy->time_series.boundary_fluxes.num_local_edges[rdy->rank];
+  PetscInt *local_flux_md;
+  PetscCall(PetscCalloc(num_md * num_local_edges + 1, &local_flux_md));
 
   // gather local metadata
-  PetscInt num_local_edges = rdy->time_series.boundary_fluxes.num_local_edges[rdy->rank];
-  PetscInt local_flux_md[num_md * num_local_edges + 1];
   PetscInt n = 0;
   for (PetscInt b = 0; b < rdy->num_boundaries; ++b) {
     RDyCondition bc = rdy->boundary_conditions[b];
@@ -30,12 +32,13 @@ static PetscErrorCode GatherBoundaryFluxMetadata(RDy rdy) {
 
   // gather it on the root process (rank 0)
   if (rdy->rank == 0) {
-    PetscMPIInt *global_flux_md;
+    PetscMPIInt *global_flux_md, *n_recv_counts, *n_recv_displs;
     PetscInt     num_global_edges = rdy->time_series.boundary_fluxes.num_global_edges;
     PetscCall(PetscCalloc1(num_md * num_global_edges, &global_flux_md));
+    PetscCall(PetscCalloc1(rdy->nproc, &n_recv_counts));
+    PetscCall(PetscCalloc1(rdy->nproc + 1, &n_recv_displs));
 
     // local -> global flux metadata
-    PetscMPIInt n_recv_counts[rdy->nproc], n_recv_displs[rdy->nproc + 1];
     n_recv_displs[0] = 0;
     for (PetscInt p = 0; p < rdy->nproc; ++p) {
       n_recv_counts[p]     = num_md * rdy->time_series.boundary_fluxes.num_local_edges[p];
@@ -46,11 +49,15 @@ static PetscErrorCode GatherBoundaryFluxMetadata(RDy rdy) {
     for (PetscInt i = 0; i < num_md * num_global_edges; ++i) {
       rdy->time_series.boundary_fluxes.global_flux_md[i] = (PetscInt)global_flux_md[i];
     }
-    PetscFree(global_flux_md);
+    PetscCall(PetscFree(global_flux_md));
+    PetscCall(PetscFree(n_recv_counts));
+    PetscCall(PetscFree(n_recv_displs));
   } else {
     // send the root proc the local flux metadata
     MPI_Gatherv(local_flux_md, num_md * num_local_edges, MPI_INT, NULL, NULL, NULL, MPI_INT, 0, rdy->comm);
   }
+
+  PetscCall(PetscFree(local_flux_md));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -85,12 +92,14 @@ static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
   }
 
   // gather per-process numbers of local boundary edges
-  PetscMPIInt num_local_edges[rdy->nproc];
+  PetscMPIInt *num_local_edges;
+  PetscCall(PetscCalloc1(rdy->nproc, &num_local_edges));
   MPI_Allgather(&num_boundary_edges, 1, MPI_INT, num_local_edges, 1, MPI_INT, rdy->comm);
   PetscCall(PetscCalloc1(rdy->nproc, &rdy->time_series.boundary_fluxes.num_local_edges));
   for (PetscInt p = 0; p < rdy->nproc; ++p) {
     rdy->time_series.boundary_fluxes.num_local_edges[p] = (PetscInt)num_local_edges[p];
   }
+  PetscCall(PetscFree(num_local_edges));
 
   // determine the global number of boundary edges
   MPI_Allreduce(&num_boundary_edges, &rdy->time_series.boundary_fluxes.num_global_edges, 1, MPI_INT, MPI_SUM, rdy->comm);
@@ -151,8 +160,9 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
   // flux data itself (mass, x-momentum, y-momentum, edge x normal, edge y normal)
   // (add a padding byte to the end to prevent a 0-length VLA in case we don't
   // have any local boundary edges)
-  PetscInt  num_data = 5;
-  PetscReal local_flux_data[num_data * num_local_edges + 1];
+  PetscInt   num_data = 5;
+  PetscReal *local_flux_data;
+  PetscCall(PetscCalloc1(num_data * num_local_edges + 1, &local_flux_data));
 
   // gather local data
   PetscInt n = 0;
@@ -179,16 +189,22 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
   // gather local data into global arrays on the root process and
   // write them out
   if (rdy->rank == 0) {
-    int         num_md         = 3;
-    PetscInt   *global_flux_md = rdy->time_series.boundary_fluxes.global_flux_md;
-    PetscMPIInt n_recv_counts[rdy->nproc], n_recv_displs[rdy->nproc + 1];
+    int          num_md         = 3;
+    PetscInt    *global_flux_md = rdy->time_series.boundary_fluxes.global_flux_md;
+    PetscMPIInt *n_recv_counts, *n_recv_displs;
+    PetscCall(PetscCalloc1(rdy->nproc, &n_recv_counts));
+    PetscCall(PetscCalloc1(rdy->nproc + 1, &n_recv_displs));
+
     n_recv_displs[0] = 0;
     for (PetscInt p = 0; p < rdy->nproc; ++p) {
       n_recv_counts[p]     = num_data * rdy->time_series.boundary_fluxes.num_local_edges[p];
       n_recv_displs[p + 1] = n_recv_displs[p] + n_recv_counts[p];
     }
-    PetscReal global_flux_data[num_data * num_global_edges];
+    PetscReal *global_flux_data;
+    PetscCall(PetscCalloc1(num_data * num_global_edges, &global_flux_data));
     MPI_Gatherv(local_flux_data, num_data * num_local_edges, MPI_DOUBLE, global_flux_data, n_recv_counts, n_recv_displs, MPI_DOUBLE, 0, rdy->comm);
+    PetscCall(PetscFree(n_recv_counts));
+    PetscCall(PetscFree(n_recv_displs));
 
     // append the data to the boundary fluxes file (or, if this is our first
     // step, overwrite the existing file)
@@ -216,6 +232,7 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
       PetscCall(PetscFPrintf(rdy->comm, fp, "%e\t%" PetscInt_FMT "\t%" PetscInt_FMT "\t%" PetscInt_FMT "\t%e\t%e\t%e\t%e\t%e\n", time, global_edge_id,
                              boundary_id, bc_type, water_mass, x_momentum, y_momentum, x_normal, y_normal));
     }
+    PetscCall(PetscFree(global_flux_data));
     PetscCall(PetscFClose(rdy->comm, fp));
   } else {
     // send the root proc the local flux data
@@ -248,7 +265,7 @@ static PetscErrorCode FetchCeedBoundaryFluxes(RDy rdy) {
     CeedVector bflux_vec;
     PetscCallCEED(CeedOperatorFieldGetVector(bflux, &bflux_vec));
     int num_comp = 3;  // SWE
-    CeedScalar(*bflux_data)[num_comp];
+    CeedScalar(*bflux_data)[3];
     PetscCallCEED(CeedVectorGetArray(bflux_vec, CEED_MEM_HOST, (CeedScalar **)&bflux_data));
 
     // hand over the boundary fluxes and zero the flux vector

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -9,7 +9,7 @@ static PetscErrorCode GatherBoundaryFluxMetadata(RDy rdy) {
   PetscInt  num_md          = 3;
   PetscInt  num_local_edges = rdy->time_series.boundary_fluxes.num_local_edges[rdy->rank];
   PetscInt *local_flux_md;
-  PetscCall(PetscCalloc(num_md * num_local_edges + 1, &local_flux_md));
+  PetscCall(PetscCalloc1(num_md * num_local_edges + 1, &local_flux_md));
 
   // gather local metadata
   PetscInt n = 0;
@@ -238,6 +238,7 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
     // send the root proc the local flux data
     MPI_Gatherv(local_flux_data, num_data * num_local_edges, MPI_DOUBLE, NULL, NULL, NULL, MPI_DOUBLE, 0, rdy->comm);
   }
+  PetscCall(PetscFree(local_flux_data));
 
   // zero the boundary fluxes so they can begin reaccumulating
   // NOTE that there are 3 fluxes (and not 5)


### PR DESCRIPTION
This PR adds compiler flags that disallow C99 VLA code and gets rid of VLA declarations in function declarations, as well as all VLA allocations.

We can go back and add in VLA multidimensional array casting where needed with pragmas (see, for example, `swe_ceed.c`).

Closes #214