### PR TITLE
Operator refactor part 1: renaming and regrouping

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,10 @@ elseif (CMAKE_C_COMPILER_ID MATCHES "Clang")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ferror-limit=10")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=vla")
-
-  # emit compile_commands.json for use with clangd
-  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
+
+# emit compile_commands.json for use with clangd
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Set linker flags where appropriate
 if (APPLE)

--- a/docs/theory/sediment.md
+++ b/docs/theory/sediment.md
@@ -15,7 +15,7 @@ Each sediment concentration $c_p$ evolves in time according to its own transport
 equation
 
 \begin{equation}
-\frac{\partial (hc)_{i}}{\partial t} + \nabla\cdot(h c_p \vec{u}) = e_p + e_{rp} + r_p + r_{rp} - d_p \tag{1}\label{1}
+\frac{\partial (hc)_p}{\partial t} + \nabla\cdot(h c_p \vec{u}) = e_p + e_{rp} + r_p + r_{rp} - d_p \tag{1}\label{1}
 \end{equation}
 
 where
@@ -41,7 +41,7 @@ All size classes deposit their layers to the bed floor, changing the bed
 elevation according to the ordinary differential equation
 
 \begin{equation}
-(1-\beta)\rho_{s}\frac{\partial z}{\partial t} = \sum_{i=1}^{I}(d_p - e_p - e_{rp} - r_p - r_{rp})\tag{3}\label{3}
+(1-\beta)\rho_{s}\frac{\partial z}{\partial t} = \sum_{p=1}^{P}(d_p - e_p - e_{rp} - r_p - r_{rp})\tag{3}\label{3}
 \end{equation}
 
 where 
@@ -98,8 +98,8 @@ clay and 1.13 for loam.
 #### Overland flow-driven entrainment and re-entrainment rates
 
 \begin{eqnarray}
-r_p &=& (1-H)p_{i}\frac{F(\Omega-\Omega_{cr})}{J} \\
-r_{rp} &=& H\frac{M_{i}}{M_{t}}\frac{F(\Omega - \Omega_{cr})}{(\rho_{s}-\rho_{w})gh/\rho_{s}} \tag{6}\label{6}
+r_p &=& (1-H)f_p}\frac{F(\Omega-\Omega_{cr})}{J} \\
+r_{rp} &=& H\frac{M_p}{M_{t}}\frac{F(\Omega - \Omega_{cr})}{(\rho_{s}-\rho_{w})gh/\rho_{s}} \tag{6}\label{6}
 \end{eqnarray}
 
 where
@@ -117,7 +117,7 @@ where
 #### Size class deposition rate
 
 \begin{equation}
-d_p = v_p c_{i} \tag{7}\label{7}
+d_p = v_p c_p \tag{7}\label{7}
 \end{equation}
 
 where $v_p$ is the _settling velocity_ of each size class with concentration
@@ -140,7 +140,7 @@ sediment size-class concentrations:
     vh     \\
     c_1 h \\
     \vdots \\
-    c_I h
+    c_P h
   \end{bmatrix}.
 \end{align}
 
@@ -156,7 +156,7 @@ equations:
     u v h                     \\
     c_1 u h                   \\
     \vdots                    \\
-    c_I u h
+    c_P u h
   \end{bmatrix},
 \end{align}
 
@@ -168,12 +168,12 @@ equations:
     v^2 h + \frac{1}{2} g h^2 \\
     c_1 v h                   \\
     \vdots                    \\
-    c_I v h
+    c_P v h
   \end{bmatrix}.
 \end{align}
 
-We also augment the shallow water equation source vector $\mathbf{S}$ with
-the (re)attachment, (re)entrainment, and deposition terms:
+Additionally, we augment the shallow water equation source vector $\mathbf{S}$
+with the (re)attachment, (re)entrainment, and deposition terms:
 
 \begin{align}
 \mathbf{S} =
@@ -181,9 +181,9 @@ the (re)attachment, (re)entrainment, and deposition terms:
     Q
     -g h\frac{\partial z}{\partial x} - C_D u\sqrt{u^2 + v^2} \\[.5em]
     -g h\frac{\partial z}{\partial y} - C_D v\sqrt{u^2 + v^2} \\
-    e_1 + e_{r1} + r_1 + r_{r1} - d_{1}                                 \\
+    e_1 + e_{r1} + r_1 + r_{r1} - d_1                                 \\
     \vdots                                                          \\
