### PR TITLE
Adds the implicit treatment of the friction term

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 To build RDycore, you need:
 
-* [CMake v3.12+](https://cmake.org/)
+* [CMake v3.14+](https://cmake.org/)
 * GNU Make
 * reliable C and Fortran compilers
 * a working MPI installation (like [OpenMPI](https://www.open-mpi.org/)

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -20,7 +20,7 @@ different aspect of the desired simulation. These sections fall into several
 broad categories:
 
 * **Model equations and discretizations**
-    * [physics](input.md#physіcs): configures the different physical models
+    * [physics](input.md#physics): configures the different physical models
       represented within RDycore
     * [numerics](input.md#numerics): specifies the numerical methods used
       to solve the model equations

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -406,7 +406,7 @@ output:
   batch_size: 1
   time_series:
     boundary_fluxes: 10
-  separate_grid_file: false
+  separate_grid_file: true
 ```
 
 The `output` section control simulation output, including visualization and
@@ -439,7 +439,10 @@ time series data (and excluding checkpoint data). Relevant parameters are
 physics:
   flow:
     mode: swe
-    tiny: 1e-7
+    tiny_h: 1e-7
+    source:
+      method: implicit_xq2018
+      xq2018_threshold: 1e-10
   sediment: false
   salinity: false
 ```
@@ -457,6 +460,13 @@ parameters in this subsection are:
    not yet supported). This parameter is required and has no default value.
 * `tiny_h`, which is the water height below which a given point is assumed to
   be dry. Default value: `1e-7`
+* `source`: this subsection controls parameters governing how the flow source
+  term is integrated in time. Parameters are:
+  * `method`: the method for integrating the flow source term. Options are
+    * `semi_implicit`: a semi-implicit source treatment (default value)
+    * `implicit_xq2018`: a fully implicit source treatment based on Xilin and Qiuhua (2018)
+  * `xq2018_threshold`: threshold for the implicit integration of the source
+    (valid only for the `implicit_xq2018` method; default value: `1e-10`)
 
 The second physical model is the sediment model. You can enable or disable this
 by setting the `sediment` parameter to `true` or `false`.

--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -3,6 +3,7 @@
 physics:
   flow:
     mode: swe
+    source_time_method: implicit_xq2018
 
 numerics:
   spatial: fv

--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -3,7 +3,8 @@
 physics:
   flow:
     mode: swe
-    source_time_method: implicit_xq2018
+    source:
+      method: implicit_xq2018
 
 numerics:
   spatial: fv

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -50,18 +50,18 @@ typedef enum {
 typedef enum {
   SOURCE_SEMI_IMPLICIT = 0,  // semi-implicit treatment
   SOURCE_IMPLICIT_XQ2018     // implicit treatment using Xilin and Qiuhua (2018)
-} RDySourceTimeMethod;
+} RDyFlowSourceMethod;
 
 typedef struct {
-  RDySourceTimeMethod method;            // temporal discretization method for source term
+  RDyFlowSourceMethod method;            // temporal discretization method for source term
   PetscReal           xq2018_threshold;  // threshold for the XQ2018's implicit time integration of source term
-} RDySource;
+} RDyFlowSource;
 
 // physics flow parameters
 typedef struct {
   RDyPhysicsFlowMode mode;    // flow mode
   PetscReal          tiny_h;  // depth below which no flow occurs
-  RDySource          source;
+  RDyFlowSource      source;
 } RDyPhysicsFlow;
 
 // all physics parameters

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -49,7 +49,7 @@ typedef enum {
 
 typedef enum {
   SOURCE_SEMI_IMPLICIT = 0,  // semi-implicit treatment
-  SOURCE_IMPLIICT_XQ2018     // implicit treatment using Xilin and Qiuhua (2018)
+  SOURCE_IMPLICIT_XQ2018     // implicit treatment using Xilin and Qiuhua (2018)
 } RDySourceTimeMethod;
 
 // physics flow parameters

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -52,12 +52,16 @@ typedef enum {
   SOURCE_IMPLICIT_XQ2018     // implicit treatment using Xilin and Qiuhua (2018)
 } RDySourceTimeMethod;
 
+typedef struct {
+  RDySourceTimeMethod method;            // temporal discretization method for source term
+  PetscReal           xq2018_threshold;  // threshold for the XQ2018's implicit time integration of source term
+} RDySource;
+
 // physics flow parameters
 typedef struct {
-  RDyPhysicsFlowMode  mode;                // flow mode
-  PetscReal           tiny_h;              // depth below which no flow occurs
-  RDySourceTimeMethod source_time_method;  // temporal discretization method for source term
-  PetscReal           xq2018_threshold;    // threshold for the XQ2018's implicit time integration of source term
+  RDyPhysicsFlowMode mode;    // flow mode
+  PetscReal          tiny_h;  // depth below which no flow occurs
+  RDySource          source;
 } RDyPhysicsFlow;
 
 // all physics parameters

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -47,10 +47,17 @@ typedef enum {
   FLOW_DIFFUSION  // diffusion equation
 } RDyPhysicsFlowMode;
 
+typedef enum {
+  SOURCE_SEMI_IMPLICIT = 0,  // semi-implicit treatment
+  SOURCE_IMPLIICT_XQ2018     // implicit treatment using Xilin and Qiuhua (2018)
+} RDySourceTimeMethod;
+
 // physics flow parameters
 typedef struct {
-  RDyPhysicsFlowMode mode;    // flow mode
-  PetscReal          tiny_h;  // depth below which no flow occurs
+  RDyPhysicsFlowMode  mode;                // flow mode
+  PetscReal           tiny_h;              // depth below which no flow occurs
+  RDySourceTimeMethod source_time_method;  // temporal discretization method for source term
+  PetscReal           xq2018_threshold;    // threshold for the XQ2018's implicit time integration of source term
 } RDyPhysicsFlow;
 
 // all physics parameters

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -8,11 +8,11 @@
 
 PETSC_INTERN PetscErrorCode CreateSWECeedInteriorFluxOperator(RDyMesh *, PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, PetscReal, CeedOperator *);
-PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, RDySourceTimeMethod, PetscReal, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, RDyFlowSourceMethod, PetscReal, PetscReal, CeedOperator *);
 
 PETSC_INTERN PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *, OperatorDiagnostics *, PetscReal, PetscOperator *);
 PETSC_INTERN PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, Vec, Vec, OperatorDiagnostics *, PetscReal,
                                                                PetscOperator *);
-PETSC_INTERN PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *, Vec, Vec, RDySourceTimeMethod, PetscReal, PetscReal, PetscOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *, Vec, Vec, RDyFlowSourceMethod, PetscReal, PetscReal, PetscOperator *);
 
 #endif

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -13,6 +13,6 @@ PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, PetscReal, Ce
 PETSC_INTERN PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *, OperatorDiagnostics *, PetscReal, PetscOperator *);
 PETSC_INTERN PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, Vec, Vec, OperatorDiagnostics *, PetscReal,
                                                                PetscOperator *);
