### PR TITLE
Updates models for Frontier

### DIFF
--- a/config/modules.frontier.gnugpu
+++ b/config/modules.frontier.gnugpu
@@ -1,6 +1,6 @@
 module purge
 module load craype-x86-trento
-module load libfabric/1.15.2.0
+module load libfabric/1.20.1
 module load craype-network-ofi
 module load perftools-base/23.12.0
 module load xpmem/2.8.4-1.0_7.3__ga37cbd9.shasta
@@ -16,7 +16,6 @@ module load PrgEnv-gnu/8.5.0
 module load cray-mpich/8.1.28
 module load craype-accel-amd-gfx90a
 module load rocm/5.4.0
-module load cray-python/3.9.13.1
 module load subversion/1.14.1
 module load git/2.36.1
 module load cmake/3.21.3


### PR DESCRIPTION
- Upgrades the version of `libfabric` module
- Removes `cray-python` module to avoid error related to missing `GLIBCXX_3.4.31` and `GLIBCXX_3.4.32`.