### PR TITLE
Adds support for Compy

### DIFF
--- a/config/install.compy.intel.debug.32bit.sh
+++ b/config/install.compy.intel.debug.32bit.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# source modules.compy.intel
+
+./configure \
+--with-mpi-dir=/share/apps/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64 \
+--with-netcdf-dir=/share/apps/netcdf/4.6.3/intel/20.0.0 \
+--with-pnetcdf-dir=/share/apps/pnetcdf/1.9.0/intel/20.0.0/intelmpi/2020 \
+--with-hdf5-dir=/share/apps/hdf5/1.10.5/serial/ \
+--with-fortran-bindings=1 \
+--download-kokkos \
+--download-kokkos-kernels \
+--with-kokkos-kernels-tpl=0 \
+--with-make-np=8 \
+--with-64-bit-indices=0 \
+--download-hypre=yes \
+--download-mumps=yes \
+--download-blas=yes \
+--download-lapack=yes \
+--download-fblaslapack=yes \
+--download-parmetis \
+--download-metis \
+--download-muparser \
+--download-zlib \
+--download-scalapack \
+--download-sowing \
+--download-triangle \
+--download-exodusii \
+--download-libceed \
+--download-cgns-commit=HEAD \
+--with-debugging=0 \
+PETSC_ARCH=opt-32bit-v3.22.0
+

--- a/config/install.compy.intel.debug.64bit.sh
+++ b/config/install.compy.intel.debug.64bit.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# source modules.compy.intel
+
+./configure \
+--with-mpi-dir=/share/apps/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64 \
+--with-netcdf-dir=/share/apps/netcdf/4.6.3/intel/20.0.0 \
+--with-pnetcdf-dir=/share/apps/pnetcdf/1.9.0/intel/20.0.0/intelmpi/2020 \
+--with-hdf5-dir=/share/apps/hdf5/1.10.5/serial/ \
+--with-fortran-bindings=1 \
+--download-kokkos \
+--download-kokkos-kernels \
+--with-kokkos-kernels-tpl=0 \
+--with-make-np=8 \
+--with-64-bit-indices=1 \
+--download-hypre=yes \
+--download-mumps=yes \
+--download-blas=yes \
+--download-lapack=yes \
+--download-fblaslapack=yes \
+--download-parmetis \
+--download-metis \
+--download-muparser \
+--download-zlib \
+--download-scalapack \
+--download-sowing \
+--download-triangle \
+--download-exodusii \
+--download-libceed \
+--download-cgns-commit=HEAD \
+--with-debugging=1 \
+PETSC_ARCH=opt-64bit-v3.22.0
+

--- a/config/install.compy.intel.opt.32bit.sh
+++ b/config/install.compy.intel.opt.32bit.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# source modules.compy.intel
+
+./configure \
+--with-mpi-dir=/share/apps/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64 \
+--with-netcdf-dir=/share/apps/netcdf/4.6.3/intel/20.0.0 \
+--with-pnetcdf-dir=/share/apps/pnetcdf/1.9.0/intel/20.0.0/intelmpi/2020 \
+--with-hdf5-dir=/share/apps/hdf5/1.10.5/serial/ \
+--with-fortran-bindings=1 \
+--download-kokkos \
+--download-kokkos-kernels \
+--with-kokkos-kernels-tpl=0 \
+--with-make-np=8 \
+--with-64-bit-indices=0 \
+--download-hypre=yes \
+--download-mumps=yes \
+--download-blas=yes \
+--download-lapack=yes \
+--download-fblaslapack=yes \
+--download-parmetis \
+--download-metis \
+--download-muparser \
+--download-zlib \
+--download-scalapack \
+--download-sowing \
+--download-triangle \
+--download-exodusii \
+--download-libceed \
+--download-cgns-commit=HEAD \
+--with-debugging=0 \
+PETSC_ARCH=opt-32bit-v3.22.0
+