-    e_I + e_{rI} + r_I + r_{rI} - d_I 
+    e_P + e_{rP} + r_P + r_{rP} - d_P
   \end{bmatrix}.
 \end{align}
 
@@ -194,18 +194,18 @@ _deposited mass vector_ $\mathbf{M}$ and a _net deposition vector_ $\mathbf{D}$:
 \begin{align}
 \mathbf{M} =
   \begin{bmatrix}
-    M_{1}    \\[.5em]
+    M_1    \\[.5em]
     \vdots   \\
-    M_{I} 
+    M_P
   \end{bmatrix},
 \end{align}
 
 \begin{align}
 \mathbf{D} =
   \begin{bmatrix}
-    d_{1}-e_{r1}-r_{r1} \\[.5em]
+    d_1-e_{r1}-r_{r1} \\[.5em]
     \vdots              \\
-    d_{I}-e_{rI}-r_{rI}  
+    d_P-e_{rI}-r_{rP}
   \end{bmatrix}.
 \end{align}
 
@@ -269,9 +269,9 @@ from the $x$ axis, the normal flux is
     hu_{\parallel}                                                                  \\[.5em]
     huu_{\parallel} + \frac{1}{2}gh^{2}cos \phi + \frac{1}{24}g\Delta h^{2}cos \phi \\
     hvu_{\parallel} + \frac{1}{2}gh^{2}sin \phi + \frac{1}{24}g\Delta h^{2}sin \phi \\
-    hc_{1}u_{\parallel}                                                             \\
+    hc_1 u_{\parallel}                                                             \\
     \vdots                                                                          \\
-    hc_{I}u_{\parallel}                                                             \\
+    hc_P u_{\parallel}                                                             \\
   \end{bmatrix}\tag{11}\label{11}.
 \end{align}
 
@@ -282,14 +282,14 @@ balance the bed slope terms for the still water condition.
 The fluxes at the interface between cells can be approximated with Roe's method:
 
 \begin{equation}
-\mathbf{F} \cdot \mathbf{n} \approx \mathbf{F}_{\parallel,f} = 
+\mathbf{F} \cdot \mathbf{n} \approx \mathbf{F}_{\parallel,f} =
 \frac{1}{2} \left(\mathbf{F}_{\parallel,L} + \mathbf{F}_{\parallel,R}-\mathbf{\hat{R}} |\mathbf{\hat{\Lambda}}| \mathbf{\Delta\hat{V}} \right)
 \end{equation}
 
 where the subscript $f$ annotates the interface between two adjacent cells,
 $L$ and $R$ indicate the "left" and "right" states for the interface, and
 $\Delta$ denotes the difference in quantities across the interface. The terms
-$\mathbf{\hat{R}}$ and $\mathbf{\hat{\Lambda}}$ are the right eigenvector and the 
+$\mathbf{\hat{R}}$ and $\mathbf{\hat{\Lambda}}$ are the right eigenvector and the
 eigenvalue of the Jacobian of $\mathbf{F}_{\parallel}$, and
 $\mathbf{\Delta}\mathbf{\hat{V}}=\hat{L}\Delta U$ denotes the wave strength,
 with $\hat{L}$ the left eigenvector of the Jacobian of $\mathbf{F}_{\parallel}$.
@@ -300,9 +300,9 @@ with $\hat{L}$ the left eigenvector of the Jacobian of $\mathbf{F}_{\parallel}$.
     1                         & 0           & 1                         & 0      & \ldots & 0      \\
     \hat{u}-\hat{a}cos \theta & -sin \theta & \hat{u}+\hat{a}cos \theta & 0      & \ldots & 0      \\
     \hat{v}-\hat{a}sin \theta &  cos \theta & \hat{v}+\hat{a}sin \theta & 0      & \ldots & 0      \\
-    \hat{c_{1}}               & 0           & \hat{c_{1}}               & 1      & \ldots & 0      \\
+    \hat{c_1}               & 0           & \hat{c_1}               & 1      & \ldots & 0      \\
     \vdots                    & \vdots      & \vdots                    & \vdots & \ddots & \vdots \\ 
-    \hat{c_{I}}               & 0           & \hat{c_{I}}               & 0      & \ldots & 1      \\
+    \hat{c_P}               & 0           & \hat{c_P}               & 0      & \ldots & 1      \\
   \end{bmatrix}
 \end{align}
 