-PETSC_INTERN PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *, Vec, Vec, PetscReal, PetscOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *, Vec, Vec, RDySourceTimeMethod, PetscReal, PetscReal, PetscOperator *);
 
 #endif

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -8,7 +8,7 @@
 
 PETSC_INTERN PetscErrorCode CreateSWECeedInteriorFluxOperator(RDyMesh *, PetscReal, CeedOperator *);
 PETSC_INTERN PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, PetscReal, CeedOperator *);
-PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, RDySourceTimeMethod, PetscReal, PetscReal, CeedOperator *);
 
 PETSC_INTERN PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *, OperatorDiagnostics *, PetscReal, PetscOperator *);
 PETSC_INTERN PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, Vec, Vec, OperatorDiagnostics *, PetscReal,

--- a/src/operator.c
+++ b/src/operator.c
@@ -185,7 +185,9 @@ static PetscErrorCode AddPetscOperators(Operator *op) {
   PetscCall(PetscCompositeOperatorCreate(&op->petsc.flux));
   PetscCall(PetscCompositeOperatorCreate(&op->petsc.source));
 
-  PetscReal tiny_h = op->config->physics.flow.tiny_h;
+  RDySourceTimeMethod time_method      = op->config->physics.flow.source_time_method;
+  PetscReal           tiny_h           = op->config->physics.flow.tiny_h;
+  PetscReal           xq2018_threshold = op->config->physics.flow.xq2018_threshold;
 
   // flux suboperator 0: fluxes between interior cells
   PetscOperator interior_flux_op;
@@ -204,7 +206,8 @@ static PetscErrorCode AddPetscOperators(Operator *op) {
 
   // domain-wide SWE source operator
   PetscOperator source_op;
-  PetscCall(CreateSWEPetscSourceOperator(op->mesh, op->petsc.external_sources, op->petsc.material_properties[OPERATOR_MANNINGS], tiny_h, &source_op));
+  PetscCall(CreateSWEPetscSourceOperator(op->mesh, op->petsc.external_sources, op->petsc.material_properties[OPERATOR_MANNINGS], time_method, tiny_h,
+                                         xq2018_threshold, &source_op));
   PetscCall(PetscCompositeOperatorAddSub(op->petsc.source, source_op));
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/operator.c
+++ b/src/operator.c
@@ -133,7 +133,7 @@ static PetscErrorCode AddCeedOperators(Operator *op) {
   // set up operators for the shallow water equations
 
   Ceed                ceed             = CeedContext();
-  RDySourceTimeMethod time_method      = op->config->physics.flow.source.method;
+  RDyFlowSourceMethod time_method      = op->config->physics.flow.source.method;
   PetscReal           tiny_h           = op->config->physics.flow.tiny_h;
   PetscReal           xq2018_threshold = op->config->physics.flow.source.xq2018_threshold;
 
@@ -187,7 +187,7 @@ static PetscErrorCode AddPetscOperators(Operator *op) {
   PetscCall(PetscCompositeOperatorCreate(&op->petsc.flux));
   PetscCall(PetscCompositeOperatorCreate(&op->petsc.source));
 
-  RDySourceTimeMethod time_method      = op->config->physics.flow.source.method;
+  RDyFlowSourceMethod time_method      = op->config->physics.flow.source.method;
   PetscReal           tiny_h           = op->config->physics.flow.tiny_h;
   PetscReal           xq2018_threshold = op->config->physics.flow.source.xq2018_threshold;
 

--- a/src/operator.c
+++ b/src/operator.c
@@ -132,8 +132,10 @@ static PetscErrorCode AddCeedOperators(Operator *op) {
 
   // set up operators for the shallow water equations
 
-  Ceed      ceed   = CeedContext();
-  PetscReal tiny_h = op->config->physics.flow.tiny_h;
+  Ceed                ceed             = CeedContext();
+  RDySourceTimeMethod time_method      = op->config->physics.flow.source_time_method;
+  PetscReal           tiny_h           = op->config->physics.flow.tiny_h;
+  PetscReal           xq2018_threshold = op->config->physics.flow.xq2018_threshold;
 
   //---------------
   // Flux Operator
@@ -166,7 +168,7 @@ static PetscErrorCode AddCeedOperators(Operator *op) {
   PetscCallCEED(CeedCompositeOperatorCreate(ceed, &op->ceed.source));
 
   CeedOperator source_op;
-  PetscCall(CreateSWECeedSourceOperator(op->mesh, tiny_h, &source_op));
+  PetscCall(CreateSWECeedSourceOperator(op->mesh, time_method, tiny_h, xq2018_threshold, &source_op));
   PetscCallCEED(CeedCompositeOperatorAddSub(op->ceed.source, source_op));
   PetscCallCEED(CeedOperatorDestroy(&source_op));
 

--- a/src/operator.c
+++ b/src/operator.c
@@ -133,9 +133,9 @@ static PetscErrorCode AddCeedOperators(Operator *op) {
   // set up operators for the shallow water equations
 
   Ceed                ceed             = CeedContext();
-  RDySourceTimeMethod time_method      = op->config->physics.flow.source_time_method;
+  RDySourceTimeMethod time_method      = op->config->physics.flow.source.method;
   PetscReal           tiny_h           = op->config->physics.flow.tiny_h;
-  PetscReal           xq2018_threshold = op->config->physics.flow.xq2018_threshold;
+  PetscReal           xq2018_threshold = op->config->physics.flow.source.xq2018_threshold;
 
   //---------------
   // Flux Operator
@@ -187,9 +187,9 @@ static PetscErrorCode AddPetscOperators(Operator *op) {
   PetscCall(PetscCompositeOperatorCreate(&op->petsc.flux));
   PetscCall(PetscCompositeOperatorCreate(&op->petsc.source));
 
-  RDySourceTimeMethod time_method      = op->config->physics.flow.source_time_method;
+  RDySourceTimeMethod time_method      = op->config->physics.flow.source.method;
   PetscReal           tiny_h           = op->config->physics.flow.tiny_h;
-  PetscReal           xq2018_threshold = op->config->physics.flow.xq2018_threshold;
+  PetscReal           xq2018_threshold = op->config->physics.flow.source.xq2018_threshold;
 
   // flux suboperator 0: fluxes between interior cells
   PetscOperator interior_flux_op;

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -50,15 +50,16 @@ static int FreeContextPetsc(void *data) {
 
 // creates a QFunction context for a flux or source operator with the given
 // minimum water height threshold
-static PetscErrorCode CreateQFunctionContext(Ceed ceed, PetscReal tiny_h, CeedQFunctionContext *qf_context) {
+static PetscErrorCode CreateQFunctionContext(Ceed ceed, PetscReal tiny_h, PetscReal xq2018_threshold, CeedQFunctionContext *qf_context) {
   PetscFunctionBeginUser;
 
   SWEContext swe_ctx;
   PetscCall(PetscCalloc1(1, &swe_ctx));
 
-  swe_ctx->dtime   = 0.0;
-  swe_ctx->tiny_h  = tiny_h;
-  swe_ctx->gravity = 9.806;
+  swe_ctx->dtime            = 0.0;
+  swe_ctx->tiny_h           = tiny_h;
+  swe_ctx->gravity          = 9.806;
+  swe_ctx->xq2018_threshold = xq2018_threshold;
 
   PetscCallCEED(CeedQFunctionContextCreate(ceed, qf_context));
   PetscCallCEED(CeedQFunctionContextSetData(*qf_context, CEED_MEM_HOST, CEED_USE_POINTER, sizeof(*swe_ctx), swe_ctx));
@@ -67,6 +68,8 @@ static PetscErrorCode CreateQFunctionContext(Ceed ceed, PetscReal tiny_h, CeedQF
   PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "small h value", offsetof(struct SWEContext_, tiny_h), 1,
                                                    "Height threshold below which dry condition is assumed"));
   PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "gravity", offsetof(struct SWEContext_, gravity), 1, "Accelaration due to gravity"));
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "xq2018_threshold", offsetof(struct SWEContext_, xq2018_threshold), 1,
+                                                   "Threshold for the treatment of Implicit XQ2018 method"));
 
   PetscFunctionReturn(CEED_ERROR_SUCCESS);
 }
@@ -134,7 +137,8 @@ PetscErrorCode CreateSWECeedInteriorFluxOperator(RDyMesh *mesh, PetscReal tiny_h
 
   // create a context for the Q-function
   CeedQFunctionContext qf_context;
-  PetscCall(CreateQFunctionContext(ceed, tiny_h, &qf_context));
+  PetscReal            xq2018_threshold_dummy = 0.0;
+  PetscCall(CreateQFunctionContext(ceed, tiny_h, xq2018_threshold_dummy, &qf_context));
   if (0) PetscCallCEED(CeedQFunctionContextView(qf_context, stdout));
   PetscCallCEED(CeedQFunctionSetContext(qf, qf_context));
   PetscCallCEED(CeedQFunctionContextDestroy(&qf_context));
@@ -320,7 +324,8 @@ PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *mesh, RDyBoundary boun
 
   // create a context for the Q-function
   CeedQFunctionContext qf_context;
-  PetscCall(CreateQFunctionContext(ceed, tiny_h, &qf_context));
+  PetscReal            xq2018_threshold_dummy = 0.0;
+  PetscCall(CreateQFunctionContext(ceed, tiny_h, xq2018_threshold_dummy, &qf_context));
   if (0) PetscCallCEED(CeedQFunctionContextView(qf_context, stdout));
   PetscCallCEED(CeedQFunctionSetContext(qf, qf_context));
   PetscCallCEED(CeedQFunctionContextDestroy(&qf_context));
@@ -466,7 +471,8 @@ PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *mesh, RDyBoundary boun
 /// @param [in]  mesh            a mesh representing the domain
 /// @param [in]  tiny_h          the water height below which dry conditions are assumed
 /// @param [out] ceed_op         the newly created CeedOperator
-PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, PetscReal tiny_h, CeedOperator *ceed_op) {
+PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, RDySourceTimeMethod method, PetscReal tiny_h, PetscReal xq2018_threshold,
+                                           CeedOperator *ceed_op) {
   PetscFunctionBeginUser;
 
   Ceed ceed = CeedContext();
@@ -479,7 +485,18 @@ PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, PetscReal tiny_h, Ceed
   // NOTE: their indexing within the Q-function's implementation (swe_ceed_impl.h)
   CeedQFunction qf;
   CeedInt       num_comp_geom = 2, num_comp_swe_src = 3, num_comp_mannings_n = 1;
-  PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWESourceTermSemiImplicit, SWESourceTermSemiImplicit_loc, &qf));
+  switch (method) {
+    case SOURCE_SEMI_IMPLICIT:
+      PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWESourceTermSemiImplicit, SWESourceTermSemiImplicit_loc, &qf));
+      break;
+    case SOURCE_IMPLIICT_XQ2018:
+      PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWESourceTermImplicitXQ2018, SWESourceTermImplicitXQ2018_loc, &qf));
+      break;
+    default:
+      PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Only semi_implicit source-term is supported in the CEED version");
+      break;
+  }
+
   PetscCallCEED(CeedQFunctionAddInput(qf, "geom", num_comp_geom, CEED_EVAL_NONE));
   PetscCallCEED(CeedQFunctionAddInput(qf, "swe_src", num_comp_swe_src, CEED_EVAL_NONE));
   PetscCallCEED(CeedQFunctionAddInput(qf, "mannings_n", num_comp_mannings_n, CEED_EVAL_NONE));