--- a/config/install.compy.intel.opt.64bit.sh
+++ b/config/install.compy.intel.opt.64bit.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# source modules.compy.intel
+
+./configure \
+--with-mpi-dir=/share/apps/intel/2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64 \
+--with-netcdf-dir=/share/apps/netcdf/4.6.3/intel/20.0.0 \
+--with-pnetcdf-dir=/share/apps/pnetcdf/1.9.0/intel/20.0.0/intelmpi/2020 \
+--with-hdf5-dir=/share/apps/hdf5/1.10.5/serial/ \
+--with-fortran-bindings=1 \
+--download-kokkos \
+--download-kokkos-kernels \
+--with-kokkos-kernels-tpl=0 \
+--with-make-np=8 \
+--with-64-bit-indices=1 \
+--download-hypre=yes \
+--download-mumps=yes \
+--download-blas=yes \
+--download-lapack=yes \
+--download-fblaslapack=yes \
+--download-parmetis \
+--download-metis \
+--download-muparser \
+--download-zlib \
+--download-scalapack \
+--download-sowing \
+--download-triangle \
+--download-exodusii \
+--download-libceed \
+--download-cgns-commit=HEAD \
+--with-debugging=0 \
+PETSC_ARCH=opt-64bit-v3.22.0
+

--- a/config/modules.compy.intel
+++ b/config/modules.compy.intel
@@ -1,0 +1,6 @@
+# Oct-9-2024
+module purge
+
+module load gcc/8.1.0 intel/20.0.0 intelmpi/2020 mkl/2019u5 cmake/3.26.0
+export LD_LIBRARY_PATH=/share/apps/gcc/8.1.0/lib:/share/apps/gcc/8.1.0/lib64:$LD_LIBRARY_PATH
+

--- a/config/set_petsc_settings.sh
+++ b/config/set_petsc_settings.sh
@@ -27,6 +27,9 @@ display_help() {
     echo "  --config 1: Without debugging, 64bit indices, and HDF5 1.14.3"
     echo "  --config 2: With debugging, 64bit indices, and HDF5 1.14.3"
     echo "  --config 3: Without debugging, 32bit indices, and HDF5 1.12.2.1"
+    echo
+    echo "For Compy (--mach compy): "
+    echo "  --config 3: Without debugging, 32bit indices, and HDF5 1.10.5"
     echo "++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++"
     echo
 
@@ -115,6 +118,18 @@ elif [ "$mach" = "frontier"  ]; then
 #    fi
 #  fi
 #
+
+elif [ "$mach" = "compy" ]; then
+   MODULE_FILE=$DIR/modules.compy.intel
+   export PETSC_DIR=/compyfs/bish218/rdycore/shared/petsc
+   if [ "$config" -eq 3 ]; then
+     export PETSC_ARCH=opt-32bit-v3.22.0
+   else
+     echo "Unsupported config for Compy"
+     display_help
+     exit
+   fi
+
 else
   echo "Could not determine the machine. mach=$mach"
   display_help


### PR DESCRIPTION
Here are the instructions to run RDycore on Compy

```
# Clone the repo and checkout the branch
git clone git@github.com:rdycore/rdycore
cd rdycore
git submodule update --init

# Load the correct module and set PETSc environment variables
source config/set_petsc_settings.sh --mach compy --config 3

# Build RDycore
mkdir build-$PETSC_ARCH
cd build-$PETSC_ARCH

cmake .. -DCMAKE_INSTALL_PREFIX=$PWD -DCMAKE_BUILD_TYPE=Debug
make -j4 install

# Let's get an interactive job
srun --pty --nodes=1 --time=1:00:00 --account=esmd /bin/bash

# Now, we'll run few cases
cd driver/tests/swe_roe/

# Run non-libCEED version of RDycore
srun -n 1 ../../rdycore ex2b.yaml -log_view

# Run libCEED version of RDycore
srun -n 1 ../../rdycore ex2b.yaml -ceed /cpu/self -log_view
```

Side note: The way to tell if libCEED was used or not is to look at entries under `--- Event Stage 1: RDyAdvance solve` that are dumped out on screen and check if `CeedOperatorApp` is listed or not:

```
--- Event Stage 1: RDyAdvance solve
...
...
...
CeedOperatorApp     2000 1.0 4.3021e-02 1.0 0.00e+00 0.0 0.0e+00 0.0e+00 0.0e+00  4  0  0  0  0   4  0  0  0  0     0       0      0 0.00e+00    0 0.00e+00  0
...

```