@@ -324,9 +324,9 @@ with $\hat{L}$ the left eigenvector of the Jacobian of $\mathbf{F}_{\parallel}$.
     \frac{1}{2} \left( \Delta h - \frac{\hat{h}\Delta u_\perp}{\hat{a}} \right) \\[.5em]
     \hat{h}u_\perp                                                          \\[.5em]
     \frac{1}{2} \left( \Delta h + \frac{\hat{h}\Delta u_\perp}{\hat{a}} \right) \\[.5em]
-    (c_{1}h)_{R} - (c_{1}h)_{L} - \hat{c_{1}}(h_{R}-h_{L})                      \\[.5em]
+    (c_1 h)_{R} - (c_1 h)_{L} - \hat{c_1}(h_{R}-h_{L})                      \\[.5em]
     \vdots                                                                      \\[.5em]
-    (c_{I}h)_{R} - (c_{I}h)_{L} - \hat{c_{I}}(h_{R}-h_{L})                      \\[.5em]
+    (c_P h)_{R} - (c_P h)_{L} - \hat{c_P}(h_{R}-h_{L})                      \\[.5em]
   \end{bmatrix}
 \end{align}
 
@@ -343,16 +343,16 @@ The quantities with a hat are Roe averages, which are calculated thus:
 \hat{u}   &=& \frac{\sqrt{h_L}u_L + \sqrt{h_R}u_R}{\sqrt{h_L}+\sqrt{h_R}} \\
 \hat{v}   &=& \frac{\sqrt{h_L}v_L + \sqrt{h_R}v_R}{\sqrt{h_L}+\sqrt{h_R}} \\
 \hat{a}   &=& \sqrt{\frac{g}{2}(h_L + h_R)}                               \\
-\hat{c_i} &=& \frac{\sqrt{h_L}c_{i,L}+\sqrt{h_R} c_{i,R}}{\sqrt{h_L}+\sqrt{h_R}} 
+\hat{c_i} &=& \frac{\sqrt{h_L}c_{i,L}+\sqrt{h_R} c_{i,R}}{\sqrt{h_L}+\sqrt{h_R}}
 \end{eqnarray}
 
-The asterisks indicate that the eigenvalues $\hat{\lambda}_{1}=\hat{u}_{\parallel}-\hat{a}$
-and $\hat{\lambda}_{3}=\hat{u}_{\parallel}+\hat{a}$ are adjusted because Roe's 
+The asterisks indicate that the eigenvalues $\hat{\lambda}_1=\hat{u}_{\parallel}-\hat{a}$
+and $\hat{\lambda}_{3}=\hat{u}_{\parallel}+\hat{a}$ are adjusted because Roe's
 method does not provide correct fluxes for critical flow:
 
 \begin{equation}