@@ -489,7 +506,7 @@ PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, PetscReal tiny_h, Ceed
 
   // create a context for the Q-function
   CeedQFunctionContext qf_context;
-  PetscCall(CreateQFunctionContext(ceed, tiny_h, &qf_context));
+  PetscCall(CreateQFunctionContext(ceed, tiny_h, xq2018_threshold, &qf_context));
   if (0) PetscCallCEED(CeedQFunctionContextView(qf_context, stdout));
   PetscCallCEED(CeedQFunctionSetContext(qf, qf_context));
   PetscCallCEED(CeedQFunctionContextDestroy(&qf_context));

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -473,7 +473,7 @@ PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *mesh, RDyBoundary boun
 /// @param [in]  tiny_h           the water height below which dry conditions are assumed
 /// @param [in]  xq2018_threshold the threshold use of the XL2018 implicit temporal method
 /// @param [out] ceed_op          the newly created CeedOperator
-PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, RDySourceTimeMethod method, PetscReal tiny_h, PetscReal xq2018_threshold,
+PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, RDyFlowSourceMethod method, PetscReal tiny_h, PetscReal xq2018_threshold,
                                            CeedOperator *ceed_op) {
   PetscFunctionBeginUser;
 

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -479,7 +479,7 @@ PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, PetscReal tiny_h, Ceed
   // NOTE: their indexing within the Q-function's implementation (swe_ceed_impl.h)
   CeedQFunction qf;
   CeedInt       num_comp_geom = 2, num_comp_swe_src = 3, num_comp_mannings_n = 1;
-  PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWESourceTerm, SWESourceTerm_loc, &qf));
+  PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWESourceTermSemiImplicit, SWESourceTermSemiImplicit_loc, &qf));
   PetscCallCEED(CeedQFunctionAddInput(qf, "geom", num_comp_geom, CEED_EVAL_NONE));
   PetscCallCEED(CeedQFunctionAddInput(qf, "swe_src", num_comp_swe_src, CEED_EVAL_NONE));
   PetscCallCEED(CeedQFunctionAddInput(qf, "mannings_n", num_comp_mannings_n, CEED_EVAL_NONE));

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -491,7 +491,7 @@ PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, RDySourceTimeMethod me
     case SOURCE_SEMI_IMPLICIT:
       PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWESourceTermSemiImplicit, SWESourceTermSemiImplicit_loc, &qf));
       break;
