### PR TITLE
Separates out CEED resource/context management.

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1277,12 +1277,11 @@ PetscErrorCode ApplyRainfallDataset(RDy rdy, PetscReal time, SourceSink *rain_da
       }
       break;
     case MULTI_HOMOGENEOUS:
-      MultiHomogeneousDataset *multi_hdata = &rain_dataset->multihomogeneous;
-      for (PetscInt idata = 0; idata < multi_hdata->ndata; idata++) {
+      for (PetscInt idata = 0; idata < rain_dataset->multihomogeneous.ndata; idata++) {
         PetscInt  size = 1;
         PetscReal data;
-        PetscCall(SetHomogeneousData(&multi_hdata->data[idata], time, size, &data));
-        PetscCall(RDySetWaterSourceForRegion(rdy, multi_hdata->region_ids[idata] - 1, data));
+        PetscCall(SetHomogeneousData(&rain_dataset->multihomogeneous.data[idata], time, size, &data));
+        PetscCall(RDySetWaterSourceForRegion(rdy, rain_dataset->multihomogeneous.region_ids[idata] - 1, data));
       }
       break;
   }
@@ -1315,11 +1314,10 @@ PetscErrorCode DestroyRainfallDataset(SourceSink *rain_dataset) {
       PetscCall(DestroyUnstructuredDataset(&rain_dataset->unstructured));
       break;
     case MULTI_HOMOGENEOUS:
-      MultiHomogeneousDataset *multi_hdata = &rain_dataset->multihomogeneous;
-      for (PetscInt idata = 0; idata < multi_hdata->ndata; idata++) {
-        PetscCall(DestroyHomogeneousDataset(&multi_hdata->data[idata]));
+      for (PetscInt idata = 0; idata < rain_dataset->multihomogeneous.ndata; idata++) {
+        PetscCall(DestroyHomogeneousDataset(&rain_dataset->multihomogeneous.data[idata]));
       }
-      PetscCall(PetscFree(multi_hdata->data));
+      PetscCall(PetscFree(rain_dataset->multihomogeneous.data));
       break;
   }
 
@@ -1396,15 +1394,15 @@ PetscErrorCode ApplyBoundaryCondition(RDy rdy, PetscReal time, BoundaryCondition
       }
       break;
     case MULTI_HOMOGENEOUS:
-      MultiHomogeneousDataset *multi_hdata = &bc_dataset->multihomogeneous;
-      for (PetscInt ibc = 0; ibc < multi_hdata->ndirichlet_bcs; ibc++) {
-        PetscInt data_idx = multi_hdata->dirichlet_bc_to_data_idx[ibc];
-        PetscInt bc_idx   = multi_hdata->dirichlet_bc_idx[ibc];
-        PetscInt nedges   = multi_hdata->ndata_for_rdycore[ibc] / 3;
+      for (PetscInt ibc = 0; ibc < bc_dataset->multihomogeneous.ndirichlet_bcs; ibc++) {
+        PetscInt data_idx = bc_dataset->multihomogeneous.dirichlet_bc_to_data_idx[ibc];
+        PetscInt bc_idx   = bc_dataset->multihomogeneous.dirichlet_bc_idx[ibc];
+        PetscInt nedges   = bc_dataset->multihomogeneous.ndata_for_rdycore[ibc] / 3;
 
         if (nedges) {
-          PetscCall(SetHomogeneousBoundary(&multi_hdata->data[data_idx], time, nedges, multi_hdata->data_for_rdycore[ibc]));
-          PetscCall(RDySetDirichletBoundaryValues(rdy, bc_idx, nedges, 3, multi_hdata->data_for_rdycore[ibc]));
+          PetscCall(
+              SetHomogeneousBoundary(&bc_dataset->multihomogeneous.data[data_idx], time, nedges, bc_dataset->multihomogeneous.data_for_rdycore[ibc]));
+          PetscCall(RDySetDirichletBoundaryValues(rdy, bc_idx, nedges, 3, bc_dataset->multihomogeneous.data_for_rdycore[ibc]));
         }
       }
       break;
@@ -1441,21 +1439,20 @@ PetscErrorCode DestroyBoundaryConditionDataset(BoundaryCondition *bc_dataset) {
       PetscCall(DestroyUnstructuredDataset(&bc_dataset->unstructured));
       break;
     case MULTI_HOMOGENEOUS:
-      MultiHomogeneousDataset *multi_hdata = &bc_dataset->multihomogeneous;
-      for (PetscInt idata = 0; idata < multi_hdata->ndata; idata++) {
-        PetscCall(DestroyHomogeneousDataset(&multi_hdata->data[idata]));
+      for (PetscInt idata = 0; idata < bc_dataset->multihomogeneous.ndata; idata++) {
+        PetscCall(DestroyHomogeneousDataset(&bc_dataset->multihomogeneous.data[idata]));
       }
-      PetscCall(PetscFree(multi_hdata->data));
+      PetscCall(PetscFree(bc_dataset->multihomogeneous.data));
 
-      if (multi_hdata->ndirichlet_bcs) {
-        PetscCall(PetscFree(multi_hdata->dirichlet_bc_idx));
-        PetscCall(PetscFree(multi_hdata->dirichlet_bc_to_data_idx));
-        PetscCall(PetscFree(multi_hdata->ndata_for_rdycore));
+      if (bc_dataset->multihomogeneous.ndirichlet_bcs) {
+        PetscCall(PetscFree(bc_dataset->multihomogeneous.dirichlet_bc_idx));
+        PetscCall(PetscFree(bc_dataset->multihomogeneous.dirichlet_bc_to_data_idx));
+        PetscCall(PetscFree(bc_dataset->multihomogeneous.ndata_for_rdycore));
 
-        for (PetscInt i = 0; i < multi_hdata->ndirichlet_bcs; i++) {
-          PetscCall(PetscFree(multi_hdata->data_for_rdycore[i]));
+        for (PetscInt i = 0; i < bc_dataset->multihomogeneous.ndirichlet_bcs; i++) {
+          PetscCall(PetscFree(bc_dataset->multihomogeneous.data_for_rdycore[i]));
         }
-        PetscCall(PetscFree(multi_hdata->data_for_rdycore));
+        PetscCall(PetscFree(bc_dataset->multihomogeneous.data_for_rdycore));
       }
       break;
   }

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -9,6 +9,13 @@
 #include <private/rdymeshimpl.h>
 #include <rdycore.h>
 
+// CEED initialization, availability, context, useful for creating CEED
+// sub-operators
+PETSC_INTERN PetscErrorCode SetCeedResource(char *);
+PETSC_INTERN PetscBool      CeedEnabled(void);
+PETSC_INTERN Ceed           CeedContext(void);
+PETSC_INTERN PetscErrorCode GetCeedVecType(VecType *);
+
 // Diagnostic structure that captures information about the conditions under
 // which the maximum courant number is encountered. If you change this struct,
 // update the call to MPI_Type_create_struct in InitMPITypesAndOps below.
@@ -168,11 +175,6 @@ struct _p_RDy {
 
   // CEED (device) solver data
   struct {
-    // CEED resource name -- used to determine the backend
-    char resource[PETSC_MAX_PATH_LEN];
-
-    Ceed context;
-
     CeedOperator flux_operator;
     CeedOperator source_operator;
 
@@ -221,7 +223,6 @@ PETSC_INTERN PetscErrorCode InitBoundaries(RDy);
 PETSC_INTERN PetscErrorCode InitRegions(RDy);
 PETSC_INTERN PetscErrorCode OverrideParameters(RDy);
 PETSC_INTERN PetscErrorCode PrintConfig(RDy);
-static inline PetscBool     CeedEnabled(RDy rdy) { return (rdy->ceed.resource[0]) ? PETSC_TRUE : PETSC_FALSE; }
 
 PETSC_INTERN PetscErrorCode RDyDestroyVectors(RDy *);
 PETSC_INTERN PetscErrorCode RDyDestroyRegions(RDy *);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Main library -- we list all source files here (incl. those in subdirectories)
 add_library(rdycore
+  ceed.c
   checkpoint.c
   ensemble.c
   rdyadvance.c

--- a/src/ceed.c
+++ b/src/ceed.c
@@ -1,0 +1,55 @@
+#include <petscdmceed.h>
+#include <private/rdycoreimpl.h>
+
+// global CEED resource name and context
+static char ceed_resource[PETSC_MAX_PATH_LEN + 1] = {0};
+static Ceed ceed_context;
+
+/// returns true iff CEED is enabled
+PetscBool CeedEnabled(void) { return (ceed_resource[0]) ? PETSC_TRUE : PETSC_FALSE; }
+
+/// returns the global CEED context, which is only valid if CeedEnabled()
+/// returns PETSC_TRUE
+Ceed CeedContext(void) { return ceed_context; }
+
+/// retrieves the appropriate PETSc Vec type for the selected CEED backend
+PetscErrorCode GetCeedVecType(VecType *vec_type) {
+  PetscFunctionBegin;
+
+  CeedMemType mem_type_backend;
+  PetscCallCEED(CeedGetPreferredMemType(ceed_context, &mem_type_backend));
+  switch (mem_type_backend) {
+    case CEED_MEM_HOST:
+      *vec_type = VECSTANDARD;
+      break;
+    case CEED_MEM_DEVICE: {
+      const char *resolved;
+      PetscCallCEED(CeedGetResource(ceed_context, &resolved));
+      if (strstr(resolved, "/gpu/cuda")) *vec_type = VECCUDA;
+      else if (strstr(resolved, "/gpu/hip")) *vec_type = VECKOKKOS;
+      else if (strstr(resolved, "/gpu/sycl")) *vec_type = VECKOKKOS;
+      else *vec_type = VECSTANDARD;
+    }
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Sets the CEED resource string to the given string, initializing the global
+/// CEED context if the argument is specified. If CEED has already been enabled
+/// with a different resource, a call to this function deletes the global
+/// context and recreates it. If the resource string is empty or NULL, CEED is
+/// disabled.
+/// @param resource a CEED resource string, possibly empty or NULL
+PetscErrorCode SetCeedResource(char *resource) {
+  PetscFunctionBegin;
+  if (ceed_resource[0]) {  // we already have a context
+    CeedDestroy(&ceed_context);
+  }
+  if (resource && resource[0]) {
+    strncpy(ceed_resource, resource, PETSC_MAX_PATH_LEN);
+    PetscCallCEED(CeedInit(ceed_resource, &ceed_context));
+  } else {
+    ceed_resource[0] = 0;
+  }
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/src/operator.c
+++ b/src/operator.c
@@ -43,7 +43,7 @@ PetscErrorCode DestroyOperators(RDy rdy) {
   PetscFree(rdy->lock.boundary_data);
   PetscFree(rdy->lock.source_data);
 
-  PetscBool ceed_enabled = CeedEnabled(rdy);
+  PetscBool ceed_enabled = CeedEnabled();
 
   if (rdy->petsc.context) {
     PetscCall(DestroyPetscSWEFlux(rdy->petsc.context, ceed_enabled, rdy->num_boundaries));
@@ -77,7 +77,7 @@ PetscErrorCode GetOperatorBoundaryData(RDy rdy, RDyBoundary boundary, OperatorBo
   boundary_data->boundary                 = boundary;
   PetscCall(VecGetBlockSize(rdy->u_global, &boundary_data->num_components));
 
-  if (CeedEnabled(rdy)) {
+  if (CeedEnabled()) {
     // get the relevant boundary sub-operator
     CeedOperator *sub_ops;
     PetscCallCEED(CeedCompositeOperatorGetSubList(rdy->ceed.flux_operator, &sub_ops));
@@ -97,7 +97,7 @@ PetscErrorCode GetOperatorBoundaryData(RDy rdy, RDyBoundary boundary, OperatorBo
 PetscErrorCode SetOperatorBoundaryValues(OperatorBoundaryData *boundary_data, PetscInt component, PetscReal *boundary_values) {
   PetscFunctionBegin;
 
-  if (CeedEnabled(boundary_data->rdy)) {
+  if (CeedEnabled()) {
     // if this is the first update, get access to the vector's data
     if (!boundary_data->storage.updated) {
       PetscCallCEED(CeedVectorGetArray(boundary_data->storage.ceed.vec, CEED_MEM_HOST, &boundary_data->storage.ceed.data));
@@ -133,7 +133,7 @@ PetscErrorCode RestoreOperatorBoundaryData(RDy rdy, RDyBoundary boundary, Operat
   PetscFunctionBegin;
   PetscCheck(rdy == boundary_data->rdy, rdy->comm, PETSC_ERR_USER, "Could not restore operator boundary data: wrong RDy");
   PetscCheck(boundary.index == boundary_data->boundary.index, rdy->comm, PETSC_ERR_USER, "Could not restore operator boundary data: wrong boundary");
-  if (CeedEnabled(boundary_data->rdy)) {
+  if (CeedEnabled()) {
     if (boundary_data->storage.updated) {
       PetscCallCEED(CeedVectorRestoreArray(boundary_data->storage.ceed.vec, &boundary_data->storage.ceed.data));
     }
@@ -155,7 +155,7 @@ PetscErrorCode GetOperatorSourceData(RDy rdy, OperatorSourceData *source_data) {
   source_data->rdy      = rdy;
   PetscCall(VecGetBlockSize(rdy->u_global, &source_data->num_components));
 
-  if (CeedEnabled(rdy)) {
+  if (CeedEnabled()) {
     // NOTE: our SWE-specific source operator has only one sub operator
     CeedOperator *sub_ops;
     PetscCallCEED(CeedCompositeOperatorGetSubList(rdy->ceed.source_operator, &sub_ops));
@@ -176,7 +176,7 @@ PetscErrorCode GetOperatorSourceData(RDy rdy, OperatorSourceData *source_data) {
 PetscErrorCode SetOperatorSourceValues(OperatorSourceData *source_data, PetscInt component, PetscReal *source_values) {
   PetscFunctionBegin;
 
-  if (CeedEnabled(source_data->rdy)) {
+  if (CeedEnabled()) {
     // if this is the first update, get access to the vector's data
     if (!source_data->sources.updated) {
       PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
@@ -212,7 +212,7 @@ PetscErrorCode SetOperatorSourceValues(OperatorSourceData *source_data, PetscInt
 PetscErrorCode GetOperatorSourceValues(OperatorSourceData *source_data, PetscInt component, PetscReal *source_values) {
   PetscFunctionBegin;
 
-  if (CeedEnabled(source_data->rdy)) {
+  if (CeedEnabled()) {
     // if this is the first update, get access to the vector's data
     if (!source_data->sources.updated) {
       PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
@@ -247,7 +247,7 @@ PetscErrorCode GetOperatorSourceValues(OperatorSourceData *source_data, PetscInt
 PetscErrorCode RestoreOperatorSourceData(RDy rdy, OperatorSourceData *source_data) {
   PetscFunctionBegin;
   PetscCheck(rdy == source_data->rdy, rdy->comm, PETSC_ERR_USER, "Could not restore operator source data: wrong RDy");
-  if (CeedEnabled(source_data->rdy)) {
+  if (CeedEnabled()) {
     if (source_data->sources.updated) {
       PetscCallCEED(CeedVectorRestoreArray(source_data->sources.ceed.vec, &source_data->sources.ceed.data));
     }
@@ -268,7 +268,7 @@ PetscErrorCode GetOperatorMaterialData(RDy rdy, OperatorMaterialData *material_d
   rdy->lock.material_data = material_data;
   material_data->rdy      = rdy;
 
-  if (CeedEnabled(rdy)) {
+  if (CeedEnabled()) {
     // NOTE: our SWE-specific source operator has only one sub operator
     CeedOperator *sub_ops;
     PetscCallCEED(CeedCompositeOperatorGetSubList(rdy->ceed.source_operator, &sub_ops));
@@ -297,7 +297,7 @@ PetscErrorCode SetOperatorMaterialValues(OperatorMaterialData *material_data, Op
       break;
   }
 
-  if (CeedEnabled(material_data->rdy)) {
+  if (CeedEnabled()) {
     // if this is the first update, get access to the vector's data
     if (!vector_data.updated) {
       PetscCallCEED(CeedVectorGetArray(vector_data.ceed.vec, CEED_MEM_HOST, &vector_data.ceed.data));
@@ -330,7 +330,7 @@ PetscErrorCode SetOperatorMaterialValues(OperatorMaterialData *material_data, Op
 PetscErrorCode RestoreOperatorMaterialData(RDy rdy, OperatorMaterialData *material_data) {
   PetscFunctionBegin;
   PetscCheck(rdy == material_data->rdy, rdy->comm, PETSC_ERR_USER, "Could not restore operator material data: wrong RDy");
-  if (CeedEnabled(material_data->rdy)) {
+  if (CeedEnabled()) {
     if (material_data->mannings.updated) {
       PetscCallCEED(CeedVectorRestoreArray(material_data->mannings.ceed.vec, &material_data->mannings.ceed.data));
     }
@@ -352,7 +352,7 @@ PetscErrorCode GetOperatorFluxDivergenceData(RDy rdy, OperatorFluxDivergenceData
   flux_div_data->rdy      = rdy;
   PetscCall(VecGetBlockSize(rdy->u_global, &flux_div_data->num_components));
 
-  if (CeedEnabled(rdy)) {
+  if (CeedEnabled()) {
     // NOTE: our SWE-specific source operator has only one sub operator
     CeedOperator *sub_ops;
     PetscCallCEED(CeedCompositeOperatorGetSubList(rdy->ceed.source_operator, &sub_ops));
@@ -373,7 +373,7 @@ PetscErrorCode GetOperatorFluxDivergenceData(RDy rdy, OperatorFluxDivergenceData
 PetscErrorCode SetOperatorFluxDivergenceValues(OperatorFluxDivergenceData *flux_div_data, PetscInt component, PetscReal *flux_div_values) {
   PetscFunctionBegin;
 
-  if (CeedEnabled(flux_div_data->rdy)) {
+  if (CeedEnabled()) {
     // if this is the first update, get access to the vector's data
     if (!flux_div_data->storage.updated) {
       PetscCallCEED(CeedVectorGetArray(flux_div_data->storage.ceed.vec, CEED_MEM_HOST, &flux_div_data->storage.ceed.data));
@@ -408,7 +408,7 @@ PetscErrorCode SetOperatorFluxDivergenceValues(OperatorFluxDivergenceData *flux_
 PetscErrorCode RestoreOperatorFluxDivergenceData(RDy rdy, OperatorFluxDivergenceData *flux_div_data) {
   PetscFunctionBegin;
   PetscCheck(rdy == flux_div_data->rdy, rdy->comm, PETSC_ERR_USER, "Could not restore operator flux divergence data: wrong RDy");
-  if (CeedEnabled(flux_div_data->rdy)) {
+  if (CeedEnabled()) {
     if (flux_div_data->storage.updated) {
       PetscCallCEED(CeedVectorRestoreArray(flux_div_data->storage.ceed.vec, &flux_div_data->storage.ceed.data));
     }

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -213,7 +213,8 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   if ((*rdy)->aux_dm) DMDestroy(&((*rdy)->aux_dm));
   if ((*rdy)->dm) DMDestroy(&((*rdy)->dm));
 
-  // destroy our CEED context as needed
+  // destroy our CEED context if needed by setting its resource to NULL
+  // (this works whether or not the CEED resource has been set previously)
   PetscCall(SetCeedResource(NULL));
 
   // close the log file if needed

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -214,9 +214,7 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   if ((*rdy)->dm) DMDestroy(&((*rdy)->dm));
 
   // destroy our CEED context as needed
-  if (CeedEnabled(*rdy)) {
-    PetscCallCEED(CeedDestroy(&((*rdy)->ceed.context)));
-  }
+  PetscCall(SetCeedResource(NULL));
 
   // close the log file if needed
   if (((*rdy)->log) && ((*rdy)->log != stdout)) {

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -95,7 +95,7 @@ PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_in
 
   // dispatch this call to CEED or PETSc
   PetscReal tiny_h = rdy->config.physics.flow.tiny_h;
-  if (CeedEnabled(rdy)) {
+  if (CeedEnabled()) {
     // FIXME: we'd like to do this for both CEED and PETSc
     // FIXME: also, I don't think we should be setting boundary values with a
     // FIXME: strided array, since it makes non-SWE situations more complicated
@@ -437,7 +437,7 @@ PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscR
 
   PetscCall(CheckNumLocalCells(rdy, size));
 
-  if (CeedEnabled(rdy)) {
+  if (CeedEnabled()) {
     // FIXME: we'd like to do this for both CEED and PETSc
     OperatorMaterialData material_data;
     PetscCall(GetOperatorMaterialData(rdy, &material_data));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -110,20 +110,19 @@ PetscErrorCode OverrideParameters(RDy rdy) {
     rdy->dt = ConvertTimeToSeconds(rdy->dt, rdy->config.time.unit);
   }
 
+  char ceed_resource[PETSC_MAX_PATH_LEN] = {0};
   PetscOptionsBegin(rdy->comm, NULL, "RDycore options", "");
   {
     PetscCall(PetscOptionsReal("-dt", "time step size (seconds)", "", rdy->dt, &rdy->dt, NULL));
-    PetscCall(PetscOptionsString("-ceed", "Ceed resource (/cpu/self, /gpu/cuda, /gpu/hip, ...)", "", rdy->ceed.resource, rdy->ceed.resource,
-                                 sizeof rdy->ceed.resource, NULL));
+    PetscCall(PetscOptionsString("-ceed", "Ceed resource (/cpu/self, /gpu/cuda, /gpu/hip, ...)", "", ceed_resource, ceed_resource,
+                                 sizeof ceed_resource, NULL));
     PetscCall(PetscOptionsString("-restart", "restart from the given checkpoint file", "", rdy->config.restart.file, rdy->config.restart.file,
                                  sizeof rdy->config.restart.file, NULL));
   }
   PetscOptionsEnd();
 
-  // initialize a CEED context if needed, assuming ownership
-  if (CeedEnabled(rdy)) {
-    PetscCallCEED(CeedInit(rdy->ceed.resource, &rdy->ceed.context));
-  }
+  // enable CEED as needed
+  PetscCallCEED(SetCeedResource(ceed_resource));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -299,7 +299,7 @@ PetscErrorCode WriteTimeSeries(TS ts, PetscInt step, PetscReal time, Vec X, void
   if ((step % rdy->config.output.time_series.boundary_fluxes == 0) && (step > rdy->time_series.last_step)) {
     // if we're using CEED, we need to fetch the boundary fluxes from the
     // flux operator
-    if (CeedEnabled(rdy)) {
+    if (CeedEnabled()) {
       FetchCeedBoundaryFluxes(rdy);
     }
     PetscCall(WriteBoundaryFluxes(rdy, step, time));


### PR DESCRIPTION
This PR moves the operative CEED resource and context out of the dycore and into a global context, since there's no situation I can think of in which we would ever support multiple CEED resources. This allows us to gather some logic and separate concerns.

Also, this PR includes a minor modification to some driver code regarding datasets (which are still under construction, as I understand it). The ability to declare variables within case blocks of switch statements is supported by C23, but many compilers are still using the C17 form of the language, so I've made the code C17-compliant.