-|\hat{\lambda}_{1}|^{*} = \frac{\hat{\lambda}_{1}^{2}}{\Delta \lambda} + \frac{\Delta \lambda}{4}
-\quad if \quad -\Delta \lambda /2 < \hat{\lambda}_{1} < \Delta \lambda /2
+|\hat{\lambda}_1|^{*} = \frac{\hat{\lambda}_1^{2}}{\Delta \lambda} + \frac{\Delta \lambda}{4}
+\quad if \quad -\Delta \lambda /2 < \hat{\lambda}_1 < \Delta \lambda /2
 \end{equation}
 
 \begin{equation}

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -176,22 +176,20 @@ struct _p_RDy {
 
   // CEED (device) solver data
   struct {
-    // CEED context and resource name
-    Ceed context;
+    // CEED resource name -- used to determine the backend
     char resource[PETSC_MAX_PATH_LEN];
 
-    // CEED (composite) operators for fluxes and sources
+    Ceed context;
+
     CeedOperator flux_operator;
     CeedOperator source_operator;
 
-    // on-device vectors
     CeedVector u_local;
     CeedVector rhs, sources;
 
     CeedScalar dt;
 
-    // host vector storing fluxes
-    Vec host_fluxes;
+    Vec host_fluxes;  // edge fluxes copied to host for diagnostics
   } ceed;
 
   // PETSc (host) solver data

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -171,8 +171,8 @@ struct _p_RDy {
   // host solution vectors (global and local)
   Vec u_global, u_local;
 
-  // host residual vector
-  Vec residual;
+  // host right-hand-side (residual) vector
+  Vec rhs;
 
   // CEED (device) solver data
   struct {

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -27,6 +27,8 @@ typedef struct {
   RiemannDataSWE      data_cells;
 } PetscRiemannDataSWE;
 
+PETSC_INTERN PetscErrorCode InitSWE(RDy);
+
 PETSC_INTERN PetscErrorCode CreateSWEFluxOperator(Ceed, RDyMesh *, CeedInt n, RDyBoundary *, RDyCondition *, PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorSetTimeStep(CeedOperator, PetscReal);
 PETSC_INTERN PetscErrorCode SWEFluxOperatorGetBoundaryFlux(CeedOperator, RDyBoundary, CeedOperatorField *);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ add_library(rdycore
   rdymesh.c
   rdymms.c
   rdysetup.c
+  solvers.c
   swe/physics_swe.c
   swe/swe_petsc.c
   swe/swe_ceed.c

--- a/src/checkpoint.c
+++ b/src/checkpoint.c
@@ -240,13 +240,13 @@ PetscErrorCode ReadCheckpointFile(RDy rdy, const char *filename) {
 #if PETSCBAG_DOESNT_SUPPORT_HDF5
   }
 #endif
-  PetscCall(PetscObjectSetName((PetscObject)rdy->X, "solution"));
-  PetscCall(VecLoad(rdy->X, viewer));
+  PetscCall(PetscObjectSetName((PetscObject)rdy->u_global, "solution"));
+  PetscCall(VecLoad(rdy->u_global, viewer));
   PetscCall(PetscViewerDestroy(&viewer));
   RDyLogInfo(rdy, "Finished reading checkpoint file.");
 
   // read the newly loaded solution vector into the timestepper
-  PetscCall(TSSetSolution(rdy->ts, rdy->X));
+  PetscCall(TSSetSolution(rdy->ts, rdy->u_global));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -213,16 +213,16 @@ static PetscErrorCode CalibrateSolverTimers(RDy rdy) {
   RDyLogDebug(rdy, "Performing preload calibration...");
 
   // create a "preload" solution so we can advance one step
-  Vec X_preload;
-  PetscCall(VecDuplicate(rdy->X, &X_preload));
-  PetscCall(VecCopy(rdy->X, X_preload));
+  Vec u_preload;
+  PetscCall(VecDuplicate(rdy->u_global, &u_preload));
+  PetscCall(VecCopy(rdy->u_global, u_preload));
 
   // take a single internal step to warm up the cache
-  PetscCall(TSSetSolution(rdy->ts, X_preload));
+  PetscCall(TSSetSolution(rdy->ts, u_preload));
   PetscCall(TSStep(rdy->ts));
 
   // clean up
-  PetscCall(VecDestroy(&X_preload));
+  PetscCall(VecDestroy(&u_preload));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -301,7 +301,7 @@ PetscErrorCode RDyAdvance(RDy rdy) {
   PetscCall(TSSetMaxTime(rdy->ts, next_coupling_time));
   PetscCall(TSSetExactFinalTime(rdy->ts, TS_EXACTFINALTIME_MATCHSTEP));
   PetscCall(TSSetTimeStep(rdy->ts, rdy->dt));
-  PetscCall(TSSetSolution(rdy->ts, rdy->X));
+  PetscCall(TSSetSolution(rdy->ts, rdy->u_global));
 
   CourantNumberDiagnostics *courant_num_diags = &rdy->courant_num_diags;
   courant_num_diags->is_set                   = PETSC_FALSE;
@@ -313,7 +313,7 @@ PetscErrorCode RDyAdvance(RDy rdy) {
     PetscCall(TSSetTime(rdy->ts, time));
     PetscCall(TSSetStepNumber(rdy->ts, step));
   } else {
-    PetscCall(TSSolve(rdy->ts, rdy->X));
+    PetscCall(TSSolve(rdy->ts, rdy->u_global));
   }
   PetscPreLoadEnd();
 

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -154,7 +154,7 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
 
   // destroy vectors
   if ((*rdy)->petsc.sources) VecDestroy(&((*rdy)->petsc.sources));
-  if ((*rdy)->residual) VecDestroy(&((*rdy)->residual));
+  if ((*rdy)->rhs) VecDestroy(&((*rdy)->rhs));
   if ((*rdy)->u_global) VecDestroy(&((*rdy)->u_global));
   if ((*rdy)->u_local) VecDestroy(&((*rdy)->u_local));
 

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -167,6 +167,11 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   if ((*rdy)->aux_dm) DMDestroy(&((*rdy)->aux_dm));
   if ((*rdy)->dm) DMDestroy(&((*rdy)->dm));
 
+  // destroy our CEED context as needed
+  if ((*rdy)->ceed.resource[0]) {
+    PetscCallCEED(CeedDestroy(&((*rdy)->ceed.context)));
+  }
+
   // close the log file if needed
   if (((*rdy)->log) && ((*rdy)->log != stdout)) {
     PetscCall(PetscFClose((*rdy)->comm, (*rdy)->log));

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -86,13 +86,13 @@ PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_in
 
   // dispatch this call to CEED or PETSc
   PetscReal tiny_h = rdy->config.physics.flow.tiny_h;
-  if (rdy->ceed_resource[0]) {  // ceed
+  if (rdy->ceed.resource[0]) {  // ceed
     PetscInt size = ndof * num_edges;
-    PetscCall(SWEFluxOperatorSetDirichletBoundaryValues(rdy->ceed_rhs.op_edges, &rdy->mesh, rdy->boundaries[boundary_index], size, values));
+    PetscCall(SWEFluxOperatorSetDirichletBoundaryValues(rdy->ceed.flux_operator, &rdy->mesh, rdy->boundaries[boundary_index], size, values));
   } else {  // petsc
     // fetch the boundary data
     RiemannDataSWE bdata;
-    PetscCall(GetPetscSWEDirichletBoundaryValues(rdy->petsc_rhs, boundary_index, &bdata));
+    PetscCall(GetPetscSWEDirichletBoundaryValues(rdy->petsc.context, boundary_index, &bdata));
 
     // set the boundary values
     RDyCells *cells = &rdy->mesh.cells;
@@ -121,12 +121,12 @@ PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_in
 static PetscErrorCode RDyGetPrognosticVariableOfLocalCell(RDy rdy, PetscInt idof, PetscReal *values) {
   PetscFunctionBegin;
 
-  PetscReal *x;
-  PetscCall(VecGetArray(rdy->X, &x));
+  PetscReal *u;
+  PetscCall(VecGetArray(rdy->u_global, &u));
   for (PetscInt i = 0; i < rdy->mesh.num_owned_cells; ++i) {
-    values[i] = x[3 * i + idof];
+    values[i] = u[3 * i + idof];
   }
-  PetscCall(VecRestoreArray(rdy->X, &x));
+  PetscCall(VecRestoreArray(rdy->u_global, &u));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -181,11 +181,11 @@ PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, Pets
 
   PetscCall(CheckNumLocalCells(rdy, size));
 
-  if (rdy->ceed_resource[0]) {  // ceed
-    PetscCall(SWESourceOperatorSetWaterSource(rdy->ceed_rhs.op_src, values));
+  if (rdy->ceed.resource[0]) {  // ceed
+    PetscCall(SWESourceOperatorSetWaterSource(rdy->ceed.source_operator, values));
   } else {  // petsc
     PetscInt idof = 0;
-    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->swe_src, idof, values));
+    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->ceed.host_fluxes, idof, values));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -196,11 +196,11 @@ PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, 
 
   PetscCall(CheckNumLocalCells(rdy, size));
 
-  if (rdy->ceed_resource[0]) {
-    PetscCall(SWESourceOperatorSetXMomentumSource(rdy->ceed_rhs.op_src, values));
+  if (rdy->ceed.resource[0]) {
+    PetscCall(SWESourceOperatorSetXMomentumSource(rdy->ceed.flux_operator, values));
   } else {
     PetscInt idof = 1;
-    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->swe_src, idof, values));
+    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->petsc.sources, idof, values));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -210,11 +210,11 @@ PetscErrorCode RDySetYMomentumSourceForLocalCells(RDy rdy, const PetscInt size, 
 
   PetscCall(CheckNumLocalCells(rdy, size));
 
-  if (rdy->ceed_resource[0]) {
-    PetscCall(SWESourceOperatorSetYMomentumSource(rdy->ceed_rhs.op_src, values));
+  if (rdy->ceed.resource[0]) {
+    PetscCall(SWESourceOperatorSetYMomentumSource(rdy->ceed.source_operator, values));
   } else {
     PetscInt idof = 2;
-    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->swe_src, idof, values));
+    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->petsc.sources, idof, values));
   }
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -383,8 +383,8 @@ PetscErrorCode RDyGetLocalCellManningsNs(RDy rdy, const PetscInt size, PetscReal
 
   PetscCall(CheckNumLocalCells(rdy, size));
 
-  if (rdy->ceed_resource[0]) {  // ceed
-    PetscCall(SWESourceOperatorSetManningsN(rdy->ceed_rhs.op_src, n_values));
+  if (rdy->ceed.resource[0]) {  // ceed
+    PetscCall(SWESourceOperatorSetManningsN(rdy->ceed.source_operator, n_values));
   } else {  // petsc
     for (PetscInt icell = 0; icell < rdy->mesh.num_owned_cells; ++icell) {
       n_values[icell] = rdy->materials_by_cell[icell].manning;
@@ -399,8 +399,8 @@ PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscR
 
   PetscCall(CheckNumLocalCells(rdy, size));
 
-  if (rdy->ceed_resource[0]) {  // ceed
-    PetscCall(SWESourceOperatorSetManningsN(rdy->ceed_rhs.op_src, n_values));
+  if (rdy->ceed.resource[0]) {  // ceed
+    PetscCall(SWESourceOperatorSetManningsN(rdy->ceed.source_operator, n_values));
   } else {  // petsc
     for (PetscInt icell = 0; icell < rdy->mesh.num_owned_cells; ++icell) {
       rdy->materials_by_cell[icell].manning = n_values[icell];
@@ -412,13 +412,13 @@ PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscR
 
 PetscErrorCode RDySetInitialConditions(RDy rdy, Vec ic) {
   PetscFunctionBegin;
-  PetscCall(VecCopy(ic, rdy->X));
+  PetscCall(VecCopy(ic, rdy->u_global));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 PetscErrorCode RDyCreatePrognosticVec(RDy rdy, Vec *prog_vec) {
   PetscFunctionBegin;
-  PetscCall(VecDuplicate(rdy->X, prog_vec));
+  PetscCall(VecDuplicate(rdy->u_global, prog_vec));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -185,7 +185,7 @@ PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, Pets
     PetscCall(SWESourceOperatorSetWaterSource(rdy->ceed.source_operator, values));
   } else {  // petsc
     PetscInt idof = 0;
-    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->ceed.host_fluxes, idof, values));
+    PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->petsc.sources, idof, values));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -197,7 +197,7 @@ PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, 
   PetscCall(CheckNumLocalCells(rdy, size));
 
   if (rdy->ceed.resource[0]) {
-    PetscCall(SWESourceOperatorSetXMomentumSource(rdy->ceed.flux_operator, values));
+    PetscCall(SWESourceOperatorSetXMomentumSource(rdy->ceed.source_operator, values));
   } else {
     PetscInt idof = 1;
     PetscCall(RDySetSourceVecForLocalCells(rdy, rdy->petsc.sources, idof, values));

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -108,9 +108,9 @@ PetscErrorCode CreateDM(RDy rdy) {
   PetscCall(DMSetType(rdy->dm, DMPLEX));
 
   // if we're using CEED, set Vec and Mat types based on the selected backend
-  if (rdy->ceed_resource[0]) {
+  if (rdy->ceed.resource[0]) {
     CeedMemType mem_type_backend;
-    PetscCallCEED(CeedGetPreferredMemType(rdy->ceed, &mem_type_backend));
+    PetscCallCEED(CeedGetPreferredMemType(rdy->ceed.context, &mem_type_backend));
     VecType vec_type = NULL;
     switch (mem_type_backend) {
       case CEED_MEM_HOST:
@@ -118,7 +118,7 @@ PetscErrorCode CreateDM(RDy rdy) {
         break;
       case CEED_MEM_DEVICE: {
         const char *resolved;
-        PetscCallCEED(CeedGetResource(rdy->ceed, &resolved));
+        PetscCallCEED(CeedGetResource(rdy->ceed.context, &resolved));
         if (strstr(resolved, "/gpu/cuda")) vec_type = VECCUDA;
         else if (strstr(resolved, "/gpu/hip")) vec_type = VECKOKKOS;
         else if (strstr(resolved, "/gpu/sycl")) vec_type = VECKOKKOS;
@@ -237,11 +237,11 @@ PetscErrorCode CreateAuxiliaryDM(RDy rdy) {
 PetscErrorCode CreateVectors(RDy rdy) {
   PetscFunctionBegin;
 
-  PetscCall(DMCreateGlobalVector(rdy->dm, &rdy->X));
-  PetscCall(VecDuplicate(rdy->X, &rdy->R));
-  PetscCall(VecViewFromOptions(rdy->X, NULL, "-vec_view"));
-  PetscCall(VecDuplicate(rdy->X, &rdy->F_dup));
-  PetscCall(DMCreateLocalVector(rdy->dm, &rdy->X_local));
+  PetscCall(DMCreateGlobalVector(rdy->dm, &rdy->u_global));
+  PetscCall(VecDuplicate(rdy->u_global, &rdy->residual));
+  PetscCall(VecViewFromOptions(rdy->u_global, NULL, "-vec_view"));
+  PetscCall(VecDuplicate(rdy->u_global, &rdy->ceed.host_fluxes));
+  PetscCall(DMCreateLocalVector(rdy->dm, &rdy->u_local));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -238,7 +238,7 @@ PetscErrorCode CreateVectors(RDy rdy) {
   PetscFunctionBegin;
 
   PetscCall(DMCreateGlobalVector(rdy->dm, &rdy->u_global));
-  PetscCall(VecDuplicate(rdy->u_global, &rdy->residual));
+  PetscCall(VecDuplicate(rdy->u_global, &rdy->rhs));
   PetscCall(VecViewFromOptions(rdy->u_global, NULL, "-vec_view"));
   PetscCall(VecDuplicate(rdy->u_global, &rdy->ceed.host_fluxes));
   PetscCall(DMCreateLocalVector(rdy->dm, &rdy->u_local));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -473,13 +473,13 @@ PetscErrorCode InitBoundaries(RDy rdy) {
         RDySurfaceCompositionSpec surface_comp = rdy->config.surface_composition[isurf_comp];          \
         if (!strcmp(surface_comp.region, region.name)) {                                               \
           if (mat_prop_vec) {                                                                          \
-            PetscScalar *u_ptr;                                                                        \
-            PetscCall(VecGetArray(mat_prop_vec, &u_ptr));                                              \
+            PetscScalar *prop_ptr;                                                                     \
+            PetscCall(VecGetArray(mat_prop_vec, &prop_ptr));                                           \
             for (PetscInt c = 0; c < region.num_cells; ++c) {                                          \
               PetscInt cell                    = region.cell_ids[c];                                   \
-              materials_by_cell[cell].property = u_ptr[c];                                             \
+              materials_by_cell[cell].property = prop_ptr[c];                                          \
             }                                                                                          \
-            PetscCall(VecRestoreArray(mat_prop_vec, &u_ptr));                                          \
+            PetscCall(VecRestoreArray(mat_prop_vec, &prop_ptr));                                       \
           } else {                                                                                     \
             /* set this material property for all cells in each matching region */                     \
             for (PetscInt c = 0; c < region.num_cells; ++c) {                                          \
@@ -792,9 +792,9 @@ static PetscErrorCode InitSolution(RDy rdy) {
           for (PetscInt c = 0; c < region.num_cells; ++c) {
             PetscInt cell_id = region.cell_ids[c];
             if (ndof * cell_id < n_local) {  // skip ghost cells
-              u_ptr[3 * cell_id]     = mupEval(flow_ic.height);
-              u_ptr[3 * cell_id + 1] = mupEval(flow_ic.x_momentum);
-              u_ptr[3 * cell_id + 2] = mupEval(flow_ic.y_momentum);
+              u_ptr[ndof * cell_id]     = mupEval(flow_ic.height);
+              u_ptr[ndof * cell_id + 1] = mupEval(flow_ic.x_momentum);
+              u_ptr[ndof * cell_id + 2] = mupEval(flow_ic.y_momentum);
             }
           }
         }

--- a/src/solvers.c
+++ b/src/solvers.c
@@ -36,8 +36,8 @@ PetscErrorCode DestroySolvers(RDy rdy) {
     PetscCallCEED(CeedVectorDestroy(&rdy->ceed.u_local));
     PetscCallCEED(CeedVectorDestroy(&rdy->ceed.rhs));
     PetscCallCEED(CeedVectorDestroy(&rdy->ceed.sources));
-    PetscCallCEED(CeedDestroy(&(rdy->ceed.context)));
     if (rdy->ceed.host_fluxes) VecDestroy(&rdy->ceed.host_fluxes);
+    // the CEED context belongs to RDycore itself, so we don't delete it
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/solvers.c
+++ b/src/solvers.c
@@ -1,0 +1,44 @@
+#include <ceed/ceed.h>
+#include <petscdmceed.h>
+#include <private/rdysweimpl.h>
+
+// these are used to register CEED operator events for profiling
+static PetscClassId RDY_CLASSID;
+PetscLogEvent       RDY_CeedOperatorApply;
+
+/// Initializes solvers for physics specified in the input configuration.
+PetscErrorCode InitSolvers(RDy rdy) {
+  PetscFunctionBegin;
+
+  // register a logging event for applying our CEED operator
+  PetscCall(PetscClassIdRegister("RDycore", &RDY_CLASSID));
+  PetscCall(PetscLogEventRegister("CeedOperatorApp", RDY_CLASSID, &RDY_CeedOperatorApply));
+
+  // just pass the call along for now
+  InitSWE(rdy);
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Frees all resources devoted to solvers.
+PetscErrorCode DestroySolvers(RDy rdy) {
+  PetscFunctionBegin;
+
+  PetscBool ceed_enabled = (rdy->ceed.resource[0]);
+
+  if (rdy->petsc.context) {
+    PetscCall(DestroyPetscSWEFlux(rdy->petsc.context, ceed_enabled, rdy->num_boundaries));
+  }
+
+  if (rdy->ceed.resource[0]) {
+    PetscCallCEED(CeedOperatorDestroy(&rdy->ceed.flux_operator));
+    PetscCallCEED(CeedOperatorDestroy(&rdy->ceed.source_operator));
+    PetscCallCEED(CeedVectorDestroy(&rdy->ceed.u_local));
+    PetscCallCEED(CeedVectorDestroy(&rdy->ceed.rhs));
+    PetscCallCEED(CeedVectorDestroy(&rdy->ceed.sources));
+    PetscCallCEED(CeedDestroy(&(rdy->ceed.context)));
+    if (rdy->ceed.host_fluxes) VecDestroy(&rdy->ceed.host_fluxes);
+  }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -108,7 +108,7 @@ static PetscErrorCode CreateSolvers(RDy rdy) {
   PetscCall(TSSetApplicationContext(rdy->ts, rdy));
 
   PetscCheck(rdy->config.physics.flow.mode == FLOW_SWE, rdy->comm, PETSC_ERR_USER, "Only the 'swe' flow mode is currently supported.");
-  PetscCall(TSSetRHSFunction(rdy->ts, rdy->residual, RHSFunctionSWE, rdy));
+  PetscCall(TSSetRHSFunction(rdy->ts, rdy->rhs, RHSFunctionSWE, rdy));
 
   if (!rdy->config.time.adaptive.enable) {
     PetscCall(TSSetMaxSteps(rdy->ts, rdy->config.time.max_step));

--- a/src/xdmf_output.c
+++ b/src/xdmf_output.c
@@ -40,10 +40,10 @@ static PetscErrorCode WriteXDMFHDF5Data(RDy rdy, PetscInt step, PetscReal time) 
   PetscCall(DMGetUseNatural(rdy->dm, &use_natural));
   if (use_natural) {
     PetscCall(DMPlexCreateNaturalVector(rdy->dm, &natural));
-    PetscCall(DMPlexGlobalToNaturalBegin(rdy->dm, rdy->X, natural));
-    PetscCall(DMPlexGlobalToNaturalEnd(rdy->dm, rdy->X, natural));
+    PetscCall(DMPlexGlobalToNaturalBegin(rdy->dm, rdy->u_global, natural));
+    PetscCall(DMPlexGlobalToNaturalEnd(rdy->dm, rdy->u_global, natural));
   } else {
-    natural = rdy->X;
+    natural = rdy->u_global;
     PetscCall(PetscObjectReference((PetscObject)natural));
   }
 


### PR DESCRIPTION
This PR moves solver-related data around, renaming things to be a bit more functionally clear.

The next step in this refactor process is to gather all the high-level solver-related logic into `solvers.c` so we can start making more complicated composite operators, such as those for the Hairsine-Rose equations that couple sediment transport to the shallow water equations.