-    case SOURCE_IMPLIICT_XQ2018:
+    case SOURCE_IMPLICIT_XQ2018:
       PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWESourceTermImplicitXQ2018, SWESourceTermImplicitXQ2018_loc, &qf));
       break;
     default:

--- a/src/swe/swe_ceed.c
+++ b/src/swe/swe_ceed.c
@@ -468,9 +468,11 @@ PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *mesh, RDyBoundary boun
 ///    * `small h value` - the water height below which dry conditions are assumed
 ///    * `gravity` - the acceleration due to gravity [m/s/s]
 ///
-/// @param [in]  mesh            a mesh representing the domain
-/// @param [in]  tiny_h          the water height below which dry conditions are assumed
-/// @param [out] ceed_op         the newly created CeedOperator
+/// @param [in]  mesh             a mesh representing the domain
+/// @param [in]  method           type of temporal method used for discretizing the friction source term
+/// @param [in]  tiny_h           the water height below which dry conditions are assumed
+/// @param [in]  xq2018_threshold the threshold use of the XL2018 implicit temporal method
+/// @param [out] ceed_op          the newly created CeedOperator
 PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *mesh, RDySourceTimeMethod method, PetscReal tiny_h, PetscReal xq2018_threshold,
                                            CeedOperator *ceed_op) {
   PetscFunctionBeginUser;

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -358,8 +358,8 @@ CEED_QFUNCTION(SWESourceTermImplicitXQ2018)(void *ctx, CeedInt Q, const CeedScal
       const CeedScalar q_magnitude = pow(Square(qx_nplus1) + Square(qy_nplus1), 0.5);
 
       // equation 21 and 22 of XQ2018
-      tbx = dt * gravity * Square(mannings_n[0][i]) * pow(h, -7.0 / 3.0) * qx_nplus1 * q_magnitude;
-      tby = dt * gravity * Square(mannings_n[0][i]) * pow(h, -7.0 / 3.0) * qy_nplus1 * q_magnitude;
+      tbx = gravity * Square(mannings_n[0][i]) * pow(h, -7.0 / 3.0) * qx_nplus1 * q_magnitude;
+      tby = gravity * Square(mannings_n[0][i]) * pow(h, -7.0 / 3.0) * qy_nplus1 * q_magnitude;
     }
 
     cell[0][i] = riemannf[0][i] + swe_src[0][i];

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -20,6 +20,7 @@ struct SWEContext_ {
   CeedScalar dtime;
   CeedScalar tiny_h;
   CeedScalar gravity;
+  CeedScalar xq2018_threshold;
 };
 
 struct SWEState_ {
@@ -289,6 +290,76 @@ CEED_QFUNCTION(SWESourceTermSemiImplicit)(void *ctx, CeedInt Q, const CeedScalar
 
       tbx = (hu + dt * Fsum_x - dt * bedx) * factor;
       tby = (hv + dt * Fsum_y - dt * bedy) * factor;
+    }
+
+    cell[0][i] = riemannf[0][i] + swe_src[0][i];
+    cell[1][i] = riemannf[1][i] - bedx - tbx + swe_src[1][i];
+    cell[2][i] = riemannf[2][i] - bedy - tby + swe_src[2][i];
+  }
+  return 0;
+}
+
+/// @brief Adds contribution of the source-term using implicit time integration approach of:
+///        Xia, Xilin, and Qiuhua Liang. "A new efficient implicit scheme for discretising the stiff
+///        friction terms in the shallow water equations." Advances in water resources 117 (2018): 87-97.
+///        https://www.sciencedirect.com/science/article/pii/S0309170818302124?ref=cra_js_challenge&fr=RR-1
+CEED_QFUNCTION(SWESourceTermImplicitXQ2018)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  const CeedScalar(*geom)[CEED_Q_VLA]       = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // dz/dx, dz/dy
+  const CeedScalar(*swe_src)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[1];  // external source (e.g. rain rate)
+  const CeedScalar(*mannings_n)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[2];  // mannings coefficient
+  const CeedScalar(*riemannf)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[3];  // riemann flux
+  const CeedScalar(*q)[CEED_Q_VLA]          = (const CeedScalar(*)[CEED_Q_VLA])in[4];
+  CeedScalar(*cell)[CEED_Q_VLA]             = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  const SWEContext context                  = (SWEContext)ctx;
+
+  const CeedScalar dt               = context->dtime;
+  const CeedScalar tiny_h           = context->tiny_h;
+  const CeedScalar gravity          = context->gravity;
+  const CeedScalar xq2018_threshold = context->xq2018_threshold;
+
+  for (CeedInt i = 0; i < Q; i++) {
+    SWEState         state = {q[0][i], q[1][i], q[2][i]};
+    const CeedScalar h     = state.h;
+    const CeedScalar hu    = state.hu;
+    const CeedScalar hv    = state.hv;
+
+    const CeedScalar dz_dx = geom[0][i];
+    const CeedScalar dz_dy = geom[1][i];
+
+    const CeedScalar bedx = dz_dx * gravity * h;
+    const CeedScalar bedy = dz_dy * gravity * h;
+
+    const CeedScalar Fsum_x = riemannf[1][i];
+    const CeedScalar Fsum_y = riemannf[2][i];
+
+    CeedScalar tbx = 0.0, tby = 0.0;
+    if (h > tiny_h) {
+      // defined in the text below equation 22 of XQ2018
+      const CeedScalar Ax = Fsum_x - bedx;
+      const CeedScalar Ay = Fsum_y - bedy;
+
+      // equation 27 of XQ2018
+      const CeedScalar mx = hu + Ax * dt;
+      const CeedScalar my = hv + Ay * dt;
+
+      const CeedScalar lambda = gravity * Square(mannings_n[0][i]) * pow(h, -4.0 / 3.0) * pow(Square(mx / h) + Square(my / h), 0.5);
+
+      CeedScalar qx_nplus1 = 0.0, qy_nplus1 = 0.0;
+
+      // equation 36 and 37 of XQ2018
+      if (dt * lambda < xq2018_threshold) {
+        qx_nplus1 = mx;
+        qy_nplus1 = my;
+      } else {
+        qx_nplus1 = (mx - mx * pow(1.0 + 4.0 * dt * lambda, 0.5)) / (-2.0 * dt * lambda);
+        qy_nplus1 = (my - my * pow(1.0 + 4.0 * dt * lambda, 0.5)) / (-2.0 * dt * lambda);
+      }
+
+      const CeedScalar q_magnitude = pow(Square(qx_nplus1) + Square(qy_nplus1), 0.5);
+
+      // equation 21 and 22 of XQ2018
+      tbx = dt * gravity * Square(mannings_n[0][i]) * pow(h, -7.0 / 3.0) * qx_nplus1 * q_magnitude;
+      tby = dt * gravity * Square(mannings_n[0][i]) * pow(h, -7.0 / 3.0) * qy_nplus1 * q_magnitude;
     }
 
     cell[0][i] = riemannf[0][i] + swe_src[0][i];

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -246,7 +246,7 @@ CEED_QFUNCTION(SWEBoundaryFlux_Outflow_Roe)(void *ctx, CeedInt Q, const CeedScal
 }
 
 // SWE regional source operator Q-function
-CEED_QFUNCTION(SWESourceTerm)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+CEED_QFUNCTION(SWESourceTermSemiImplicit)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   const CeedScalar(*geom)[CEED_Q_VLA]       = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // dz/dx, dz/dy
   const CeedScalar(*swe_src)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[1];  // external source (e.g. rain rate)
   const CeedScalar(*mannings_n)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[2];  // mannings coefficient

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -721,7 +721,7 @@ static PetscErrorCode ApplySourceImplicitXQ2018(void *context, PetscOperatorFiel
   RDyMesh        *mesh             = source_op->mesh;
   RDyCells       *cells            = &mesh->cells;
   PetscReal       tiny_h           = source_op->tiny_h;
-  PetscReal       xq2018_threshold = 10e-10;
+  PetscReal       xq2018_threshold = source_op->xq2018_threshold;
 
   // access Vec data
   PetscScalar *source_ptr, *mannings_ptr, *u_ptr, *f_ptr;

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -613,7 +613,7 @@ typedef struct {
 } SourceOperator;
 
 // adds source terms to the right hand side vector F
-static PetscErrorCode ApplySource(void *context, PetscOperatorFields fields, PetscReal dt, Vec u_local, Vec f_global) {
+static PetscErrorCode ApplySourceSemiImplicit(void *context, PetscOperatorFields fields, PetscReal dt, Vec u_local, Vec f_global) {
   PetscFunctionBeginUser;
 
   MPI_Comm comm;
@@ -833,7 +833,7 @@ PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *mesh, Vec external_sources,
       .mannings         = mannings,
       .tiny_h           = tiny_h,
   };
-  PetscCall(PetscOperatorCreate(source_op, ApplySource, DestroySource, petsc_op));
+  PetscCall(PetscOperatorCreate(source_op, ApplySourceSemiImplicit, DestroySource, petsc_op));
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -708,7 +708,7 @@ static PetscErrorCode ApplySourceSemiImplicit(void *context, PetscOperatorFields
 /// @param u_local
 /// @param f_global
 /// @return
-static PetscErrorCode ApplySourceXL2018(void *context, PetscOperatorFields fields, PetscReal dt, Vec u_local, Vec f_global) {
+static PetscErrorCode ApplySourceXQ2018(void *context, PetscOperatorFields fields, PetscReal dt, Vec u_local, Vec f_global) {
   PetscFunctionBeginUser;
 
   MPI_Comm comm;
@@ -720,7 +720,7 @@ static PetscErrorCode ApplySourceXL2018(void *context, PetscOperatorFields field
   RDyMesh        *mesh             = source_op->mesh;
   RDyCells       *cells            = &mesh->cells;
   PetscReal       tiny_h           = source_op->tiny_h;
-  PetscReal       xl2018_threshold = 10e-10;
+  PetscReal       xq2018_threshold = 10e-10;
 
   // access Vec data
   PetscScalar *source_ptr, *mannings_ptr, *u_ptr, *f_ptr;
@@ -765,11 +765,11 @@ static PetscErrorCode ApplySourceXL2018(void *context, PetscOperatorFields field
         PetscReal Fsum_x = flux_div_ptr[n_dof * owned_cell_id + 1];
         PetscReal Fsum_y = flux_div_ptr[n_dof * owned_cell_id + 2];
 
-        // defined in the text below equation 22 of XL2018
+        // defined in the text below equation 22 of XQ2018
         PetscReal Ax = Fsum_x - bedx;
         PetscReal Ay = Fsum_y - bedy;
 
-        // equation 27 of XL2018
+        // equation 27 of XQ2018
         PetscReal mx = hu + Ax * dt;
         PetscReal my = hv + Ay * dt;
 
@@ -777,8 +777,8 @@ static PetscErrorCode ApplySourceXL2018(void *context, PetscOperatorFields field
 
         PetscReal qx_nplus1, qy_nplus1;
 
-        // equation 36 and 37 of XL2018
-        if (dt * lambda < xl2018_threshold) {
+        // equation 36 and 37 of XQ2018
+        if (dt * lambda < xq2018_threshold) {
           qx_nplus1 = mx;
           qy_nplus1 = my;
         } else {
@@ -788,7 +788,7 @@ static PetscErrorCode ApplySourceXL2018(void *context, PetscOperatorFields field
 
         PetscReal q_magnitude = PetscPowReal(Square(qx_nplus1) + Square(qy_nplus1), 0.5);
 
-        // equation 21 and 22 of XL2018
+        // equation 21 and 22 of XQ2018
         tbx = dt * GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qx_nplus1 * q_magnitude;
         tby = dt * GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qy_nplus1 * q_magnitude;
       }

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -846,7 +846,7 @@ PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *mesh, Vec external_sources,
     case SOURCE_SEMI_IMPLICIT:
       PetscCall(PetscOperatorCreate(source_op, ApplySourceSemiImplicit, DestroySource, petsc_op));
       break;
-    case SOURCE_IMPLIICT_XQ2018:
+    case SOURCE_IMPLICIT_XQ2018:
       PetscCall(PetscOperatorCreate(source_op, ApplySourceImplicitXQ2018, DestroySource, petsc_op));
       break;
     default:

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -826,7 +826,7 @@ static PetscErrorCode DestroySource(void *context) {
 /// @param [in]    tiny_h           the water height below which dry conditions are assumed
 /// @param [in]    xq2018_threshold the threshold use of the XL2018 implicit temporal method
 /// @param [out]   petsc_op         the newly created PetscOperator
-PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *mesh, Vec external_sources, Vec mannings, RDySourceTimeMethod method, PetscReal tiny_h,
+PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *mesh, Vec external_sources, Vec mannings, RDyFlowSourceMethod method, PetscReal tiny_h,
                                             PetscReal xq2018_threshold, PetscOperator *petsc_op) {
   PetscFunctionBegin;
   SourceOperator *source_op;

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -698,6 +698,117 @@ static PetscErrorCode ApplySource(void *context, PetscOperatorFields fields, Pet
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+/// @brief Adds contribution of the source-term using implicit time integration approach of:
+///        Xia, Xilin, and Qiuhua Liang. "A new efficient implicit scheme for discretising the stiff
+///        friction terms in the shallow water equations." Advances in water resources 117 (2018): 87-97.
+///        https://www.sciencedirect.com/science/article/pii/S0309170818302124?ref=cra_js_challenge&fr=RR-1
+/// @param context
+/// @param fields
+/// @param dt
+/// @param u_local
+/// @param f_global
+/// @return
+static PetscErrorCode ApplySourceXL2018(void *context, PetscOperatorFields fields, PetscReal dt, Vec u_local, Vec f_global) {
+  PetscFunctionBeginUser;
+
+  MPI_Comm comm;
+  PetscCall(PetscObjectGetComm((PetscObject)u_local, &comm));
+
+  SourceOperator *source_op        = context;
+  Vec             source_vec       = source_op->external_sources;
+  Vec             mannings_vec     = source_op->mannings;
+  RDyMesh        *mesh             = source_op->mesh;
+  RDyCells       *cells            = &mesh->cells;
+  PetscReal       tiny_h           = source_op->tiny_h;
+  PetscReal       xl2018_threshold = 10e-10;
+
+  // access Vec data
+  PetscScalar *source_ptr, *mannings_ptr, *u_ptr, *f_ptr;
+  PetscCall(VecGetArray(source_vec, &source_ptr));      // sequential vector
+  PetscCall(VecGetArray(mannings_vec, &mannings_ptr));  // sequential vector
+  PetscCall(VecGetArray(u_local, &u_ptr));              // domain local vector (indexed by local cells)
+  PetscCall(VecGetArray(f_global, &f_ptr));             // domain global vector (indexed by owned cells)
+
+  // access previously-computed flux divergence data
+  Vec flux_div;
+  PetscCall(PetscOperatorFieldsGet(fields, "riemannf", &flux_div));
+  PetscCheck(flux_div, comm, PETSC_ERR_USER, "No 'riemannf' field found in source operator!");
+  PetscScalar *flux_div_ptr;
+  PetscCall(VecGetArray(flux_div, &flux_div_ptr));  // domain global vector
+
+  PetscInt size;
+  PetscCall(VecGetSize(source_vec, &size));
+  PetscInt n_dof = size / mesh->num_owned_cells;
+  PetscCheck(n_dof == 3, comm, PETSC_ERR_USER, "Number of dof in local vector must be 3!");
+
+  for (PetscInt c = 0; c < mesh->num_cells; ++c) {
+    if (cells->is_owned[c]) {
+      PetscInt owned_cell_id = cells->local_to_owned[c];
+
+      PetscReal h  = u_ptr[n_dof * c + 0];
+      PetscReal hu = u_ptr[n_dof * c + 1];
+      PetscReal hv = u_ptr[n_dof * c + 2];
+
+      PetscReal dz_dx = cells->dz_dx[c];
+      PetscReal dz_dy = cells->dz_dy[c];
+
+      PetscReal bedx = dz_dx * GRAVITY * h;
+      PetscReal bedy = dz_dy * GRAVITY * h;
+
+      PetscReal tbx = 0.0, tby = 0.0;
+
+      if (h >= tiny_h) {  // wet conditions
+
+        // Manning's coefficient
+        PetscReal N_mannings = mannings_ptr[c];
+
+        PetscReal Fsum_x = flux_div_ptr[n_dof * owned_cell_id + 1];
+        PetscReal Fsum_y = flux_div_ptr[n_dof * owned_cell_id + 2];
+
+        // defined in the text below equation 22 of XL2018
+        PetscReal Ax = Fsum_x - bedx;
+        PetscReal Ay = Fsum_y - bedy;
+
+        // equation 27 of XL2018
+        PetscReal mx = hu + Ax * dt;
+        PetscReal my = hv + Ay * dt;
+
+        PetscReal lambda = GRAVITY * Square(N_mannings) * PetscPowReal(h, -4.0 / 3.0) * PetscPowReal(Square(mx / h) + Square(my / h), 0.5);
+
+        PetscReal qx_nplus1, qy_nplus1;
+
+        // equation 36 and 37 of XL2018
+        if (dt * lambda < xl2018_threshold) {
+          qx_nplus1 = mx;
+          qy_nplus1 = my;
+        } else {
+          qx_nplus1 = (mx - mx * PetscPowReal(1 + 4 * dt * lambda, 0.5)) / (-2 * dt * lambda);
+          qy_nplus1 = (my - my * PetscPowReal(1 + 4 * dt * lambda, 0.5)) / (-2 * dt * lambda);
+        }
+
+        PetscReal q_magnitude = PetscPowReal(Square(qx_nplus1) + Square(qy_nplus1), 0.5);
+
+        // equation 21 and 22 of XL2018
+        tbx = dt * GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qx_nplus1 * q_magnitude;
+        tby = dt * GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qy_nplus1 * q_magnitude;
+      }
+
+      // NOTE: we accumulate everything into the RHS vector by convention.
+      f_ptr[n_dof * owned_cell_id + 0] += source_ptr[n_dof * owned_cell_id + 0];
+      f_ptr[n_dof * owned_cell_id + 1] += -bedx - tbx + source_ptr[n_dof * owned_cell_id + 1];
+      f_ptr[n_dof * owned_cell_id + 2] += -bedy - tby + source_ptr[n_dof * owned_cell_id + 2];
+    }
+  }
+
+  // restore vectors
+  PetscCall(VecRestoreArray(u_local, &u_ptr));
+  PetscCall(VecRestoreArray(f_global, &f_ptr));
+  PetscCall(VecRestoreArray(source_vec, &source_ptr));
+  PetscCall(VecRestoreArray(mannings_vec, &mannings_ptr));
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 static PetscErrorCode DestroySource(void *context) {
   PetscFunctionBegin;
   SourceOperator *source_op = context;

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -790,8 +790,8 @@ static PetscErrorCode ApplySourceImplicitXQ2018(void *context, PetscOperatorFiel
         PetscReal q_magnitude = PetscPowReal(Square(qx_nplus1) + Square(qy_nplus1), 0.5);
 
         // equation 21 and 22 of XQ2018
-        tbx = dt * GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qx_nplus1 * q_magnitude;
-        tby = dt * GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qy_nplus1 * q_magnitude;
+        tbx = GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qx_nplus1 * q_magnitude;
+        tby = GRAVITY * Square(N_mannings) * PetscPowReal(h, -7.0 / 3.0) * qy_nplus1 * q_magnitude;
       }
 
       // NOTE: we accumulate everything into the RHS vector by convention.

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -783,8 +783,8 @@ static PetscErrorCode ApplySourceImplicitXQ2018(void *context, PetscOperatorFiel
           qx_nplus1 = mx;
           qy_nplus1 = my;
         } else {
-          qx_nplus1 = (mx - mx * PetscPowReal(1 + 4 * dt * lambda, 0.5)) / (-2 * dt * lambda);
-          qy_nplus1 = (my - my * PetscPowReal(1 + 4 * dt * lambda, 0.5)) / (-2 * dt * lambda);
+          qx_nplus1 = (mx - mx * PetscPowReal(1.0 + 4.0 * dt * lambda, 0.5)) / (-2.0 * dt * lambda);
+          qy_nplus1 = (my - my * PetscPowReal(1.0 + 4.0 * dt * lambda, 0.5)) / (-2.0 * dt * lambda);
         }
 
         PetscReal q_magnitude = PetscPowReal(Square(qx_nplus1) + Square(qy_nplus1), 0.5);

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -703,11 +703,11 @@ static PetscErrorCode ApplySourceSemiImplicit(void *context, PetscOperatorFields
 ///        Xia, Xilin, and Qiuhua Liang. "A new efficient implicit scheme for discretising the stiff
 ///        friction terms in the shallow water equations." Advances in water resources 117 (2018): 87-97.
 ///        https://www.sciencedirect.com/science/article/pii/S0309170818302124?ref=cra_js_challenge&fr=RR-1
-/// @param context
-/// @param fields
-/// @param dt
-/// @param u_local
-/// @param f_global
+/// @param [in] context   a context for the SourceOperator
+/// @param [in] fields    a PetscOperatorFields from which includes the "rimeannf" field
+/// @param [in] dt        time step
+/// @param [in] u_local   a Vec that contain unknowns for locally-present and ghost cells
+/// @param [out] f_global a Vec that stores the fluxes for only locally-present cells
 /// @return
 static PetscErrorCode ApplySourceImplicitXQ2018(void *context, PetscOperatorFields fields, PetscReal dt, Vec u_local, Vec f_global) {
   PetscFunctionBeginUser;
@@ -822,7 +822,9 @@ static PetscErrorCode DestroySource(void *context) {
 /// @param [in]    mesh             a mesh representing the domain
 /// @param [in]    external_sources a Vec storing external source values (if any) for the domain
 /// @param [in]    mannings         a Vec storing Mannings coefficient values for the domain
+/// @param [in]    method           type of temporal method used for discretizing the friction source term
 /// @param [in]    tiny_h           the water height below which dry conditions are assumed
+/// @param [in]    xq2018_threshold the threshold use of the XL2018 implicit temporal method
 /// @param [out]   petsc_op         the newly created PetscOperator
 PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *mesh, Vec external_sources, Vec mannings, RDySourceTimeMethod method, PetscReal tiny_h,
                                             PetscReal xq2018_threshold, PetscOperator *petsc_op) {

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -40,6 +40,7 @@
 //   flow:
 //     mode: <swe|diffusion> # swe by default
 //     tiny_h: <value> # 1e-7 by default
+//     xq2018_threshold: <value> # 1e-10 by default
 //   sediment: <true|false> # off by default
 //   salinity: <true|false> # off by default
 
@@ -49,10 +50,17 @@ static const cyaml_strval_t physics_flow_modes[] = {
     {"diffusion", FLOW_DIFFUSION},
 };
 
+static const cyaml_strval_t source_time_methods[] = {
+    {"semi_implicit",   SOURCE_SEMI_IMPLICIT  },
+    {"implicit_xq2018", SOURCE_IMPLIICT_XQ2018},
+};
+
 // mapping of physics.flow fields to members of RDyPhysicsFlow
 static const cyaml_schema_field_t physics_flow_fields_schema[] = {
     CYAML_FIELD_ENUM("mode", CYAML_FLAG_DEFAULT, RDyPhysicsFlow, mode, physics_flow_modes, CYAML_ARRAY_LEN(physics_flow_modes)),
     CYAML_FIELD_FLOAT("tiny_h", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, tiny_h),
+    CYAML_FIELD_ENUM("source_time_method", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, source_time_method, source_time_methods, CYAML_ARRAY_LEN(source_time_methods)),
+    CYAML_FIELD_FLOAT("xq2018_threshold", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, xq2018_threshold),
     CYAML_FIELD_END
 };
 
@@ -735,6 +743,8 @@ static PetscErrorCode SetMissingValues(RDyConfig *config) {
   PetscFunctionBegin;
 
   SET_MISSING_PARAMETER(config->physics.flow.tiny_h, 1e-7);
+  SET_MISSING_PARAMETER(config->physics.flow.source_time_method, SOURCE_SEMI_IMPLICIT);
+  SET_MISSING_PARAMETER(config->physics.flow.xq2018_threshold, 1e-10);
 
   SET_MISSING_PARAMETER(config->time.final_time, INVALID_REAL);
   SET_MISSING_PARAMETER(config->time.max_step, INVALID_INT);

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -56,16 +56,16 @@ static const cyaml_strval_t source_time_methods[] = {
 };
 
 // mapping of treatment of "source" fields to members
-static const cyaml_schema_field_t output_source_fields_schema[] = {
+static const cyaml_schema_field_t source_fields_schema[] = {
     CYAML_FIELD_ENUM("method", CYAML_FLAG_OPTIONAL, RDyFlowSource, method, source_time_methods, CYAML_ARRAY_LEN(source_time_methods)),
-    CYAML_FIELD_INT("xq2018_threshold", CYAML_FLAG_OPTIONAL, RDyFlowSource, xq2018_threshold),
+    CYAML_FIELD_FLOAT("xq2018_threshold", CYAML_FLAG_OPTIONAL, RDyFlowSource, xq2018_threshold),
 };
 
 // mapping of physics.flow fields to members of RDyPhysicsFlow
 static const cyaml_schema_field_t physics_flow_fields_schema[] = {
     CYAML_FIELD_ENUM("mode", CYAML_FLAG_DEFAULT, RDyPhysicsFlow, mode, physics_flow_modes, CYAML_ARRAY_LEN(physics_flow_modes)),
     CYAML_FIELD_FLOAT("tiny_h", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, tiny_h),
-    CYAML_FIELD_MAPPING("source", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, source, output_source_fields_schema),
+    CYAML_FIELD_MAPPING("source", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, source, source_fields_schema),
     CYAML_FIELD_END
 };
 

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -57,8 +57,8 @@ static const cyaml_strval_t source_time_methods[] = {
 
 // mapping of treatment of "source" fields to members
 static const cyaml_schema_field_t output_source_fields_schema[] = {
-    CYAML_FIELD_ENUM("method", CYAML_FLAG_OPTIONAL, RDySource, method, source_time_methods, CYAML_ARRAY_LEN(source_time_methods)),
-    CYAML_FIELD_INT("xq2018_threshold", CYAML_FLAG_OPTIONAL, RDySource, xq2018_threshold),
+    CYAML_FIELD_ENUM("method", CYAML_FLAG_OPTIONAL, RDyFlowSource, method, source_time_methods, CYAML_ARRAY_LEN(source_time_methods)),
+    CYAML_FIELD_INT("xq2018_threshold", CYAML_FLAG_OPTIONAL, RDyFlowSource, xq2018_threshold),
 };
 
 // mapping of physics.flow fields to members of RDyPhysicsFlow

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -55,12 +55,17 @@ static const cyaml_strval_t source_time_methods[] = {
     {"implicit_xq2018", SOURCE_IMPLICIT_XQ2018},
 };
 
+// mapping of treatment of "source" fields to members
+static const cyaml_schema_field_t output_source_fields_schema[] = {
+    CYAML_FIELD_ENUM("method", CYAML_FLAG_OPTIONAL, RDySource, method, source_time_methods, CYAML_ARRAY_LEN(source_time_methods)),
+    CYAML_FIELD_INT("xq2018_threshold", CYAML_FLAG_OPTIONAL, RDySource, xq2018_threshold),
+};
+
 // mapping of physics.flow fields to members of RDyPhysicsFlow
 static const cyaml_schema_field_t physics_flow_fields_schema[] = {
     CYAML_FIELD_ENUM("mode", CYAML_FLAG_DEFAULT, RDyPhysicsFlow, mode, physics_flow_modes, CYAML_ARRAY_LEN(physics_flow_modes)),
     CYAML_FIELD_FLOAT("tiny_h", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, tiny_h),
-    CYAML_FIELD_ENUM("source_time_method", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, source_time_method, source_time_methods, CYAML_ARRAY_LEN(source_time_methods)),
-    CYAML_FIELD_FLOAT("xq2018_threshold", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, xq2018_threshold),
+    CYAML_FIELD_MAPPING("source", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, source, output_source_fields_schema),
     CYAML_FIELD_END
 };
 
@@ -743,8 +748,8 @@ static PetscErrorCode SetMissingValues(RDyConfig *config) {
   PetscFunctionBegin;
 
   SET_MISSING_PARAMETER(config->physics.flow.tiny_h, 1e-7);
-  SET_MISSING_PARAMETER(config->physics.flow.source_time_method, SOURCE_SEMI_IMPLICIT);
-  SET_MISSING_PARAMETER(config->physics.flow.xq2018_threshold, 1e-10);
+  SET_MISSING_PARAMETER(config->physics.flow.source.method, SOURCE_SEMI_IMPLICIT);
+  SET_MISSING_PARAMETER(config->physics.flow.source.xq2018_threshold, 1e-10);
 
   SET_MISSING_PARAMETER(config->time.final_time, INVALID_REAL);
   SET_MISSING_PARAMETER(config->time.max_step, INVALID_INT);

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -40,7 +40,9 @@
 //   flow:
 //     mode: <swe|diffusion> # swe by default
 //     tiny_h: <value> # 1e-7 by default
-//     xq2018_threshold: <value> # 1e-10 by default
+//     source:
+//       method: <semi_implicit|implicit_xq2018> # semi_implicit by default
+//       xq2018_threshold: <value> # 1e-10 by default
 //   sediment: <true|false> # off by default
 //   salinity: <true|false> # off by default
 

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -52,7 +52,7 @@ static const cyaml_strval_t physics_flow_modes[] = {
 
 static const cyaml_strval_t source_time_methods[] = {
     {"semi_implicit",   SOURCE_SEMI_IMPLICIT  },
-    {"implicit_xq2018", SOURCE_IMPLIICT_XQ2018},
+    {"implicit_xq2018", SOURCE_IMPLICIT_XQ2018},
 };
 
 // mapping of physics.flow fields to members of RDyPhysicsFlow


### PR DESCRIPTION
- The implicit time integration approach for the friction source term of [Xilin and 
Liang (2018)](https://www.sciencedirect.com/science/article/pii/S0309170818302124?ref=cra_js_challenge&fr=RR-1) is implemented here. The new method can be used by specifying
`source_time_method: implicit_xq2018` within the `physics` block in the .yaml
file, e.g.,

```
physics:
  flow:
    mode: swe
    source:
      method: implicit_xq2018
      xq2018_threshold: 1.0e-12
```

- The valid for the optional `source_time_method` are:
    1. `semi_implicit` (default)
    2. `implicit_xq2018`.