### PR TITLE
Corrects the computation of CFL when using CEED

### DIFF
--- a/src/swe/physics_swe.c
+++ b/src/swe/physics_swe.c
@@ -331,16 +331,9 @@ static PetscErrorCode CeedFindMaxCourantNumberInternalEdges(CeedOperator op_edge
   CeedScalar(*courant_num_data)[2];  // values to the left/right of an edge
   PetscCallCEED(CeedVectorGetArray(courant_num_vec, CEED_MEM_HOST, (CeedScalar **)&courant_num_data));
 
-  // RDyMesh  *mesh  = &rdy->mesh;
-  RDyEdges *edges = &mesh->edges;
-
-  PetscInt iedge_owned = 0;
-  for (PetscInt ii = 0; ii < mesh->num_internal_edges; ii++) {
-    if (edges->is_owned[ii]) {
-      CeedScalar local_max = fmax(courant_num_data[iedge_owned][0], courant_num_data[iedge_owned][1]);
-      *max_courant_number  = fmax(*max_courant_number, local_max);
-      iedge_owned++;
-    }
+  for (PetscInt ii = 0; ii < mesh->num_owned_internal_edges; ii++) {
+    CeedScalar local_max = fmax(courant_num_data[ii][0], courant_num_data[ii][1]);
+    *max_courant_number  = fmax(*max_courant_number, local_max);
   }
   PetscCallCEED(CeedVectorRestoreArray(courant_num_vec, (CeedScalar **)&courant_num_data));
 


### PR DESCRIPTION
The memory for the courant number is allocated only for the owned internal edges.
This fixes and simplifies the for-loop that computes the max courant number.

Fixes #238 