### PR TITLE
Added output.directory option for specifying an output directory.

### DIFF
--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -400,6 +400,7 @@ RDycore. The parameters that define these discretizations are
 
 ```yaml
 output:
+  directory: output
   format: xdmf
   step_interval: 100
   batch_size: 1
@@ -410,6 +411,7 @@ output:
 The `output` section control simulation output, including visualization and
 time series data (and excluding checkpoint data). Relevant parameters are
 
+* `directory`: the name of the directory to which output is written. It can be a relative or absolute path, and is created if it doesn't already exist. Default value: `output`
 * `format`: the format of the output written. Available options are
     * `none`: no output is written. This is the default value.
     * `binary`: output is written using PETSc's binary data format

--- a/driver/tests/swe_roe/ex2b_dirichlet_bc.yaml
+++ b/driver/tests/swe_roe/ex2b_dirichlet_bc.yaml
@@ -16,6 +16,7 @@ time:
   max_step: 100
 
 output:
+  directory: dirichlet-bc-output
   format: xdmf
   step_interval: 100
   batch_size: 20

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -156,14 +156,15 @@ typedef struct {
 
 // all output parameters
 typedef struct {
-  PetscBool       enable;            // true if output is requested
-  RDyOutputFormat format;            // file format
-  PetscInt        step_interval;     // output interval [steps between outputs]
-  PetscInt        time_interval;     // temporal interval at which output is written
-  RDyTimeUnit     time_unit;         // unit of time for temporal interval
-  PetscInt        batch_size;        // number of timesteps per output file (if available)
-  RDyTimeSeries   time_series;       // time series appended to text (.dat) files
-  PetscReal       prev_output_time;  // previous time at which output was written
+  PetscBool       enable;                         // true if output is requested
+  char            directory[PETSC_MAX_PATH_LEN];  // output directory
+  RDyOutputFormat format;                         // file format
+  PetscInt        step_interval;                  // output interval [steps between outputs]
+  PetscInt        time_interval;                  // temporal interval at which output is written
+  RDyTimeUnit     time_unit;                      // unit of time for temporal interval
+  PetscInt        batch_size;                     // number of timesteps per output file (if available)
+  RDyTimeSeries   time_series;                    // time series appended to text (.dat) files
+  PetscReal       prev_output_time;               // previous time at which output was written
 } RDyOutputSection;
 
 // ------------

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -10,16 +10,16 @@ extern PetscReal ConvertTimeToSeconds(PetscReal time, RDyTimeUnit time_unit);
 extern PetscReal ConvertTimeFromSeconds(PetscReal time, RDyTimeUnit time_unit);
 
 /// Returns the name of the output directory:
-/// * "output"                        (single-run mode)
-/// * "output/<ensemble-member-name>" (ensemble mode)
+/// * <output_dir>                         (single-run mode)
+/// * <output_dir>/<ensemble-member-name>" (ensemble mode)
 PetscErrorCode GetOutputDirectory(RDy rdy, char dir[PETSC_MAX_PATH_LEN]) {
   PetscFunctionBegin;
   static char output_dir[PETSC_MAX_PATH_LEN] = {0};
   if (!output_dir[0]) {
     if (rdy->config.ensemble.size > 1) {
-      sprintf(output_dir, "output/%s", rdy->config.ensemble.members[rdy->ensemble_member_index].name);
+      sprintf(output_dir, "%s/%s", rdy->config.output.directory, rdy->config.ensemble.members[rdy->ensemble_member_index].name);
     } else {
-      strcpy(output_dir, "output");
+      sprintf(output_dir, "%s", rdy->config.output.directory);
     }
   }
   strncpy(dir, output_dir, PETSC_MAX_PATH_LEN - 1);
@@ -51,9 +51,9 @@ static PetscErrorCode CreateOutputDirectory(RDy rdy) {
   PetscCall(GetOutputDirectory(rdy, output_dir));
   RDyLogDebug(rdy, "Creating output directory %s...", output_dir);
 
-  // create the output/ directory on global rank 0
+  // create the output directory on global rank 0
   if (rdy->config.ensemble.size > 1) {
-    PetscCall(CreateDirectory(rdy->global_comm, "output"));
+    PetscCall(CreateDirectory(rdy->global_comm, rdy->config.output.directory));
   }
   PetscCall(CreateDirectory(rdy->comm, output_dir));
   MPI_Barrier(rdy->global_comm);

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -227,6 +227,7 @@ static const cyaml_schema_field_t output_time_series_fields_schema[] = {
 
 // mapping of output fields to members of RDyOutputSection
 static const cyaml_schema_field_t output_fields_schema[] = {
+    CYAML_FIELD_STRING("directory", CYAML_FLAG_OPTIONAL, RDyOutputSection, directory, 0),
     CYAML_FIELD_ENUM("format", CYAML_FLAG_OPTIONAL, RDyOutputSection, format, output_file_formats, CYAML_ARRAY_LEN(output_file_formats)),
     CYAML_FIELD_INT("step_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, step_interval),
     CYAML_FIELD_INT("time_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_interval),
@@ -736,6 +737,8 @@ static PetscErrorCode SetMissingValues(RDyConfig *config) {
   SET_MISSING_PARAMETER(config->time.max_step, INVALID_INT);
   SET_MISSING_PARAMETER(config->time.time_step, INVALID_REAL);
   SET_MISSING_PARAMETER(config->time.coupling_interval, INVALID_REAL);
+
+  if (!config->output.directory[0]) strcpy(config->output.directory, "output");
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }


### PR DESCRIPTION
See the input specification in the documentation for details.

I added the `output.directory` field to [this test](https://github.com/RDycore/RDycore/blob/jeff-cohere/229/driver/tests/swe_roe/ex2b_dirichlet_bc.yaml#L19) and it seems to work.

Closes #229