### PR TITLE
Added an option to write the grid to a separate file (XDMF only).

### DIFF
--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -406,6 +406,7 @@ output:
   batch_size: 1
   time_series:
     boundary_fluxes: 10
+  separate_grid_file: false
 ```
 
 The `output` section control simulation output, including visualization and
@@ -428,6 +429,9 @@ time series data (and excluding checkpoint data). Relevant parameters are
   has only one parameter:
     * `boundary_fluxes`: the interval (number of timesteps) at which boundary
       flux data is appended to a tab-delimited text file
+* `separate_grid_file`: this optional parameter specifies whether the grid is
+  written to its own file, which saves space in very large simulations. Currently,
+  this option is only supported for `xdmf` output.
 
 ## `physics`
 

--- a/driver/tests/swe_roe/Simons.OceanDirichletBC.yaml
+++ b/driver/tests/swe_roe/Simons.OceanDirichletBC.yaml
@@ -22,6 +22,7 @@ output:
   batch_size: 20
   time_series:
     boundary_fluxes: 1
+  separate_grid_file: true
 
 grid:
   file: simons.exo

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -165,6 +165,7 @@ typedef struct {
   PetscInt        batch_size;                     // number of timesteps per output file (if available)
   RDyTimeSeries   time_series;                    // time series appended to text (.dat) files
   PetscReal       prev_output_time;               // previous time at which output was written
+  PetscBool       separate_grid_file;             // whether grid is written to a separate file
 } RDyOutputSection;
 
 // ------------

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -234,6 +234,7 @@ static const cyaml_schema_field_t output_fields_schema[] = {
     CYAML_FIELD_ENUM("time_unit", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_unit, time_units, CYAML_ARRAY_LEN(time_units)),
     CYAML_FIELD_INT("batch_size", CYAML_FLAG_OPTIONAL, RDyOutputSection, batch_size),
     CYAML_FIELD_MAPPING("time_series", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_series, output_time_series_fields_schema),
+    CYAML_FIELD_BOOL("separate_grid_file", CYAML_FLAG_OPTIONAL, RDyOutputSection, separate_grid_file),
     CYAML_FIELD_END
 };
 


### PR DESCRIPTION
This option lets us save some space when the domain is very large. It's demonstrated in the Simons.OceanDirechletBC.yaml test input.

Closes #248