### PR TITLE
Fixes seg fault when writing flux data

### DIFF
--- a/config/modules.pm-cpu.gnu
+++ b/config/modules.pm-cpu.gnu
@@ -1,10 +1,9 @@
 module purge
 module load craype-x86-milan
-module load libfabric/1.15.2.0
+module load libfabric/1.20.1
 module load craype-network-ofi
-module load xpmem/2.6.2-2.5_2.38__gd067c3f.shasta
+module load xpmem/2.6.2-2.5_2.40__gd067c3f.shasta
 module load cpe/23.12
-module load gpu/1.0
 module load conda/Miniconda3-py311_23.11.0-2
 module load evp-patch
 module load python/3.11

--- a/config/modules.pm-gpu.gnugpu
+++ b/config/modules.pm-gpu.gnugpu
@@ -1,8 +1,8 @@
 module purge
 module load craype-x86-milan
-module load libfabric/1.15.2.0
+module load libfabric/1.20.1
 module load craype-network-ofi
-module load xpmem/2.6.2-2.5_2.38__gd067c3f.shasta
+module load xpmem/2.6.2-2.5_2.40__gd067c3f.shasta
 module load cpe/23.12
 module load gpu/1.0
 module load conda/Miniconda3-py311_23.11.0-2

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -243,7 +243,7 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
   // zero the boundary fluxes so they can begin reaccumulating
   // NOTE that there are 3 fluxes (and not 5)
   if (rdy->time_series.boundary_fluxes.fluxes) {
-    memset(rdy->time_series.boundary_fluxes.fluxes, 0, 3 * num_global_edges * sizeof(PetscReal));
+    memset(rdy->time_series.boundary_fluxes.fluxes, 0, rdy->time_series.boundary_fluxes.offsets[rdy->num_boundaries] * sizeof(PetscReal));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -88,7 +88,7 @@ static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
         if (rdy->mesh.cells.is_local[cell_id]) ++num_boundary_edges;
       }
     }
-    rdy->time_series.boundary_fluxes.offsets[b + 1] = ndof * num_boundary_edges;
+    rdy->time_series.boundary_fluxes.offsets[b + 1] = num_boundary_edges;
   }
 
   // gather per-process numbers of local boundary edges
@@ -108,7 +108,7 @@ static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
   PetscCall(GatherBoundaryFluxMetadata(rdy));
 
   // allocate (local) boundary flux storage
-  PetscCall(PetscCalloc1(3 * num_boundary_edges, &(rdy->time_series.boundary_fluxes.fluxes)));
+  PetscCall(PetscCalloc1(num_boundary_edges, &(rdy->time_series.boundary_fluxes.fluxes)));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -243,7 +243,11 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
   // zero the boundary fluxes so they can begin reaccumulating
   // NOTE that there are 3 fluxes (and not 5)
   if (rdy->time_series.boundary_fluxes.fluxes) {
-    memset(rdy->time_series.boundary_fluxes.fluxes, 0, rdy->time_series.boundary_fluxes.offsets[rdy->num_boundaries] * sizeof(PetscReal));
+    for (PetscInt e = 0; e < rdy->time_series.boundary_fluxes.offsets[rdy->num_boundaries]; e++) {
+      rdy->time_series.boundary_fluxes.fluxes[e].water_mass = 0.0;
+      rdy->time_series.boundary_fluxes.fluxes[e].x_momentum = 0.0;
+      rdy->time_series.boundary_fluxes.fluxes[e].y_momentum = 0.0;
+    }
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);


### PR DESCRIPTION
The size of the memory being `memset`  was (`3 * num_global_edges`) more than the one
allocated (`3 * num_boundary_edges`).

This PR adds a for-loop instead of `memset` to zero out the values after the fluxes are
written out. It also reduces the total amount of memory that is allocated by a factor of
`3` because `fluxes` is a struct that already has three `PetscReal` for storing the three
flux values corresponding to the three components of SWE.

Fixes #236