### PR TITLE
Separated courant number diagnostic core logic from SWE operator.

### DIFF
--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -26,6 +26,12 @@ typedef struct {
   PetscBool is_set;           // true if max_courant_num is set, otherwise false
 } CourantNumberDiagnostics;
 
+// MPI datatype and operator for reducing CourantNumberDiagnostics with MPI_AllReduce,
+// and related initialization function
+extern MPI_Datatype         MPI_COURANT_NUMBER_DIAGNOSTICS;
+extern MPI_Op               MPI_MAX_COURANT_NUMBER;
+PETSC_INTERN PetscErrorCode InitCourantNumberDiagnostics(void);
+
 // This type defines a material with specific properties.
 // (undefined properties are set to INVALID_INT/INVALID_REAL)
 typedef struct {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(rdycore
   ceed.c
   checkpoint.c
+  courant.c
   ensemble.c
   rdyadvance.c
   rdycore.c

--- a/src/courant.c
+++ b/src/courant.c
@@ -1,0 +1,63 @@
+#include <private/rdycoreimpl.h>
+
+// MPI datatype corresponding to CourantNumberDiagnostics. Created during
+// CreateSWEOperator.
+MPI_Datatype MPI_COURANT_NUMBER_DIAGNOSTICS = {0};
+
+// MPI operator used to determine the prevailing diagnostics for the maximum
+// courant number on all processes. Created during CreateSWEOperator.
+MPI_Op MPI_MAX_COURANT_NUMBER = {0};
+
+// function implementing the above MPI operator
+static void FindCourantNumberDiagnostics(void *in_vec, void *result_vec, int *len, MPI_Datatype *type) {
+  CourantNumberDiagnostics *in_diags     = in_vec;
+  CourantNumberDiagnostics *result_diags = result_vec;
+
+  // select the item with the maximum courant number
+  for (int i = 0; i < *len; ++i) {
+    if (in_diags[i].max_courant_num > result_diags[i].max_courant_num) {
+      result_diags[i]        = in_diags[i];
+      result_diags[i].is_set = PETSC_TRUE;  // mark as set
+    }
+  }
+}
+
+// this function destroys the above MPI datatype and operator
+static void DestroyCourantNumberDiagnostics(void) {
+  MPI_Op_free(&MPI_MAX_COURANT_NUMBER);
+  MPI_Type_free(&MPI_COURANT_NUMBER_DIAGNOSTICS);
+}
+
+// this function initializes some MPI machinery for the above Courant number
+// diagnostics, and is called by CreateBasicOperator, which is called when a
+// CEED or PETSc Operator is created
+PetscErrorCode InitCourantNumberDiagnostics(void) {
+  PetscFunctionBegin;
+
+  static PetscBool initialized = PETSC_FALSE;
+
+  if (!initialized) {
+    // create an MPI data type for the CourantNumberDiagnostics struct
+    const int      num_blocks             = 4;
+    const int      block_lengths[4]       = {1, 1, 1, 1};
+    const MPI_Aint block_displacements[4] = {
+        offsetof(CourantNumberDiagnostics, max_courant_num),
+        offsetof(CourantNumberDiagnostics, global_edge_id),
+        offsetof(CourantNumberDiagnostics, global_cell_id),
+        offsetof(CourantNumberDiagnostics, is_set),
+    };
+    MPI_Datatype block_types[4] = {MPIU_REAL, MPI_INT, MPI_INT, MPIU_BOOL};
+    MPI_Type_create_struct(num_blocks, block_lengths, block_displacements, block_types, &MPI_COURANT_NUMBER_DIAGNOSTICS);
+    MPI_Type_commit(&MPI_COURANT_NUMBER_DIAGNOSTICS);
+
+    // create a corresponding reduction operator for the new type
+    MPI_Op_create(FindCourantNumberDiagnostics, 1, &MPI_MAX_COURANT_NUMBER);
+
+    // make sure the operator and the type are destroyed upon exit
+    PetscCall(RDyOnFinalize(DestroyCourantNumberDiagnostics));
+
+    initialized = PETSC_TRUE;
+  }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -16,8 +16,13 @@ PetscErrorCode RDyInit(int argc, char *argv[], const char *help) {
     if (!petsc_initialized) {
       PetscCall(PetscInitialize(&argc, &argv, (char *)0, (char *)help));
     }
+
+    // initialize our Courant number diagnostics MPI datatype / operator
+    PetscCall(InitCourantNumberDiagnostics());
+
     initialized_ = PETSC_TRUE;
   }
+
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -33,6 +38,10 @@ PetscErrorCode RDyInitFortran(void) {
       // no need for PetscInitializeFortran because PetscInitialize is
       // called before this function in the rdycore Fortran module.
     }
+
+    // initialize our Courant number diagnostics MPI datatype / operator
+    PetscCall(InitCourantNumberDiagnostics());
+
     initialized_ = PETSC_TRUE;
   }
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/swe/swe.c
+++ b/src/swe/swe.c
@@ -12,68 +12,6 @@ PetscErrorCode SWERHSFunctionForBoundaryEdges(RDy rdy, Vec F, CourantNumberDiagn
 PetscErrorCode ComputeSWEDiagnosticVariables(RDy rdy);
 PetscErrorCode AddSWESourceTerm(RDy rdy, Vec F);
 
-//-----------------------
-// Debugging diagnostics
-//-----------------------
-
-// MPI datatype corresponding to CourantNumberDiagnostics. Created during InitSWE.
-static MPI_Datatype courant_num_diags_type;
-
-// MPI operator used to determine the prevailing diagnostics for the maximum
-// courant number on all processes. Created during InitSWE.
-static MPI_Op courant_num_diags_op;
-
-// function backing the above MPI operator
-static void FindCourantNumberDiagnostics(void *in_vec, void *result_vec, int *len, MPI_Datatype *type) {
-  CourantNumberDiagnostics *in_diags     = in_vec;
-  CourantNumberDiagnostics *result_diags = result_vec;
-
-  // select the item with the maximum courant number
-  for (int i = 0; i < *len; ++i) {
-    if (in_diags[i].max_courant_num > result_diags[i].max_courant_num) {
-      result_diags[i] = in_diags[i];
-    }
-  }
-}
-
-// this function destroys the MPI type and operator associated with CourantNumberDiagnostics
-static void DestroyCourantNumberDiagnostics(void) {
-  MPI_Op_free(&courant_num_diags_op);
-  MPI_Type_free(&courant_num_diags_type);
-}
-
-// this function is called by InitSWE to initialize the above type(s) and op(s).
-static PetscErrorCode InitMPITypesAndOps(void) {
-  PetscFunctionBegin;
-
-  static PetscBool initialized = PETSC_FALSE;
-
-  if (!initialized) {
-    // create an MPI data type for the CourantNumberDiagnostics struct
-    const int      num_blocks             = 4;
-    const int      block_lengths[4]       = {1, 1, 1, 1};
-    const MPI_Aint block_displacements[4] = {
-        offsetof(CourantNumberDiagnostics, max_courant_num),
-        offsetof(CourantNumberDiagnostics, global_edge_id),
-        offsetof(CourantNumberDiagnostics, global_cell_id),
-        offsetof(CourantNumberDiagnostics, is_set),
-    };
-    MPI_Datatype block_types[4] = {MPIU_REAL, MPI_INT, MPI_INT, MPIU_BOOL};
-    MPI_Type_create_struct(num_blocks, block_lengths, block_displacements, block_types, &courant_num_diags_type);
-    MPI_Type_commit(&courant_num_diags_type);
-
-    // create a corresponding reduction operator for the new type
-    MPI_Op_create(FindCourantNumberDiagnostics, 1, &courant_num_diags_op);
-
-    // make sure the operator and the type are destroyed upon exit
-    PetscCall(RDyOnFinalize(DestroyCourantNumberDiagnostics));
-
-    initialized = PETSC_TRUE;
-  }
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
 static PetscErrorCode RHSFunctionSWE(TS, PetscReal, Vec, Vec, void *);
 
 // create solvers and vectors
@@ -167,9 +105,6 @@ static PetscErrorCode CreateOperators(RDy rdy) {
 // This function initializes SWE physics for the given dycore.
 PetscErrorCode InitSWE(RDy rdy) {
   PetscFunctionBeginUser;
-
-  // set up MPI types and operators used by SWE physics
-  PetscCall(InitMPITypesAndOps());
 
   // sets up solvers, operators, all that stuff
   PetscCall(CreateSolvers(rdy));
@@ -397,8 +332,6 @@ static PetscErrorCode CeedFindMaxCourantNumber(CeedOperator op_edges, RDyMesh *m
   PetscCall(CeedFindMaxCourantNumberInternalEdges(op_edges, mesh, max_courant_number));
   PetscCall(CeedFindMaxCourantNumberBoundaryEdges(op_edges, num_boundaries, boundaries, max_courant_number));
 
-  PetscCall(MPI_Allreduce(MPI_IN_PLACE, max_courant_number, 1, MPI_DOUBLE, MPI_MAX, comm));
-
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -411,13 +344,14 @@ PetscErrorCode SWEFindMaxCourantNumber(RDy rdy) {
   CourantNumberDiagnostics *courant_num_diags = &rdy->courant_num_diags;
 
   if (CeedEnabled()) {
+    // we need to extract the maximum courant number from the operator in the
+    // CEED case; in the PETSc case it's already set for this process
     PetscCall(CeedFindMaxCourantNumber(rdy->ceed.flux_operator, &rdy->mesh, rdy->num_boundaries, rdy->boundaries, rdy->comm,
                                        &courant_num_diags->max_courant_num));
-    courant_num_diags->is_set = PETSC_TRUE;
-  } else {
-    MPI_Allreduce(MPI_IN_PLACE, courant_num_diags, 1, courant_num_diags_type, courant_num_diags_op, rdy->comm);
-    courant_num_diags->is_set = PETSC_TRUE;
   }
+
+  // reduce the courant diagnostics across all processes
+  MPI_Allreduce(MPI_IN_PLACE, courant_num_diags, 1, MPI_COURANT_NUMBER_DIAGNOSTICS, MPI_MAX_COURANT_NUMBER, rdy->comm);
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 


### PR DESCRIPTION
This PR pulls some basic logic for our courant number diagnostics (including a MPI datatype and operator for reducing maximum wave speeds) out of the SWE code. The actual determination of the maxwave speed remains part of the SWE code, but as we generalize our approach to "operators", this will also be pulled out.