### PR TITLE
Changes OperatorSourceData interface to be region-aware.

### DIFF
--- a/driver/main.F90
+++ b/driver/main.F90
@@ -104,6 +104,7 @@ program rdycore_f90
   PetscInt             :: dirc_bc_idx, global_dirc_bc_idx
   PetscInt             :: cur_rain_idx, prev_rain_idx
   PetscInt             :: cur_bc_idx, prev_bc_idx
+  PetscInt             :: region_idx
   PetscReal            :: cur_rain, cur_bc
   PetscBool            :: interpolate_rain, interpolate_bc, flg
   PetscInt, parameter  :: ndof = 3
@@ -198,16 +199,17 @@ program rdycore_f90
       do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
 
         ! apply a 1 mm/hr rain over the entire domain (region 0)
+        region_idx = 0
         if (.not. rain_specified) then
           rain(:) = 1.d0/3600.d0/1000.d0
-          PetscCallA(RDySetRegionalWaterSource(rdy_, 0, n, rain, ierr))
+          PetscCallA(RDySetRegionalWaterSource(rdy_, region_idx, n, rain, ierr))
         else
           PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
           call getcurrentdata(rain_ptr, nrain, cur_time, interpolate_rain, cur_rain_idx, cur_rain)
           if (interpolate_rain .or. cur_rain_idx /= prev_rain_idx) then
             prev_rain_idx = cur_rain_idx
             rain(:) = cur_rain
-            PetscCallA(RDySetRegionalWaterSource(rdy_, 0, n, rain, ierr))
+            PetscCallA(RDySetRegionalWaterSource(rdy_, region_idx, n, rain, ierr))
           endif
         endif
 

--- a/driver/main.F90
+++ b/driver/main.F90
@@ -104,10 +104,13 @@ program rdycore_f90
   PetscInt             :: dirc_bc_idx, global_dirc_bc_idx
   PetscInt             :: cur_rain_idx, prev_rain_idx
   PetscInt             :: cur_bc_idx, prev_bc_idx
-  PetscInt             :: region_idx
+  PetscInt             :: region_0
   PetscReal            :: cur_rain, cur_bc
   PetscBool            :: interpolate_rain, interpolate_bc, flg
   PetscInt, parameter  :: ndof = 3
+
+  ! region 0 is the entire domain
+  region_0 = 0
 
   if (command_argument_count() < 1) then
     call usage()
@@ -154,8 +157,8 @@ program rdycore_f90
       PetscCallA(RDyGetLocalCellNaturalIDs(rdy_, n, nat_id, ierr))
 
       values(:) = 0.d0
-      PetscCallA(RDySetRegionalXMomentumSource(rdy_, 0, n, values, ierr))
-      PetscCallA(RDySetRegionalYMomentumSource(rdy_, 0, n, values, ierr))
+      PetscCallA(RDySetRegionalXMomentumSource(rdy_, region_0, n, values, ierr))
+      PetscCallA(RDySetRegionalYMomentumSource(rdy_, region_0, n, values, ierr))
 
       ! get information about boundary conditions
       dirc_bc_idx = 0
@@ -199,17 +202,16 @@ program rdycore_f90
       do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
 
         ! apply a 1 mm/hr rain over the entire domain (region 0)
-        region_idx = 0
         if (.not. rain_specified) then
           rain(:) = 1.d0/3600.d0/1000.d0
-          PetscCallA(RDySetRegionalWaterSource(rdy_, region_idx, n, rain, ierr))
+          PetscCallA(RDySetRegionalWaterSource(rdy_, region_0, n, rain, ierr))
         else
           PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
           call getcurrentdata(rain_ptr, nrain, cur_time, interpolate_rain, cur_rain_idx, cur_rain)
           if (interpolate_rain .or. cur_rain_idx /= prev_rain_idx) then
             prev_rain_idx = cur_rain_idx
             rain(:) = cur_rain
-            PetscCallA(RDySetRegionalWaterSource(rdy_, region_idx, n, rain, ierr))
+            PetscCallA(RDySetRegionalWaterSource(rdy_, region_0, n, rain, ierr))
           endif
         endif
 

--- a/driver/main.F90
+++ b/driver/main.F90
@@ -153,8 +153,8 @@ program rdycore_f90
       PetscCallA(RDyGetLocalCellNaturalIDs(rdy_, n, nat_id, ierr))
 
       values(:) = 0.d0
-      PetscCallA(RDySetDomainXMomentumSource(rdy_, n, values, ierr))
-      PetscCallA(RDySetDomainYMomentumSource(rdy_, n, values, ierr))
+      PetscCallA(RDySetRegionalXMomentumSource(rdy_, 0, n, values, ierr))
+      PetscCallA(RDySetRegionalYMomentumSource(rdy_, 0, n, values, ierr))
 
       ! get information about boundary conditions
       dirc_bc_idx = 0
@@ -197,17 +197,17 @@ program rdycore_f90
 
       do while (.not. RDyFinished(rdy_)) ! returns true based on stopping criteria
 
-        ! apply a 1 mm/hr rain over the entire domain
+        ! apply a 1 mm/hr rain over the entire domain (region 0)
         if (.not. rain_specified) then
           rain(:) = 1.d0/3600.d0/1000.d0
-          PetscCallA(RDySetDomainWaterSource(rdy_, n, rain, ierr))
+          PetscCallA(RDySetRegionalWaterSource(rdy_, 0, n, rain, ierr))
         else
           PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
           call getcurrentdata(rain_ptr, nrain, cur_time, interpolate_rain, cur_rain_idx, cur_rain)
           if (interpolate_rain .or. cur_rain_idx /= prev_rain_idx) then
             prev_rain_idx = cur_rain_idx
             rain(:) = cur_rain
-            PetscCallA(RDySetDomainWaterSource(rdy_, n, rain, ierr))
+            PetscCallA(RDySetRegionalWaterSource(rdy_, 0, n, rain, ierr))
           endif
         endif
 

--- a/driver/main.F90
+++ b/driver/main.F90
@@ -153,8 +153,8 @@ program rdycore_f90
       PetscCallA(RDyGetLocalCellNaturalIDs(rdy_, n, nat_id, ierr))
 
       values(:) = 0.d0
-      PetscCallA(RDySetXMomentumSourceForLocalCells(rdy_, n, values, ierr))
-      PetscCallA(RDySetYMomentumSourceForLocalCells(rdy_, n, values, ierr))
+      PetscCallA(RDySetDomainXMomentumSource(rdy_, n, values, ierr))
+      PetscCallA(RDySetDomainYMomentumSource(rdy_, n, values, ierr))
 
       ! get information about boundary conditions
       dirc_bc_idx = 0
@@ -200,14 +200,14 @@ program rdycore_f90
         ! apply a 1 mm/hr rain over the entire domain
         if (.not. rain_specified) then
           rain(:) = 1.d0/3600.d0/1000.d0
-          PetscCallA(RDySetWaterSourceForLocalCells(rdy_, n, rain, ierr))
+          PetscCallA(RDySetDomainWaterSource(rdy_, n, rain, ierr))
         else
           PetscCallA(RDyGetTime(rdy_, time_unit, cur_time, ierr))
           call getcurrentdata(rain_ptr, nrain, cur_time, interpolate_rain, cur_rain_idx, cur_rain)
           if (interpolate_rain .or. cur_rain_idx /= prev_rain_idx) then
             prev_rain_idx = cur_rain_idx
             rain(:) = cur_rain
-            PetscCallA(RDySetWaterSourceForLocalCells(rdy_, n, rain, ierr))
+            PetscCallA(RDySetDomainWaterSource(rdy_, n, rain, ierr))
           endif
         endif
 

--- a/driver/main.c
+++ b/driver/main.c
@@ -1255,25 +1255,25 @@ PetscErrorCode ApplyRainfallDataset(RDy rdy, PetscReal time, SourceSink *rain_da
     case CONSTANT:
       if (rain_dataset->ndata) {
         PetscCall(SetConstantRainfall(rain_dataset->constant.rate, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetWaterSourceForLocalCells(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case HOMOGENEOUS:
       if (rain_dataset->ndata) {
         PetscCall(SetHomogeneousData(&rain_dataset->homogeneous, time, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetWaterSourceForLocalCells(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case RASTER:
       if (rain_dataset->ndata) {
         PetscCall(SetRasterData(&rain_dataset->raster, time, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetWaterSourceForLocalCells(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case UNSTRUCTURED:
       if (rain_dataset->ndata) {
         PetscCall(SetUnstructuredData(&rain_dataset->unstructured, time, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetWaterSourceForLocalCells(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case MULTI_HOMOGENEOUS:
@@ -1281,7 +1281,7 @@ PetscErrorCode ApplyRainfallDataset(RDy rdy, PetscReal time, SourceSink *rain_da
         PetscInt  size = 1;
         PetscReal data;
         PetscCall(SetHomogeneousData(&rain_dataset->multihomogeneous.data[idata], time, size, &data));
-        PetscCall(RDySetWaterSourceForRegion(rdy, rain_dataset->multihomogeneous.region_ids[idata] - 1, data));
+        PetscCall(RDySetHomogeneousRegionalWaterSource(rdy, rain_dataset->multihomogeneous.region_ids[idata] - 1, data));
       }
       break;
   }

--- a/driver/main.c
+++ b/driver/main.c
@@ -1255,25 +1255,25 @@ PetscErrorCode ApplyRainfallDataset(RDy rdy, PetscReal time, SourceSink *rain_da
     case CONSTANT:
       if (rain_dataset->ndata) {
         PetscCall(SetConstantRainfall(rain_dataset->constant.rate, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case HOMOGENEOUS:
       if (rain_dataset->ndata) {
         PetscCall(SetHomogeneousData(&rain_dataset->homogeneous, time, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case RASTER:
       if (rain_dataset->ndata) {
         PetscCall(SetRasterData(&rain_dataset->raster, time, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case UNSTRUCTURED:
       if (rain_dataset->ndata) {
         PetscCall(SetUnstructuredData(&rain_dataset->unstructured, time, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetDomainWaterSource(rdy, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case MULTI_HOMOGENEOUS:

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -7,6 +7,7 @@
 #include <private/rdyconfigimpl.h>
 #include <private/rdylogimpl.h>
 #include <private/rdymeshimpl.h>
+#include <private/rdyregionimpl.h>
 #include <rdycore.h>
 
 // CEED initialization, availability, context, useful for creating CEED
@@ -38,16 +39,6 @@ typedef struct {
   char      name[MAX_NAME_LEN + 1];
   PetscReal manning;  // Manning's coefficient [s/m**(1/3)]
 } RDyMaterial;
-
-// This type defines a region consisting of cells identified by their local
-// indices.
-typedef struct {
-  char      name[MAX_NAME_LEN + 1];  // region name
-  PetscInt  id;                      // region ID (as specified in mesh file)
-  PetscInt  index;                   // index of region witin RDycore region list
-  PetscInt *cell_ids;
-  PetscInt  num_cells;
-} RDyRegion;
 
 // This type defines a "condition" representing
 // * an initial condition or source/sink associated with a region
@@ -197,14 +188,14 @@ struct _p_RDy {
     // context pointer -- must be cast to e.g. PetscRiemannDataSWE*
     void *context;
 
-    // source-sink vector
+    // source-sink vector for domain
     Vec sources;
   } petsc;
 
   // locks on operator data for exclusive access (see rdyoperatorimpl.h)
   struct {
     void **boundary_data;  // per-boundary operator boundary data
-    void  *source_data;    // operator source data for the domain
+    void  *source_data;    // domain operator source data
     void  *material_data;  // operator material data for the domain
     void  *flux_div_data;  // operator flux divergence data for the domain
   } lock;

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -222,7 +222,6 @@ PETSC_INTERN PetscErrorCode OverrideParameters(RDy);
 PETSC_INTERN PetscErrorCode PrintConfig(RDy);
 
 PETSC_INTERN PetscErrorCode RDyDestroyVectors(RDy *);
-PETSC_INTERN PetscErrorCode RDyDestroyRegions(RDy *);
 PETSC_INTERN PetscErrorCode RDyDestroyMaterials(RDy *);
 PETSC_INTERN PetscErrorCode RDyDestroyBoundaries(RDy *);
 

--- a/include/private/rdymeshimpl.h
+++ b/include/private/rdymeshimpl.h
@@ -32,7 +32,7 @@ typedef struct {
   PetscInt *natural_ids;
 
   /// PETSC_TRUE iff corresponding cell is owned (locally stored)
-  PetscBool *is_local;
+  PetscBool *is_owned;
 
   /// numbers of cell vertices
   PetscInt *num_vertices;

--- a/include/private/rdymeshimpl.h
+++ b/include/private/rdymeshimpl.h
@@ -31,7 +31,7 @@ typedef struct {
   /// natural IDs of cells in local numbering
   PetscInt *natural_ids;
 
-  /// PETSC_TRUE iff corresponding cell is locally stored
+  /// PETSC_TRUE iff corresponding cell is owned (locally stored)
   PetscBool *is_local;
 
   /// numbers of cell vertices

--- a/include/private/rdymeshimpl.h
+++ b/include/private/rdymeshimpl.h
@@ -82,9 +82,6 @@ typedef struct {
   // global IDs of vertices in local numbering
   PetscInt *global_ids;
 
-  // PETSC_TRUE iff vertex is attached to a local cell
-  PetscBool *is_local;
-
   // numbers of cells attached to vertices
   PetscInt *num_cells;
   // numbers of edges attached to vertices
@@ -115,11 +112,6 @@ typedef struct {
   PetscInt *internal_edge_ids;
   // local IDs of boundary edges
   PetscInt *boundary_edge_ids;
-
-  // PETSC_TRUE iff edge is shared by locally owned cells, OR
-  // if it is shared by a local cell c1 and non-local cell c2 such that
-  // global ID(c1) < global ID(c2).
-  PetscBool *is_local;
 
   // IDs of vertices attached to edges
   PetscInt *vertex_ids;

--- a/include/private/rdyoperatorimpl.h
+++ b/include/private/rdyoperatorimpl.h
@@ -4,6 +4,7 @@
 #include <ceed/ceed.h>
 #include <petsc/private/petscimpl.h>
 #include <private/rdyboundaryimpl.h>
+#include <private/rdyregionimpl.h>
 
 // initialization/finalization functions
 PETSC_INTERN PetscErrorCode InitOperators(RDy);
@@ -36,7 +37,7 @@ typedef struct {
   PetscBool updated;  // true iff updated
 } OperatorVectorData;
 
-// This type allows the direct manipulation of per-boundary values for the
+// This type allows the direct manipulation of boundary values for the
 // system of equations being solved by RDycore.
 typedef struct {
   // associated RDy object
@@ -53,21 +54,23 @@ PETSC_INTERN PetscErrorCode GetOperatorBoundaryData(RDy, RDyBoundary, OperatorBo
 PETSC_INTERN PetscErrorCode SetOperatorBoundaryValues(OperatorBoundaryData *, PetscInt, PetscReal *);
 PETSC_INTERN PetscErrorCode RestoreOperatorBoundaryData(RDy, RDyBoundary, OperatorBoundaryData *);
 
-// This type allows the direct manipulation of source values on the entire
-// domain for the system of equations being solved by RDycore.
+// This type allows the direct manipulation of source values on a specific
+// region for the system of equations being solved by RDycore.
 typedef struct {
   // associated RDy object
   RDy rdy;
+  // associated region
+  RDyRegion region;
   // number of components in the underlying system
   PetscInt num_components;
   // underlying data storage
   OperatorVectorData sources;
 } OperatorSourceData;
 
-PETSC_INTERN PetscErrorCode GetOperatorSourceData(RDy, OperatorSourceData *);
+PETSC_INTERN PetscErrorCode GetOperatorSourceData(RDy, RDyRegion, OperatorSourceData *);
 PETSC_INTERN PetscErrorCode SetOperatorSourceValues(OperatorSourceData *, PetscInt, PetscReal *);
 PETSC_INTERN PetscErrorCode GetOperatorSourceValues(OperatorSourceData *, PetscInt, PetscReal *);
-PETSC_INTERN PetscErrorCode RestoreOperatorSourceData(RDy, OperatorSourceData *);
+PETSC_INTERN PetscErrorCode RestoreOperatorSourceData(RDy, RDyRegion, OperatorSourceData *);
 
 // This type allows the direct manipulation of operator material properties on
 // the entire domain for the system of equations being solved by RDycore.

--- a/include/private/rdyregionimpl.h
+++ b/include/private/rdyregionimpl.h
@@ -4,14 +4,26 @@
 #include <petsc/private/petscimpl.h>
 #include <rdycore.h>
 
-// This type defines a region consisting of cells identified by their local
-// indices.
+// This type defines a region consisting of cells referenced by specific IDs.
 typedef struct {
-  char      name[MAX_NAME_LEN + 1];  // region name
-  PetscInt  id;                      // region ID (as specified in mesh file)
-  PetscInt  index;                   // index of region witin RDycore region list
-  PetscInt *cell_ids;
-  PetscInt  num_cells;
+  char     name[MAX_NAME_LEN + 1];  // region name
+  PetscInt id;                      // region ID (as specified in mesh file)
+  PetscInt index;                   // index of region witin RDycore region list
+
+  PetscInt  num_owned_cells;        // number of owned cells in the region
+  PetscInt *owned_cell_global_ids;  // global IDs for owned cells in the region,
+                                    // for use with a global PETSc Vec
+                                    // (this is redundant, since cells belonging
+                                    //  to the global topology are all owned, but
+                                    //  it serves as a reminder of our complicated
+                                    //  indexing nomenclature)
+
+  PetscInt num_local_cells;  // number of cells in the region that belong to
+                             // the local topology
+  PetscInt *cell_local_ids;  // local IDs for cells in the region, for use with
+                             // a local PETSc Vec
 } RDyRegion;
+
+PETSC_INTERN PetscErrorCode DestroyRegion(RDyRegion *region);
 
 #endif

--- a/include/private/rdyregionimpl.h
+++ b/include/private/rdyregionimpl.h
@@ -1,0 +1,17 @@
+#ifndef RDYCOREREGIONIMPL_H
+#define RDYCOREREGIONIMPL_H
+
+#include <petsc/private/petscimpl.h>
+#include <rdycore.h>
+
+// This type defines a region consisting of cells identified by their local
+// indices.
+typedef struct {
+  char      name[MAX_NAME_LEN + 1];  // region name
+  PetscInt  id;                      // region ID (as specified in mesh file)
+  PetscInt  index;                   // index of region witin RDycore region list
+  PetscInt *cell_ids;
+  PetscInt  num_cells;
+} RDyRegion;
+
+#endif

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -102,21 +102,13 @@ PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt
 
 PETSC_EXTERN PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_index, const PetscInt num_edges, const PetscInt ndof, PetscReal *values);
 
-PETSC_EXTERN PetscErrorCode RDySetRegionalWaterSource(RDy rdy, const PetscInt region_idx, PetscReal *values);
-PETSC_EXTERN PetscErrorCode RDySetRegionalXMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal *values);
-PETSC_EXTERN PetscErrorCode RDySetRegionalYMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetRegionalWaterSource(RDy rdy, const PetscInt region_idx, PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetRegionalXMomentumSource(RDy rdy, const PetscInt region_idx, PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetRegionalYMomentumSource(RDy rdy, const PetscInt region_idx, PetscInt size, PetscReal *values);
 
 PETSC_EXTERN PetscErrorCode RDySetHomogeneousRegionalWaterSource(RDy rdy, const PetscInt region_idx, PetscReal value);
 PETSC_EXTERN PetscErrorCode RDySetHomogeneousRegionalXMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal value);
 PETSC_EXTERN PetscErrorCode RDySetHomogeneousRegionalYMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal value);
-
-PETSC_EXTERN PetscErrorCode RDySetDomainWaterSource(RDy rdy, PetscInt size, PetscReal *values);
-PETSC_EXTERN PetscErrorCode RDySetDomainXMomentumSource(RDy rdy, PetscInt size, PetscReal *values);
-PETSC_EXTERN PetscErrorCode RDySetDomainYMomentumSource(RDy rdy, PetscInt size, PetscReal *values);
-
-PETSC_EXTERN PetscErrorCode RDySetHomogeneousDomainWaterSource(RDy rdy, PetscReal value);
-PETSC_EXTERN PetscErrorCode RDySetHomogeneousDomainXMomentumSource(RDy rdy, PetscReal value);
-PETSC_EXTERN PetscErrorCode RDySetHomogeneousDomainYMomentumSource(RDy rdy, PetscReal value);
 
 PETSC_EXTERN PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
 PETSC_EXTERN PetscErrorCode RDySetInitialConditions(RDy rdy, Vec ic);

--- a/include/rdycore.h.in
+++ b/include/rdycore.h.in
@@ -101,10 +101,23 @@ PETSC_EXTERN PetscErrorCode RDyGetBoundaryID(RDy rdy, const PetscInt boundary_in
 PETSC_EXTERN PetscErrorCode RDyGetBoundaryCellNaturalIDs(RDy rdy, const PetscInt boundary_index, const PetscInt size, PetscInt *values);
 
 PETSC_EXTERN PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_index, const PetscInt num_edges, const PetscInt ndof, PetscReal *values);
-PETSC_EXTERN PetscErrorCode RDySetWaterSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
-PETSC_EXTERN PetscErrorCode RDySetWaterSourceForRegion(RDy rdy, const PetscInt region_idx, PetscReal values);
-PETSC_EXTERN PetscErrorCode RDySetXMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
-PETSC_EXTERN PetscErrorCode RDySetYMomentumSourceForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
+
+PETSC_EXTERN PetscErrorCode RDySetRegionalWaterSource(RDy rdy, const PetscInt region_idx, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetRegionalXMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetRegionalYMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal *values);
+
+PETSC_EXTERN PetscErrorCode RDySetHomogeneousRegionalWaterSource(RDy rdy, const PetscInt region_idx, PetscReal value);
+PETSC_EXTERN PetscErrorCode RDySetHomogeneousRegionalXMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal value);
+PETSC_EXTERN PetscErrorCode RDySetHomogeneousRegionalYMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal value);
+
+PETSC_EXTERN PetscErrorCode RDySetDomainWaterSource(RDy rdy, PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetDomainXMomentumSource(RDy rdy, PetscInt size, PetscReal *values);
+PETSC_EXTERN PetscErrorCode RDySetDomainYMomentumSource(RDy rdy, PetscInt size, PetscReal *values);
+
+PETSC_EXTERN PetscErrorCode RDySetHomogeneousDomainWaterSource(RDy rdy, PetscReal value);
+PETSC_EXTERN PetscErrorCode RDySetHomogeneousDomainXMomentumSource(RDy rdy, PetscReal value);
+PETSC_EXTERN PetscErrorCode RDySetHomogeneousDomainYMomentumSource(RDy rdy, PetscReal value);
+
 PETSC_EXTERN PetscErrorCode RDySetManningsNForLocalCells(RDy rdy, const PetscInt size, PetscReal *values);
 PETSC_EXTERN PetscErrorCode RDySetInitialConditions(RDy rdy, Vec ic);
 

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -24,7 +24,7 @@ module rdycore
             RDyGetLocalCellAreas, RDyGetLocalCellNaturalIDs, &
             RDyGetBoundaryEdgeXCentroids, RDyGetBoundaryEdgeYCentroids, RDyGetBoundaryEdgeZCentroids, &
             RDyGetBoundaryCellNaturalIDs, &
-            RDySetWaterSourceForLocalCells, RDySetXMomentumSourceForLocalCells, RDySetYMomentumSourceForLocalCells, &
+            RDySetDomainWaterSource, RDySetDomainXMomentumSource, RDySetDomainYMomentumSource, &
             RDySetManningsNForLocalCells, RDySetInitialConditions, &
             RDyCreatePrognosticVec, RDyReadOneDOFLocalVecFromBinaryFile, RDyReadOneDOFGlobalVecFromBinaryFile
 
@@ -331,24 +331,24 @@ module rdycore
       type(c_ptr), value, intent(in) :: values
     end function
 
-    integer(c_int) function rdysetwatersourceforlocalcells_(rdy, size, watsrc) bind(c, name="RDySetWaterSourceForLocalCells")
+    integer(c_int) function rdysetdomainwatersource_(rdy, size, watsrc) bind(c, name="RDySetDomainWaterSource")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
-      PetscInt, value, intent(in)    :: size
+      PetscInt   , value, intent(in) :: size
       type(c_ptr), value, intent(in) :: watsrc
     end function
 
-    integer(c_int) function rdysetxmomentumsourceforlocalcells_(rdy, size, xmomsrc) bind(c, name="RDySetXMomentumSourceForLocalCells")
+    integer(c_int) function rdysetdomainxmomentumsource_(rdy, size, xmomsrc) bind(c, name="RDySetDomainXMomentumSource")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
-      PetscInt, value, intent(in)    :: size
+      PetscInt   , value, intent(in) :: size
       type(c_ptr), value, intent(in) :: xmomsrc
     end function
 
-    integer(c_int) function rdysetymomentumsourceforlocalcells_(rdy, size, ymomsrc) bind(c, name="RDySetYMomentumSourceForLocalCells")
+    integer(c_int) function rdysetdomainymomentumsource_(rdy, size, ymomsrc) bind(c, name="RDySetDomainYMomentumSource")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
-      PetscInt, value, intent(in)    :: size
+      PetscInt   , value, intent(in) :: size
       type(c_ptr), value, intent(in) :: ymomsrc
     end function
 
@@ -763,28 +763,28 @@ contains
     ierr = rdygetboundarycellnaturalids_(rdy_%c_rdy, boundary_index - 1, size, c_loc(values))
   end subroutine
 
-  subroutine RDySetWaterSourceForLocalCells(rdy_, size, watsrc, ierr)
+  subroutine RDySetDomainWaterSource(rdy_, size, watsrc, ierr)
     type(RDy),       intent(inout)       :: rdy_
     PetscInt,        intent(in)          :: size
     real(RDyDouble), pointer, intent(in) :: watsrc(:)
     integer,         intent(out)         :: ierr
-    ierr = rdysetwatersourceforlocalcells_(rdy_%c_rdy, size, c_loc(watsrc))
+    ierr = rdysetdomainwatersource_(rdy_%c_rdy, size, c_loc(watsrc))
   end subroutine
 
-  subroutine RDySetXMomentumSourceForLocalCells(rdy_, size, xmomsrc, ierr)
+  subroutine RDySetDomainXMomentumSource(rdy_, size, xmomsrc, ierr)
     type(RDy),       intent(inout)       :: rdy_
     PetscInt,        intent(in)          :: size
     real(RDyDouble), pointer, intent(in) :: xmomsrc(:)
     integer,         intent(out)         :: ierr
-    ierr = rdysetxmomentumsourceforlocalcells_(rdy_%c_rdy, size, c_loc(xmomsrc))
+    ierr = rdysetdomainxmomentumsource_(rdy_%c_rdy, size, c_loc(xmomsrc))
   end subroutine
 
-  subroutine RDySetYMomentumSourceForLocalCells(rdy_, size, ymomsrc, ierr)
+  subroutine RDySetDomainYMomentumSource(rdy_, size, ymomsrc, ierr)
     type(RDy),       intent(inout)       :: rdy_
     PetscInt,        intent(in)          :: size
     real(RDyDouble), pointer, intent(in) :: ymomsrc(:)
     integer,         intent(out)         :: ierr
-    ierr = rdysetymomentumsourceforlocalcells_(rdy_%c_rdy, size, c_loc(ymomsrc))
+    ierr = rdysetdomainymomentumsource_(rdy_%c_rdy, size, c_loc(ymomsrc))
   end subroutine
 
   subroutine RDySetManningsNForLocalCells(rdy_, size, n, ierr)

--- a/src/f90-mod/rdycore.F90
+++ b/src/f90-mod/rdycore.F90
@@ -24,7 +24,7 @@ module rdycore
             RDyGetLocalCellAreas, RDyGetLocalCellNaturalIDs, &
             RDyGetBoundaryEdgeXCentroids, RDyGetBoundaryEdgeYCentroids, RDyGetBoundaryEdgeZCentroids, &
             RDyGetBoundaryCellNaturalIDs, &
-            RDySetDomainWaterSource, RDySetDomainXMomentumSource, RDySetDomainYMomentumSource, &
+            RDySetRegionalWaterSource, RDySetRegionalXMomentumSource, RDySetRegionalYMomentumSource, &
             RDySetManningsNForLocalCells, RDySetInitialConditions, &
             RDyCreatePrognosticVec, RDyReadOneDOFLocalVecFromBinaryFile, RDyReadOneDOFGlobalVecFromBinaryFile
 
@@ -331,23 +331,26 @@ module rdycore
       type(c_ptr), value, intent(in) :: values
     end function
 
-    integer(c_int) function rdysetdomainwatersource_(rdy, size, watsrc) bind(c, name="RDySetDomainWaterSource")
+    integer(c_int) function rdysetregionalwatersource_(rdy, region_idx, size, watsrc) bind(c, name="RDySetRegionalWaterSource")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
+      PetscInt   , value, intent(in) :: region_idx
       PetscInt   , value, intent(in) :: size
       type(c_ptr), value, intent(in) :: watsrc
     end function
 
-    integer(c_int) function rdysetdomainxmomentumsource_(rdy, size, xmomsrc) bind(c, name="RDySetDomainXMomentumSource")
+    integer(c_int) function rdysetregionalxmomentumsource_(rdy, region_idx, size, xmomsrc) bind(c, name="RDySetRegionalXMomentumSource")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
+      PetscInt   , value, intent(in) :: region_idx
       PetscInt   , value, intent(in) :: size
       type(c_ptr), value, intent(in) :: xmomsrc
     end function
 
-    integer(c_int) function rdysetdomainymomentumsource_(rdy, size, ymomsrc) bind(c, name="RDySetDomainYMomentumSource")
+    integer(c_int) function rdysetregionalymomentumsource_(rdy, region_idx, size, ymomsrc) bind(c, name="RDySetRegionalYMomentumSource")
       use iso_c_binding, only: c_int, c_ptr
       type(c_ptr), value, intent(in) :: rdy
+      PetscInt   , value, intent(in) :: region_idx
       PetscInt   , value, intent(in) :: size
       type(c_ptr), value, intent(in) :: ymomsrc
     end function
@@ -763,28 +766,31 @@ contains
     ierr = rdygetboundarycellnaturalids_(rdy_%c_rdy, boundary_index - 1, size, c_loc(values))
   end subroutine
 
-  subroutine RDySetDomainWaterSource(rdy_, size, watsrc, ierr)
+  subroutine RDySetRegionalWaterSource(rdy_, region_idx, size, watsrc, ierr)
     type(RDy),       intent(inout)       :: rdy_
+    PetscInt,        intent(in)          :: region_idx
     PetscInt,        intent(in)          :: size
     real(RDyDouble), pointer, intent(in) :: watsrc(:)
     integer,         intent(out)         :: ierr
-    ierr = rdysetdomainwatersource_(rdy_%c_rdy, size, c_loc(watsrc))
+    ierr = rdysetregionalwatersource_(rdy_%c_rdy, region_idx, size, c_loc(watsrc))
   end subroutine
 
-  subroutine RDySetDomainXMomentumSource(rdy_, size, xmomsrc, ierr)
+  subroutine RDySetRegionalXMomentumSource(rdy_, region_idx, size, xmomsrc, ierr)
     type(RDy),       intent(inout)       :: rdy_
+    PetscInt,        intent(in)          :: region_idx
     PetscInt,        intent(in)          :: size
     real(RDyDouble), pointer, intent(in) :: xmomsrc(:)
     integer,         intent(out)         :: ierr
-    ierr = rdysetdomainxmomentumsource_(rdy_%c_rdy, size, c_loc(xmomsrc))
+    ierr = rdysetregionalxmomentumsource_(rdy_%c_rdy, region_idx, size, c_loc(xmomsrc))
   end subroutine
 
-  subroutine RDySetDomainYMomentumSource(rdy_, size, ymomsrc, ierr)
+  subroutine RDySetRegionalYMomentumSource(rdy_, region_idx, size, ymomsrc, ierr)
     type(RDy),       intent(inout)       :: rdy_
+    PetscInt,        intent(in)          :: region_idx
     PetscInt,        intent(in)          :: size
     real(RDyDouble), pointer, intent(in) :: ymomsrc(:)
     integer,         intent(out)         :: ierr
-    ierr = rdysetdomainymomentumsource_(rdy_%c_rdy, size, c_loc(ymomsrc))
+    ierr = rdysetregionalymomentumsource_(rdy_%c_rdy, region_idx, size, c_loc(ymomsrc))
   end subroutine
 
   subroutine RDySetManningsNForLocalCells(rdy_, size, n, ierr)

--- a/src/f90-mod/tests/test_coupling.F90
+++ b/src/f90-mod/tests/test_coupling.F90
@@ -83,6 +83,7 @@ contains
     PetscInt             :: t
     integer(RDyTimeUnit) :: time_unit
     PetscReal            :: time_dn, time_up, cur_time, cur_rain
+    PetscInt             :: region_id
     PetscErrorCode       :: ierr
 
     cur_time = (nstep-1)*dtime
@@ -90,7 +91,8 @@ contains
     ! Set spatially homogeneous rainfall for all grid cells
     ! (the domain is region 0)
     rain_data(:) = 0.d0
-    PetscCallA(RDySetRegionalWaterSource(rdy_, 0, num_cells_owned, rain_data, ierr))
+    region_id = 0
+    PetscCallA(RDySetRegionalWaterSource(rdy_, region_id, num_cells_owned, rain_data, ierr))
 
     ! Set the coupling time step
     PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))

--- a/src/f90-mod/tests/test_coupling.F90
+++ b/src/f90-mod/tests/test_coupling.F90
@@ -88,8 +88,9 @@ contains
     cur_time = (nstep-1)*dtime
 
     ! Set spatially homogeneous rainfall for all grid cells
+    ! (the domain is region 0)
     rain_data(:) = 0.d0
-    PetscCallA(RDySetDomainWaterSource(rdy_, num_cells_owned, rain_data, ierr))
+    PetscCallA(RDySetRegionalWaterSource(rdy_, 0, num_cells_owned, rain_data, ierr))
 
     ! Set the coupling time step
     PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))

--- a/src/f90-mod/tests/test_coupling.F90
+++ b/src/f90-mod/tests/test_coupling.F90
@@ -89,7 +89,7 @@ contains
 
     ! Set spatially homogeneous rainfall for all grid cells
     rain_data(:) = 0.d0
-    PetscCallA(RDySetWaterSourceForLocalCells(rdy_, num_cells_owned, rain_data, ierr))
+    PetscCallA(RDySetDomainWaterSource(rdy_, num_cells_owned, rain_data, ierr))
 
     ! Set the coupling time step
     PetscCallA(RDyGetTimeUnit(rdy_, time_unit, ierr))

--- a/src/operator.c
+++ b/src/operator.c
@@ -142,17 +142,20 @@ PetscErrorCode RestoreOperatorBoundaryData(RDy rdy, RDyBoundary boundary, Operat
       PetscCall(VecRestoreArray(boundary_data->storage.petsc.vec, &boundary_data->storage.petsc.data));
     }
   }
-  boundary_data->rdy->lock.boundary_data[boundary_data->boundary.index] = NULL;
-  *boundary_data                                                        = (OperatorBoundaryData){0};
+  boundary_data->rdy->lock.boundary_data[boundary.index] = NULL;
+  *boundary_data                                         = (OperatorBoundaryData){0};
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode GetOperatorSourceData(RDy rdy, OperatorSourceData *source_data) {
+PetscErrorCode GetOperatorSourceData(RDy rdy, RDyRegion region, OperatorSourceData *source_data) {
   PetscFunctionBegin;
   *source_data = (OperatorSourceData){0};
   PetscCheck(!rdy->lock.source_data, rdy->comm, PETSC_ERR_USER, "Could not acquire lock on source data -- another entity has access");
+  PetscCheck(region.index >= 0 && region.index < rdy->num_regions, rdy->comm, PETSC_ERR_USER,
+             "Invalid region for source data (index: %" PetscInt_FMT ")", region.index);
   rdy->lock.source_data = source_data;
   source_data->rdy      = rdy;
+  source_data->region   = region;
   PetscCall(VecGetBlockSize(rdy->u_global, &source_data->num_components));
 
   if (CeedEnabled()) {
@@ -176,32 +179,48 @@ PetscErrorCode GetOperatorSourceData(RDy rdy, OperatorSourceData *source_data) {
 PetscErrorCode SetOperatorSourceValues(OperatorSourceData *source_data, PetscInt component, PetscReal *source_values) {
   PetscFunctionBegin;
 
-  if (CeedEnabled()) {
-    // if this is the first update, get access to the vector's data
-    if (!source_data->sources.updated) {
-      PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
-      source_data->sources.updated = PETSC_TRUE;
+  // if this is the first update, get access to the vector's data
+  // (only the source data that obtained the lock actually gains access to
+  //  the array)
+  OperatorSourceData *source_data_with_lock = source_data->rdy->lock.source_data;
+  if (!source_data->sources.updated) {
+    if (source_data == source_data_with_lock) {
+      if (CeedEnabled()) {
+        PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
+      } else {
+        PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
+      }
+    } else {
+      source_data->sources.ceed.data = source_data_with_lock->sources.ceed.data;
     }
+    source_data->sources.updated = PETSC_TRUE;
+  }
 
+  RDyMesh  *mesh  = &source_data->rdy->mesh;
+  RDyCells *cells = &mesh->cells;
+
+  // fetch values -- the underlying vector is the set of all owned cells in
+  // the computational domain, so we have to sift through indices
+  if (CeedEnabled()) {
     // reshape for multicomponent access
     CeedScalar(*values)[source_data->num_components];
     *((CeedScalar **)&values) = source_data->sources.ceed.data;
 
-    // set the values
-    for (CeedInt i = 0; i < source_data->rdy->mesh.num_owned_cells; ++i) {
-      values[i][component] = source_values[i];
+    for (PetscInt c = 0; c < source_data->region.num_cells; ++c) {
+      PetscInt cell_id = source_data->region.cell_ids[c];
+      if (cells->is_local[cell_id]) {
+        PetscInt owned_cell_id           = cells->local_to_owned[cell_id];
+        values[owned_cell_id][component] = source_values[c];
+      }
     }
   } else {
-    // if this is the first update, get access to the vector's data
-    if (!source_data->sources.updated) {
-      PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
-      source_data->sources.updated = PETSC_TRUE;
-    }
-
-    // set the values
     PetscReal *s = source_data->sources.petsc.data;
-    for (PetscInt i = 0; i < source_data->rdy->mesh.num_owned_cells; ++i) {
-      s[i * source_data->num_components + component] = source_values[i];
+    for (PetscInt c = 0; c < source_data->region.num_cells; ++c) {
+      PetscInt cell_id = source_data->region.cell_ids[c];
+      if (cells->is_local[cell_id]) {
+        PetscInt owned_cell_id                                     = cells->local_to_owned[cell_id];
+        s[owned_cell_id * source_data->num_components + component] = source_values[c];
+      }
     }
   }
 
@@ -212,47 +231,67 @@ PetscErrorCode SetOperatorSourceValues(OperatorSourceData *source_data, PetscInt
 PetscErrorCode GetOperatorSourceValues(OperatorSourceData *source_data, PetscInt component, PetscReal *source_values) {
   PetscFunctionBegin;
 
-  if (CeedEnabled()) {
-    // if this is the first update, get access to the vector's data
-    if (!source_data->sources.updated) {
-      PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
-      source_data->sources.updated = PETSC_TRUE;
+  // if this is the first update, get access to the vector's data
+  // (only the source data that obtained the lock actually gains access to
+  //  the array)
+  OperatorSourceData *source_data_with_lock = source_data->rdy->lock.source_data;
+  if (!source_data->sources.updated) {
+    if (source_data == source_data_with_lock) {
+      if (CeedEnabled()) {
+        PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
+      } else {
+        PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
+      }
+    } else {
+      source_data->sources.ceed.data = source_data_with_lock->sources.ceed.data;
     }
+    source_data->sources.updated = PETSC_TRUE;
+  }
 
+  RDyMesh  *mesh  = &source_data->rdy->mesh;
+  RDyCells *cells = &mesh->cells;
+
+  // fetch values -- the underlying vector is the set of all owned cells in
+  // the computational domain, so we have to sift through indices
+  if (CeedEnabled()) {
     // reshape for multicomponent access
     CeedScalar(*values)[source_data->num_components];
     *((CeedScalar **)&values) = source_data->sources.ceed.data;
 
-    // set the values
-    for (CeedInt i = 0; i < source_data->rdy->mesh.num_owned_cells; ++i) {
-      source_values[i] = values[i][component];
+    for (PetscInt c = 0; c < source_data->region.num_cells; ++c) {
+      PetscInt cell_id = source_data->region.cell_ids[c];
+      if (cells->is_local[cell_id]) {
+        PetscInt owned_cell_id = cells->local_to_owned[cell_id];
+        source_values[c]       = values[owned_cell_id][component];
+      }
     }
   } else {
-    // if this is the first update, get access to the vector's data
-    if (!source_data->sources.updated) {
-      PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
-      source_data->sources.updated = PETSC_TRUE;
-    }
-
-    // set the values
     PetscReal *s = source_data->sources.petsc.data;
-    for (PetscInt i = 0; i < source_data->rdy->mesh.num_owned_cells; ++i) {
-      source_values[i] = s[i * source_data->num_components + component];
+
+    for (PetscInt c = 0; c < source_data->region.num_cells; ++c) {
+      PetscInt cell_id = source_data->region.cell_ids[c];
+      if (cells->is_local[cell_id]) {
+        PetscInt owned_cell_id = cells->local_to_owned[cell_id];
+        source_values[c]       = s[owned_cell_id * source_data->num_components + component];
+      }
     }
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-PetscErrorCode RestoreOperatorSourceData(RDy rdy, OperatorSourceData *source_data) {
+PetscErrorCode RestoreOperatorSourceData(RDy rdy, RDyRegion region, OperatorSourceData *source_data) {
   PetscFunctionBegin;
   PetscCheck(rdy == source_data->rdy, rdy->comm, PETSC_ERR_USER, "Could not restore operator source data: wrong RDy");
-  if (CeedEnabled()) {
-    if (source_data->sources.updated) {
+  PetscCheck(region.index == source_data->region.index, rdy->comm, PETSC_ERR_USER, "Could not restore operator source data: wrong region");
+
+  // only the source data that obtained the lock actually gains access to
+  // the array
+  OperatorSourceData *source_data_with_lock = source_data->rdy->lock.source_data;
+  if (source_data->sources.updated && source_data == source_data_with_lock) {
+    if (CeedEnabled()) {
       PetscCallCEED(CeedVectorRestoreArray(source_data->sources.ceed.vec, &source_data->sources.ceed.data));
-    }
-  } else {  // petsc
-    if (source_data->sources.updated) {
+    } else {  // petsc
       PetscCall(VecRestoreArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
     }
   }

--- a/src/operator.c
+++ b/src/operator.c
@@ -180,18 +180,11 @@ PetscErrorCode SetOperatorSourceValues(OperatorSourceData *source_data, PetscInt
   PetscFunctionBegin;
 
   // if this is the first update, get access to the vector's data
-  // (only the source data that obtained the lock actually gains access to
-  //  the array)
-  OperatorSourceData *source_data_with_lock = source_data->rdy->lock.source_data;
   if (!source_data->sources.updated) {
-    if (source_data == source_data_with_lock) {
-      if (CeedEnabled()) {
-        PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
-      } else {
-        PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
-      }
+    if (CeedEnabled()) {
+      PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
     } else {
-      source_data->sources.ceed.data = source_data_with_lock->sources.ceed.data;
+      PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
     }
     source_data->sources.updated = PETSC_TRUE;
   }
@@ -232,18 +225,11 @@ PetscErrorCode GetOperatorSourceValues(OperatorSourceData *source_data, PetscInt
   PetscFunctionBegin;
 
   // if this is the first update, get access to the vector's data
-  // (only the source data that obtained the lock actually gains access to
-  //  the array)
-  OperatorSourceData *source_data_with_lock = source_data->rdy->lock.source_data;
   if (!source_data->sources.updated) {
-    if (source_data == source_data_with_lock) {
-      if (CeedEnabled()) {
-        PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
-      } else {
-        PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
-      }
+    if (CeedEnabled()) {
+      PetscCallCEED(CeedVectorGetArray(source_data->sources.ceed.vec, CEED_MEM_HOST, &source_data->sources.ceed.data));
     } else {
-      source_data->sources.ceed.data = source_data_with_lock->sources.ceed.data;
+      PetscCall(VecGetArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
     }
     source_data->sources.updated = PETSC_TRUE;
   }
@@ -285,15 +271,10 @@ PetscErrorCode RestoreOperatorSourceData(RDy rdy, RDyRegion region, OperatorSour
   PetscCheck(rdy == source_data->rdy, rdy->comm, PETSC_ERR_USER, "Could not restore operator source data: wrong RDy");
   PetscCheck(region.index == source_data->region.index, rdy->comm, PETSC_ERR_USER, "Could not restore operator source data: wrong region");
 
-  // only the source data that obtained the lock actually gains access to
-  // the array
-  OperatorSourceData *source_data_with_lock = source_data->rdy->lock.source_data;
-  if (source_data->sources.updated && source_data == source_data_with_lock) {
-    if (CeedEnabled()) {
-      PetscCallCEED(CeedVectorRestoreArray(source_data->sources.ceed.vec, &source_data->sources.ceed.data));
-    } else {  // petsc
-      PetscCall(VecRestoreArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
-    }
+  if (CeedEnabled()) {
+    PetscCallCEED(CeedVectorRestoreArray(source_data->sources.ceed.vec, &source_data->sources.ceed.data));
+  } else {  // petsc
+    PetscCall(VecRestoreArray(source_data->sources.petsc.vec, &source_data->sources.petsc.data));
   }
   source_data->rdy->lock.source_data = NULL;
   *source_data                       = (OperatorSourceData){0};

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -141,18 +141,16 @@ PetscErrorCode RDyDestroyVectors(RDy *rdy) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// @brief Destroy data structures for regions
-/// @param rdy A RDy struct
-/// @return 0 on success, or a non-zero error code on failure
-PetscErrorCode RDyDestroyRegions(RDy *rdy) {
+/// @brief Destroys a region data structure.
+PetscErrorCode DestroyRegion(RDyRegion *region) {
   PetscFunctionBegin;
 
-  for (PetscInt i = 0; i < (*rdy)->num_regions; ++i) {
-    if ((*rdy)->regions[i].cell_ids) {
-      PetscFree((*rdy)->regions[i].cell_ids);
-    }
+  if (region->owned_cell_global_ids) {
+    PetscFree(region->owned_cell_global_ids);
   }
-  if ((*rdy)->regions) PetscFree((*rdy)->regions);
+  if (region->cell_local_ids) {
+    PetscFree(region->cell_local_ids);
+  }
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -203,7 +201,10 @@ PetscErrorCode RDyDestroy(RDy *rdy) {
   PetscCall(RDyDestroyMaterials(rdy));
 
   // destroy regions
-  PetscCall(RDyDestroyRegions(rdy));
+  for (PetscInt r = 0; r < (*rdy)->num_regions; ++r) {
+    PetscCall(DestroyRegion(&((*rdy)->regions[r])));
+  }
+  PetscFree((*rdy)->regions);
 
   // destroy materials
   PetscCall(RDyDestroyBoundaries(rdy));

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -132,7 +132,7 @@ PetscErrorCode RDySetDirichletBoundaryValues(RDy rdy, const PetscInt boundary_in
     for (PetscInt e = 0; e < boundary.num_edges; ++e) {
       PetscInt iedge = boundary.edge_ids[e];
       PetscInt icell = edges->cell_ids[2 * iedge];
-      if (cells->is_local[icell]) {
+      if (cells->is_owned[icell]) {
         bdata.h[e]  = values[3 * e];
         bdata.hu[e] = values[3 * e + 1];
         bdata.hv[e] = values[3 * e + 2];
@@ -269,7 +269,7 @@ static PetscErrorCode RDyGetIDimCentroidOfLocalCell(RDy rdy, PetscInt idim, Pets
 
   PetscInt count = 0;
   for (PetscInt icell = 0; icell < rdy->mesh.num_cells; ++icell) {
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       x[count++] = cells->centroids[icell].X[idim];
     }
   }
@@ -305,7 +305,7 @@ PetscErrorCode RDyGetLocalCellAreas(RDy rdy, const PetscInt size, PetscReal *val
 
   PetscInt count = 0;
   for (PetscInt icell = 0; icell < rdy->mesh.num_cells; ++icell) {
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       values[count++] = cells->areas[icell];
     }
   }
@@ -321,7 +321,7 @@ PetscErrorCode RDyGetLocalCellNaturalIDs(RDy rdy, const PetscInt size, PetscInt 
 
   PetscInt count = 0;
   for (PetscInt icell = 0; icell < rdy->mesh.num_cells; ++icell) {
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       values[count++] = cells->natural_ids[icell];
     }
   }

--- a/src/rdydata.c
+++ b/src/rdydata.c
@@ -190,9 +190,10 @@ PetscErrorCode RDyGetLocalCellYMomentums(RDy rdy, const PetscInt size, PetscReal
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode SetRegionalSourceComponent(RDy rdy, const PetscInt region_idx, PetscInt component, PetscReal *values) {
+static PetscErrorCode SetRegionalSourceComponent(RDy rdy, const PetscInt region_idx, PetscInt component, PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
   PetscCall(CheckRegionIndex(rdy, region_idx));
+  PetscCall(CheckNumLocalCells(rdy, size));
 
   RDyRegion region = rdy->regions[region_idx];
   if (region.num_owned_cells) {
@@ -208,27 +209,27 @@ static PetscErrorCode SetRegionalSourceComponent(RDy rdy, const PetscInt region_
 /// Sets the external water source term on the region with the given index to
 /// the values in the given array (whose length is equal to the number of owned
 /// cells in that region).
-PetscErrorCode RDySetRegionalWaterSource(RDy rdy, const PetscInt region_idx, PetscReal *values) {
+PetscErrorCode RDySetRegionalWaterSource(RDy rdy, const PetscInt region_idx, PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
-  PetscCall(SetRegionalSourceComponent(rdy, region_idx, 0, values));
+  PetscCall(SetRegionalSourceComponent(rdy, region_idx, 0, size, values));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /// Sets the external x-momentum term on the region with the given index to
 /// the values in the given array (whose length is equal to the number of owned
 /// cells in that region).
-PetscErrorCode RDySetRegionalXMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal *values) {
+PetscErrorCode RDySetRegionalXMomentumSource(RDy rdy, const PetscInt region_idx, PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
-  PetscCall(SetRegionalSourceComponent(rdy, region_idx, 1, values));
+  PetscCall(SetRegionalSourceComponent(rdy, region_idx, 1, size, values));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
 /// Sets the external y-momentum term on the region with the given index to
 /// the values in the given array (whose length is equal to the number of owned
 /// cells in that region).
-PetscErrorCode RDySetRegionalYMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal *values) {
+PetscErrorCode RDySetRegionalYMomentumSource(RDy rdy, const PetscInt region_idx, PetscInt size, PetscReal *values) {
   PetscFunctionBegin;
-  PetscCall(SetRegionalSourceComponent(rdy, region_idx, 2, values));
+  PetscCall(SetRegionalSourceComponent(rdy, region_idx, 2, size, values));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
@@ -275,103 +276,6 @@ PetscErrorCode RDySetHomogeneousXMomentumSource(RDy rdy, const PetscInt region_i
 PetscErrorCode RDySetHomogeneousYMomentumSource(RDy rdy, const PetscInt region_idx, PetscReal value) {
   PetscFunctionBegin;
   PetscCall(SetHomogeneousRegionalSourceComponent(rdy, region_idx, 2, value));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-static PetscErrorCode SetDomainSourceComponent(RDy rdy, const PetscInt component, PetscInt size, PetscReal *values) {
-  PetscFunctionBegin;
-
-  PetscCall(CheckNumLocalCells(rdy, size));
-
-  for (PetscInt r = 0; r < rdy->num_regions; ++r) {
-    RDyRegion  region          = rdy->regions[r];
-    PetscReal *regional_values = NULL;
-    PetscCall(PetscCalloc1(region.num_owned_cells, &regional_values));
-    for (PetscInt c = 0; c < region.num_owned_cells; c++) {
-      regional_values[c] = values[region.owned_cell_global_ids[c]];
-    }
-
-    OperatorSourceData source_data;
-    PetscCall(GetOperatorSourceData(rdy, region, &source_data));
-    PetscCall(SetOperatorSourceValues(&source_data, component, regional_values));
-    PetscCall(RestoreOperatorSourceData(rdy, region, &source_data));
-
-    PetscFree(regional_values);
-  }
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Sets the external water source term on the entire domain to the values in the
-/// given array (whose length is equal to the number of owned cells in the
-/// domain).
-PetscErrorCode RDySetDomainWaterSource(RDy rdy, PetscInt size, PetscReal *values) {
-  PetscFunctionBegin;
-  PetscCall(SetDomainSourceComponent(rdy, 0, size, values));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Sets the external x-momentum source term on the entire domain to the values
-/// in the given array (whose length is equal to the number of owned cells in
-/// the domain).
-PetscErrorCode RDySetDomainXMomentumSource(RDy rdy, PetscInt size, PetscReal *values) {
-  PetscFunctionBegin;
-  PetscCall(SetDomainSourceComponent(rdy, 1, size, values));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Sets the external y-momentum source term on the entire domain to the values
-/// in the given array (whose length is equal to the number of owned cells in
-/// the domain).
-PetscErrorCode RDySetDomainYMomentumSource(RDy rdy, PetscInt size, PetscReal *values) {
-  PetscFunctionBegin;
-  PetscCall(SetDomainSourceComponent(rdy, 2, size, values));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-static PetscErrorCode SetHomogeneousDomainSourceComponent(RDy rdy, const PetscInt component, PetscReal value) {
-  PetscFunctionBegin;
-
-  for (PetscInt r = 0; r < rdy->num_regions; ++r) {
-    RDyRegion  region          = rdy->regions[r];
-    PetscReal *regional_values = NULL;
-    PetscCall(PetscCalloc1(region.num_owned_cells, &regional_values));
-    for (PetscInt c = 0; c < region.num_owned_cells; c++) {
-      regional_values[c] = value;
-    }
-
-    OperatorSourceData source_data;
-    PetscCall(GetOperatorSourceData(rdy, region, &source_data));
-    PetscCall(SetOperatorSourceValues(&source_data, component, regional_values));
-    PetscCall(RestoreOperatorSourceData(rdy, region, &source_data));
-
-    PetscFree(regional_values);
-  }
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Sets the external water source term on the entire domain to the given single
-/// (homogeneous) value.
-PetscErrorCode RDySetHomogeneousDomainWaterSource(RDy rdy, PetscReal value) {
-  PetscFunctionBegin;
-  PetscCall(SetHomogeneousDomainSourceComponent(rdy, 0, value));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Sets the external x-momentum source term on the entire domain to the given
-/// single (homogeneous) value.
-PetscErrorCode RDySetHomogeneousDomainXMomentumSource(RDy rdy, PetscReal value) {
-  PetscFunctionBegin;
-  PetscCall(SetHomogeneousDomainSourceComponent(rdy, 1, value));
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Sets the external y-momentum source term on the entire domain to the given
-/// single (homogeneous) value.
-PetscErrorCode RDySetHomogeneousDomainYMomentumSource(RDy rdy, PetscReal value) {
-  PetscFunctionBegin;
-  PetscCall(SetHomogeneousDomainSourceComponent(rdy, 2, value));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/rdymesh.c
+++ b/src/rdymesh.c
@@ -222,8 +222,6 @@ static PetscErrorCode RDyVerticesCreate(PetscInt num_vertices, PetscInt ncells_p
   PetscCall(PetscCalloc1(num_vertices, &vertices->num_edges));
   FILL(num_vertices, vertices->global_ids, -1);
 
-  PetscCall(PetscCalloc1(num_vertices, &vertices->is_local));
-
   PetscCall(PetscCalloc1(num_vertices, &vertices->points));
 
   PetscCall(PetscCalloc1(num_vertices + 1, &vertices->edge_offsets));
@@ -384,7 +382,6 @@ static PetscErrorCode RDyVerticesDestroy(RDyVertices vertices) {
 
   PetscCall(PetscFree(vertices.ids));
   PetscCall(PetscFree(vertices.global_ids));
-  PetscCall(PetscFree(vertices.is_local));
   PetscCall(PetscFree(vertices.num_cells));
   PetscCall(PetscFree(vertices.num_edges));
   PetscCall(PetscFree(vertices.cell_offsets));

--- a/src/rdymesh.c
+++ b/src/rdymesh.c
@@ -34,8 +34,6 @@ static PetscErrorCode RDyCellsCreate(PetscInt num_cells, PetscInt nvertices_per_
   FILL(num_cells, cells->natural_ids, -1);
 
   PetscCall(PetscCalloc1(num_cells, &cells->is_owned));
-  PetscCall(PetscCalloc1(num_cells, &cells->is_owned));
-
   PetscCall(PetscCalloc1(num_cells, &cells->local_to_owned));
   FILL(num_cells, cells->local_to_owned, -1);
 
@@ -409,7 +407,6 @@ static PetscErrorCode RDyEdgesCreate(PetscInt num_edges, RDyEdges *edges) {
 
   PetscCall(PetscCalloc1(num_edges, &edges->is_owned));
   PetscCall(PetscCalloc1(num_edges, &edges->is_internal));
-  PetscCall(PetscCalloc1(num_edges, &edges->is_owned));
 
   PetscCall(PetscCalloc1(2 * num_edges, &edges->cell_ids));
   FILL(2 * num_edges, edges->cell_ids, -1);
@@ -515,7 +512,6 @@ static PetscErrorCode RDyEdgesDestroy(RDyEdges edges) {
   PetscCall(PetscFree(edges.vertex_ids));
   PetscCall(PetscFree(edges.cell_ids));
   PetscCall(PetscFree(edges.is_internal));
-  PetscCall(PetscFree(edges.is_owned));
   PetscCall(PetscFree(edges.normals));
   PetscCall(PetscFree(edges.centroids));
   PetscCall(PetscFree(edges.lengths));

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -210,12 +210,12 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
 
     // Create vectorized (x, y, t) triples for bulk expression evaluation
     PetscReal *cell_x, *cell_y;
-    PetscCall(PetscCalloc1(region.num_cells, &cell_x));
-    PetscCall(PetscCalloc1(region.num_cells, &cell_y));
+    PetscCall(PetscCalloc1(region.num_local_cells, &cell_x));
+    PetscCall(PetscCalloc1(region.num_local_cells, &cell_y));
 
     PetscInt N = 0;  // number of bulk evaluations
-    for (PetscInt c = 0; c < region.num_cells; ++c) {
-      PetscInt cell_id = region.cell_ids[c];
+    for (PetscInt c = 0; c < region.num_local_cells; ++c) {
+      PetscInt cell_id = region.cell_local_ids[c];
       if (3 * cell_id < n_local) {
         cell_x[N] = rdy->mesh.cells.centroids[cell_id].X[0];
         cell_y[N] = rdy->mesh.cells.centroids[cell_id].X[1];
@@ -228,9 +228,9 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
 
       // evaluate the manufactured ѕolutions at all (x, y, t)
       PetscReal *h, *u, *v;
-      PetscCall(PetscCalloc1(region.num_cells, &h));
-      PetscCall(PetscCalloc1(region.num_cells, &u));
-      PetscCall(PetscCalloc1(region.num_cells, &v));
+      PetscCall(PetscCalloc1(region.num_local_cells, &h));
+      PetscCall(PetscCalloc1(region.num_local_cells, &u));
+      PetscCall(PetscCalloc1(region.num_local_cells, &v));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.h, N, cell_x, cell_y, time, h));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.u, N, cell_x, cell_y, time, u));
       PetscCall(EvaluateTemporalSolution(rdy->config.mms.swe.solutions.v, N, cell_x, cell_y, time, v));
@@ -238,8 +238,8 @@ PetscErrorCode RDyMMSComputeSolution(RDy rdy, PetscReal time, Vec solution) {
       // TODO: salinity and sediment initial conditions go here.
 
       PetscInt l = 0;
-      for (PetscInt c = 0; c < region.num_cells; ++c) {
-        PetscInt cell_id = region.cell_ids[c];
+      for (PetscInt c = 0; c < region.num_local_cells; ++c) {
+        PetscInt cell_id = region.cell_local_ids[c];
         if (3 * cell_id < n_local) {  // skip ghost cells
           x_ptr[3 * cell_id]     = h[l];
           x_ptr[3 * cell_id + 1] = h[l] * u[l];
@@ -448,12 +448,12 @@ PetscErrorCode RDyMMSUpdateMaterialProperties(RDy rdy) {
 
     // create vectorized (x, y) pairs for bulk expression evaluation
     PetscReal *cell_x, *cell_y;
-    PetscCall(PetscCalloc1(region.num_cells, &cell_x));
-    PetscCall(PetscCalloc1(region.num_cells, &cell_y));
+    PetscCall(PetscCalloc1(region.num_local_cells, &cell_x));
+    PetscCall(PetscCalloc1(region.num_local_cells, &cell_y));
 
     PetscInt N = 0;  // number of bulk evaluations
-    for (PetscInt c = 0; c < region.num_cells; ++c) {
-      PetscInt cell_id = region.cell_ids[c];
+    for (PetscInt c = 0; c < region.num_local_cells; ++c) {
+      PetscInt cell_id = region.cell_local_ids[c];
       if (3 * cell_id < n_local) {
         cell_x[N] = rdy->mesh.cells.centroids[cell_id].X[0];
         cell_y[N] = rdy->mesh.cells.centroids[cell_id].X[1];

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -274,7 +274,7 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
 
   PetscInt l = 0;
   for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       cell_x[l] = rdy->mesh.cells.centroids[icell].X[0];
       cell_y[l] = rdy->mesh.cells.centroids[icell].X[1];
       ++l;
@@ -333,7 +333,7 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
 
     l = 0;
     for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
-      if (cells->is_local[icell]) {
+      if (cells->is_owned[icell]) {
         PetscReal Cd = GRAVITY * Square(n[l]) * PetscPowReal(h[l], -1.0 / 3.0);
 
         h_source[l] = dhdt[l] + u[l] * dhdx[l] + h[l] * dudx[l] + v[l] * dhdy[l] + h[l] * dvdy[l];

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -353,9 +353,9 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
       }
     }
 
-    PetscCall(RDySetDomainWaterSource(rdy, N, h_source));
-    PetscCall(RDySetDomainXMomentumSource(rdy, N, hu_source));
-    PetscCall(RDySetDomainYMomentumSource(rdy, N, hv_source));
+    PetscCall(RDySetRegionalWaterSource(rdy, 0, N, h_source));
+    PetscCall(RDySetRegionalXMomentumSource(rdy, 0, N, hu_source));
+    PetscCall(RDySetRegionalYMomentumSource(rdy, 0, N, hv_source));
 
     PetscCall(PetscFree(h));
     PetscCall(PetscFree(u));

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -353,9 +353,9 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
       }
     }
 
-    PetscCall(RDySetWaterSourceForLocalCells(rdy, N, h_source));
-    PetscCall(RDySetXMomentumSourceForLocalCells(rdy, N, hu_source));
-    PetscCall(RDySetYMomentumSourceForLocalCells(rdy, N, hv_source));
+    PetscCall(RDySetDomainWaterSource(rdy, N, h_source));
+    PetscCall(RDySetDomainXMomentumSource(rdy, N, hu_source));
+    PetscCall(RDySetDomainYMomentumSource(rdy, N, hv_source));
 
     PetscCall(PetscFree(h));
     PetscCall(PetscFree(u));

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -167,13 +167,13 @@ PetscErrorCode RDyMMSSetup(RDy rdy) {
   // adjust the vertices of a refined mesh to conform to our analytical z(x, y)
   PetscCall(SnapVerticesToBathymetry(rdy));
 
-  RDyLogDebug(rdy, "Initializing regions...");
-  PetscCall(InitRegions(rdy));
-
   // note: this must be done after global vectors are created so a global
   // note: section exists for the DM
   RDyLogDebug(rdy, "Creating FV mesh...");
   PetscCall(RDyMeshCreateFromDM(rdy->dm, &rdy->mesh));
+
+  RDyLogDebug(rdy, "Initializing regions...");
+  PetscCall(InitRegions(rdy));
 
   RDyLogDebug(rdy, "Initializing boundaries and boundary conditions...");
   PetscCall(InitBoundaries(rdy));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -868,7 +868,7 @@ static PetscErrorCode InitSourceConditions(RDy rdy) {
 
       RDyFlowCondition *flow_src = src.flow;
       if (flow_src) {
-        PetscCall(RDySetWaterSourceForRegion(rdy, r, mupEval(flow_src->value)));
+        PetscCall(RDySetHomogeneousRegionalWaterSource(rdy, r, mupEval(flow_src->value)));
       }
     }
   }

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -298,9 +298,9 @@ PetscErrorCode InitBoundaries(RDy rdy) {
 
       // check if the edge is valid
       if (cell_id_2 >= 0) {
-        edge_valid = (cells->is_local[cell_id_1] || cells->is_local[cell_id_2]);
+        edge_valid = (cells->is_owned[cell_id_1] || cells->is_owned[cell_id_2]);
       } else {
-        edge_valid = cells->is_local[cell_id_1];
+        edge_valid = cells->is_owned[cell_id_1];
       }
 
       if (!edge_valid) {
@@ -795,7 +795,7 @@ static PetscErrorCode InitSolution(RDy rdy) {
           for (PetscInt c = 0; c < region.num_local_cells; ++c) {
             PetscInt cell_local_id = region.cell_local_ids[c];
             PetscInt owned_cell_id = rdy->mesh.cells.local_to_owned[cell_local_id];
-            if (rdy->mesh.cells.is_local[cell_local_id]) {  // skip ghost cells
+            if (rdy->mesh.cells.is_owned[cell_local_id]) {  // skip ghost cells
               for (PetscInt idof = 0; idof < ndof; idof++) {
                 u_ptr[ndof * owned_cell_id + idof] = local_ptr[ndof * cell_local_id + idof];
               }

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -235,16 +235,15 @@ PetscErrorCode InitRegions(RDy rdy) {
         // construct global IDs for owned cells
         region->num_owned_cells = 0;
         for (PetscInt i = 0; i < num_local_cells; ++i) {
-          if (rdy->mesh.cells.local_to_owned[region->cell_local_ids[i]] != -1) {
+          if (rdy->mesh.cells.is_owned[region->cell_local_ids[i]]) {
             ++region->num_owned_cells;
           }
         }
         PetscCall(PetscCalloc1(region->num_owned_cells, &region->owned_cell_global_ids));
         PetscInt k = 0;
         for (PetscInt i = 0; i < num_local_cells; ++i) {
-          PetscInt owned_cell_global_id = rdy->mesh.cells.local_to_owned[region->cell_local_ids[i]];
-          if (owned_cell_global_id != -1) {
-            region->owned_cell_global_ids[k] = owned_cell_global_id;
+          if (rdy->mesh.cells.is_owned[region->cell_local_ids[i]]) {
+            region->owned_cell_global_ids[k] = rdy->mesh.cells.local_to_owned[region->cell_local_ids[i]];
             ++k;
           }
         }

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -446,7 +446,7 @@ PetscErrorCode CreateSWESourceOperator(Ceed ceed, RDyMesh *mesh, PetscInt num_ce
       PetscCallCEED(CeedVectorGetArray(geom, CEED_MEM_HOST, (CeedScalar **)&g));
       PetscCallCEED(CeedVectorGetArray(mannings_n, CEED_MEM_HOST, (CeedScalar **)&n));
       for (CeedInt c = 0, oc = 0; c < mesh->num_cells; c++) {
-        if (!cells->is_local[c]) continue;
+        if (!cells->is_owned[c]) continue;
 
         offset_q[oc] = c * num_comp;
         offset_c[oc] = cells->local_to_owned[c] * num_comp;

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -367,12 +367,12 @@ PetscErrorCode SWERHSFunctionForInternalEdges(RDy rdy, Vec F, CourantNumberDiagn
         }
 
         for (PetscInt idof = 0; idof < ndof; idof++) {
-          if (cells->is_local[l]) {
+          if (cells->is_owned[l]) {
             PetscInt idx = cells->local_to_owned[l];
             f_ptr[idx * ndof + idof] += flux_vec_int[ii * ndof + idof] * (-edge_len / areal);
           }
 
-          if (cells->is_local[r]) {
+          if (cells->is_owned[r]) {
             PetscInt idx = cells->local_to_owned[r];
             f_ptr[idx * ndof + idof] += flux_vec_int[ii * ndof + idof] * (edge_len / arear);
           }
@@ -437,7 +437,7 @@ static PetscErrorCode ComputeBC(RDy rdy, RDyBoundary boundary, PetscReal tiny_h,
     PetscReal edge_len  = edges->lengths[iedge];
     PetscReal cell_area = cells->areas[icell];
 
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       PetscReal hl = datal->h[e];
       PetscReal hr = datar->h[e];
 
@@ -485,7 +485,7 @@ static PetscErrorCode ApplyReflectingBC(RDy rdy, RDyBoundary boundary, RiemannDa
     PetscInt iedge = boundary.edge_ids[e];
     PetscInt icell = edges->cell_ids[2 * iedge];
 
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       datar->h[e] = datal->h[e];
 
       PetscReal dum1 = Square(sn_vec_bnd[e]) - Square(cn_vec_bnd[e]);
@@ -547,7 +547,7 @@ static PetscErrorCode ApplyCriticalOutflowBC(RDy rdy, RDyBoundary boundary, Riem
     PetscInt iedge = boundary.edge_ids[e];
     PetscInt icell = edges->cell_ids[2 * iedge];
 
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       PetscReal uperp = datal->u[e] * cn_vec_bnd[e] + datal->v[e] * sn_vec_bnd[e];
       PetscReal q     = datal->h[e] * fabs(uperp);
 
@@ -667,7 +667,7 @@ PetscErrorCode AddSWESourceTerm(RDy rdy, Vec F) {
   RiemannDataSWE      *data     = &data_swe->data_cells;
 
   for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
-    if (cells->is_local[icell]) {
+    if (cells->is_owned[icell]) {
       PetscReal h  = data->h[icell];
       PetscReal hu = data->hu[icell];
       PetscReal hv = data->hv[icell];

--- a/src/time_series.c
+++ b/src/time_series.c
@@ -20,7 +20,7 @@ static PetscErrorCode GatherBoundaryFluxMetadata(RDy rdy) {
       for (PetscInt e = 0; e < boundary.num_edges; ++e) {
         PetscInt edge_id = boundary.edge_ids[e];
         PetscInt cell_id = rdy->mesh.edges.cell_ids[2 * edge_id];
-        if (rdy->mesh.cells.is_local[cell_id]) {
+        if (rdy->mesh.cells.is_owned[cell_id]) {
           local_flux_md[num_md * n]     = rdy->mesh.edges.centroids[edge_id].X[0];
           local_flux_md[num_md * n + 1] = rdy->mesh.edges.centroids[edge_id].X[1];
           local_flux_md[num_md * n + 2] = bc.flow->type;
@@ -85,7 +85,7 @@ static PetscErrorCode InitBoundaryFluxes(RDy rdy) {
       for (PetscInt e = 0; e < boundary.num_edges; ++e) {
         PetscInt edge_id = boundary.edge_ids[e];
         PetscInt cell_id = rdy->mesh.edges.cell_ids[2 * edge_id];
-        if (rdy->mesh.cells.is_local[cell_id]) ++num_boundary_edges;
+        if (rdy->mesh.cells.is_owned[cell_id]) ++num_boundary_edges;
       }
     }
     rdy->time_series.boundary_fluxes.offsets[b + 1] = num_boundary_edges;
@@ -139,7 +139,7 @@ PetscErrorCode AccumulateBoundaryFluxes(RDy rdy, RDyBoundary boundary, PetscInt 
         PetscInt  edge_id  = boundary.edge_ids[e];
         PetscInt  cell_id  = rdy->mesh.edges.cell_ids[2 * edge_id];
         PetscReal edge_len = rdy->mesh.edges.lengths[edge_id];
-        if (rdy->mesh.cells.is_local[cell_id]) {
+        if (rdy->mesh.cells.is_owned[cell_id]) {
           time_series->boundary_fluxes.fluxes[n].water_mass += edge_len * fluxes[e * ndof + 0];
           time_series->boundary_fluxes.fluxes[n].x_momentum += edge_len * fluxes[e * ndof + 1];
           time_series->boundary_fluxes.fluxes[n].y_momentum += edge_len * fluxes[e * ndof + 2];
@@ -173,7 +173,7 @@ static PetscErrorCode WriteBoundaryFluxes(RDy rdy, PetscInt step, PetscReal time
       for (PetscInt e = 0; e < boundary.num_edges; ++e) {
         PetscInt edge_id = boundary.edge_ids[e];
         PetscInt cell_id = rdy->mesh.edges.cell_ids[2 * edge_id];
-        if (rdy->mesh.cells.is_local[cell_id]) {
+        if (rdy->mesh.cells.is_owned[cell_id]) {
           local_flux_data[num_data * n]     = rdy->time_series.boundary_fluxes.fluxes[n].water_mass;
           local_flux_data[num_data * n + 1] = rdy->time_series.boundary_fluxes.fluxes[n].x_momentum;
           local_flux_data[num_data * n + 2] = rdy->time_series.boundary_fluxes.fluxes[n].y_momentum;


### PR DESCRIPTION
Last one for the week!

This PR changes the OperatorSourceData interface to associate source data with regions, in the same way as boundary flux data relates to boundaries. The difference between these two cases is that while boundary data is stored per-boundary, all source data lives in one vector of owned-cell data. So we do some index mapping to translate between representations.

**Update**: based on review feedback, I've made a few more changes:

* the `RDyRegion` type now keeps track of IDs of cells for local and global vectors
* the `is_local` field in the `RDyCells` type has been renamed to `is_owned`
* the `is_local` fields in the `RDyVertices` and `RDyEdges` types have been removed