### PR TITLE
Adds CEED version of the sediment dynamics

### DIFF
--- a/driver/tests/sediment/CMakeLists.txt
+++ b/driver/tests/sediment/CMakeLists.txt
@@ -27,7 +27,7 @@ file(COPY
      ${MATERIALS_DIR}/manning_grid5x10.${PETSC_ID_TYPE}.bin
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 2) # test on 1, 2 processes
-  foreach(config basic)
+  foreach(config basic ceed)
     foreach(lang c f90)
       add_test(sediment_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} sediment.yaml ${${config}_args})
     endforeach()
@@ -42,7 +42,7 @@ file(COPY
      ${MATERIALS_DIR}/manning_grid5x10.${PETSC_ID_TYPE}.bin
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 2) # test on 1, 2 processes
-  foreach(config basic)
+  foreach(config basic ceed)
     foreach(lang c)
       add_test(sediment_ic_file${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} sediment_ic_file.yaml ${${config}_args})
     endforeach()

--- a/driver/tests/sediment/CMakeLists.txt
+++ b/driver/tests/sediment/CMakeLists.txt
@@ -13,7 +13,7 @@ file(COPY
      ${MESH_DIR}/mms_triangles_dx1.exo
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 2) # test on 1, 2 processes
-  foreach(config basic)
+  foreach(config basic ceed)
     foreach(lang c f90)
       add_test(mms_conv_study_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${mms_${lang}_driver} sediment_mms_conv_study.yaml ${${config}_args})
     endforeach()

--- a/include/private/rdysedimentimpl.h
+++ b/include/private/rdysedimentimpl.h
@@ -6,6 +6,11 @@
 #include <private/rdycoreimpl.h>
 #include <private/rdyoperatorimpl.h>
 
+PETSC_INTERN PetscErrorCode CreateSedimentCeedInteriorFluxOperator(RDyMesh *, const PetscInt, const PetscInt, const PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSedimentCeedBoundaryFluxOperator(RDyMesh *, const PetscInt, const PetscInt, RDyBoundary, RDyCondition, PetscReal,
+                                                                   CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSedimentCeedSourceOperator(RDyMesh *, PetscInt, const PetscInt, RDyFlowSourceMethod, PetscReal, PetscReal,
+                                                             CeedOperator *);
 PETSC_INTERN PetscErrorCode CreateSedimentPetscInteriorFluxOperator(RDyMesh *, PetscInt, PetscInt, OperatorDiagnostics *, PetscReal, PetscOperator *);
 PETSC_INTERN PetscErrorCode CreateSedimentPetscBoundaryFluxOperator(RDyMesh *, PetscInt, PetscInt, RDyBoundary, RDyCondition, Vec, Vec,
                                                                     OperatorDiagnostics *, PetscReal, PetscOperator *);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ set(RDYCORE_C_SOURCE_FILES
   swe/swe_petsc.c
   swe/swe_ceed.c
   sediment/sediment_petsc.c
+  sediment/sediment_ceed.c
   time_series.c
   xdmf_output.c
   yaml_input.c

--- a/src/sediment/sediment_ceed.c
+++ b/src/sediment/sediment_ceed.c
@@ -72,6 +72,13 @@ static PetscErrorCode CreateSedimentQFunctionContext(Ceed ceed, const PetscReal 
   PetscFunctionReturn(CEED_ERROR_SUCCESS);
 }
 
+/// @brief Creates a CEED operator for solving flow and sediment dynamics equation for interior edges
+/// @param [in] mesh               a RDymesh struct for the mesh
+/// @param [in] num_flow_comp      number of components for the flow problem
+/// @param [in] num_sediment_comp  number of components for the sediment dynamics problem. Currently only one component is supported.
+/// @param [in] tiny_h             the water height below which dry conditions are assumed
+/// @param [out] ceed_op           a CeedOperator that is created and returned
+/// @return 0 on success, or a non-zero error code on failure
 PetscErrorCode CreateSedimentCeedInteriorFluxOperator(RDyMesh *mesh, const PetscInt num_flow_comp, const PetscInt num_sediment_comp,
                                                       const PetscReal tiny_h, CeedOperator *ceed_op) {
   PetscFunctionBeginUser;
@@ -202,6 +209,15 @@ PetscErrorCode CreateSedimentCeedInteriorFluxOperator(RDyMesh *mesh, const Petsc
   PetscFunctionReturn(CEED_ERROR_SUCCESS);
 }
 
+/// @brief Creates a CEED operator for solving flow and sediment dynamics equation for a set of boundary edges
+/// @param [in] mesh               a RDymesh struct for the mesh
+/// @param [in] num_flow_comp      number of components for the flow problem
+/// @param [in] num_sediment_comp  number of components for the sediment dynamics problem. Currently only one component is supported.
+/// @param boundary                a RDyBoundary struct describing the boundary on which the boundary condition is applied
+/// @param boundary_condition      a RDyCondition describing the type of boundary condition
+/// @param [in] tiny_h             the water height below which dry conditions are assumed
+/// @param [out] ceed_op           a CeedOperator that is created and returned
+/// @return 0 on success, or a non-zero error code on failure
 PetscErrorCode CreateSedimentCeedBoundaryFluxOperator(RDyMesh *mesh, const PetscInt num_flow_comp, const PetscInt num_sediment_comp,
                                                       RDyBoundary boundary, RDyCondition boundary_condition, PetscReal tiny_h,
                                                       CeedOperator *ceed_op) {
@@ -363,6 +379,15 @@ PetscErrorCode CreateSedimentCeedBoundaryFluxOperator(RDyMesh *mesh, const Petsc
   PetscFunctionReturn(CEED_ERROR_SUCCESS);
 }
 
+/// @brief Creates a CEED operator for solving flow and sediment dynamics equation for the source-sink term
+/// @param [in] mesh               a RDymesh struct for the mesh
+/// @param [in] num_flow_comp      number of components for the flow problem
+/// @param [in] num_sediment_comp  number of components for the sediment dynamics problem. Currently only one component is supported.
+/// @param [in]  method            type of temporal method used for discretizing the friction source term
+/// @param [in] tiny_h             the water height below which dry conditions are assumed
+/// @param xq2018_threshold        the threshold use of the XL2018 implicit temporal method
+/// @param [out] ceed_op           a CeedOperator that is created and returned
+/// @return 0 on success, or a non-zero error code on failure
 PetscErrorCode CreateSedimentCeedSourceOperator(RDyMesh *mesh, PetscInt num_flow_comp, const PetscInt num_sediment_comp, RDyFlowSourceMethod method,
                                                 PetscReal tiny_h, PetscReal xq2018_threshold, CeedOperator *ceed_op) {
   PetscFunctionBeginUser;

--- a/src/sediment/sediment_ceed.c
+++ b/src/sediment/sediment_ceed.c
@@ -1,0 +1,491 @@
+#include <petscdmceed.h>
+#include <private/rdysedimentimpl.h>
+
+#include "sediment_ceed_impl.h"
+
+// CEED uses C99 VLA features for shaping multidimensional
+// arrays, which don't have the same drawbacks as VLA allocations.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
+
+static const PetscReal GRAVITY          = 9.806;   // gravitational acceleration [m/s^2]
+static const PetscReal DENSITY_OF_WATER = 1000.0;  // [kg/m^3]
+
+// frees a data context allocated using PETSc, returning a libCEED error code
+static int FreeContextPetsc(void *data) {
+  if (PetscFree(data)) return CeedError(NULL, CEED_ERROR_ACCESS, "PetscFree failed");
+  return CEED_ERROR_SUCCESS;
+}
+
+// creates a QFunction context for a flux or source operator with the given
+// minimum water height threshold
+static PetscErrorCode CreateSedimentQFunctionContext(Ceed ceed, const PetscReal tiny_h, const PetscReal xq2018_threshold,
+                                                     CeedQFunctionContext *qf_context) {
+  PetscFunctionBeginUser;
+
+  SedimentContext sediment_ctx;
+  PetscCall(PetscCalloc1(1, &sediment_ctx));
+
+  sediment_ctx->dtime                   = 0.0;
+  sediment_ctx->tiny_h                  = tiny_h;
+  sediment_ctx->gravity                 = GRAVITY;
+  sediment_ctx->xq2018_threshold        = xq2018_threshold;
+  sediment_ctx->kp_constant             = 0.001;
+  sediment_ctx->settling_velocity       = 0.01;
+  sediment_ctx->tau_critical_erosion    = 0.1;
+  sediment_ctx->tau_critical_deposition = 1000.0;
+  sediment_ctx->rhow                    = DENSITY_OF_WATER;
+
+  PetscCallCEED(CeedQFunctionContextCreate(ceed, qf_context));
+
+  PetscCallCEED(CeedQFunctionContextSetData(*qf_context, CEED_MEM_HOST, CEED_USE_POINTER, sizeof(*sediment_ctx), sediment_ctx));
+
+  PetscCallCEED(CeedQFunctionContextSetDataDestroy(*qf_context, CEED_MEM_HOST, FreeContextPetsc));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "time step", offsetof(struct SedimentContext_, dtime), 1, "Time step of TS"));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "small h value", offsetof(struct SedimentContext_, tiny_h), 1,
+                                                   "Height threshold below which dry condition is assumed"));
+  PetscCallCEED(
+      CeedQFunctionContextRegisterDouble(*qf_context, "gravity", offsetof(struct SedimentContext_, gravity), 1, "Accelaration due to gravity"));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "xq2018_threshold", offsetof(struct SedimentContext_, xq2018_threshold), 1,
+                                                   "Threshold for the treatment of Implicit XQ2018 method"));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "kp_constant", offsetof(struct SedimentContext_, kp_constant), 1,
+                                                   "Krone-Partheniades erosion law constant [kg/m2/s]"));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "settling_velocity", offsetof(struct SedimentContext_, settling_velocity), 1,
+                                                   "settling velocity of sediment class"));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "tau_critical_erosion", offsetof(struct SedimentContext_, tau_critical_erosion), 1,
+                                                   "critical shear stress for erosion (N/m2)"));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "tau_critical_deposition", offsetof(struct SedimentContext_, tau_critical_deposition),
+                                                   1, "critical shear stress for deposition (N/m2)"));
+
+  PetscCallCEED(CeedQFunctionContextRegisterDouble(*qf_context, "rhow", offsetof(struct SedimentContext_, rhow), 1, "density of water"));
+
+  PetscFunctionReturn(CEED_ERROR_SUCCESS);
+}
+
+PetscErrorCode CreateSedimentCeedInteriorFluxOperator(RDyMesh *mesh, const PetscInt num_flow_comp, const PetscInt num_sediment_comp,
+                                                      const PetscReal tiny_h, CeedOperator *ceed_op) {
+  PetscFunctionBeginUser;
+
+  Ceed ceed = CeedContext();
+
+  PetscCheck((num_sediment_comp == 1), PETSC_COMM_WORLD, PETSC_ERR_USER, "Ceed version of sediment only support one sediment class");
+  CeedInt   num_comp = num_flow_comp + num_sediment_comp;
+  RDyCells *cells    = &mesh->cells;
+  RDyEdges *edges    = &mesh->edges;
+
+  // create the Q-function that underlies the operator, and set its inputs and outputs
+  // NOTE: the order in which these inputs and outputs are specified determines
+  // NOTE: their indexing within the Q-function's implementation (swe_ceed_impl.h)
+  CeedQFunction qf;
+  CeedInt       num_comp_geom = 4, num_comp_cnum = 2;
+  PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SedimentFlux_Roe, SedimentFlux_Roe_loc, &qf));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "geom", num_comp_geom, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "q_left", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "q_right", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "cell_left", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "cell_right", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "flux", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "courant_number", num_comp_cnum, CEED_EVAL_NONE));
+
+  // create a context for the Q-function
+  CeedQFunctionContext qf_context;
+  PetscReal            xq2018_threshold_dummy = 0.0;
+  PetscCall(CreateSedimentQFunctionContext(ceed, tiny_h, xq2018_threshold_dummy, &qf_context));
+  if (0) PetscCallCEED(CeedQFunctionContextView(qf_context, stdout));
+  PetscCallCEED(CeedQFunctionSetContext(qf, qf_context));
+  PetscCallCEED(CeedQFunctionContextDestroy(&qf_context));
+
+  // create vectors (and their supporting restrictions) for the operator
+  CeedElemRestriction q_restrict_l, q_restrict_r, c_restrict_l, c_restrict_r, restrict_geom, restrict_flux, restrict_cnum;
+  CeedVector          geom, flux, cnum;
+  {
+    CeedInt num_edges = mesh->num_owned_internal_edges;
+
+    // create a vector of geometric factors that transform fluxes to cell states
+    CeedInt g_strides[] = {num_comp_geom, 1, num_comp_geom};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_edges, 1, num_comp_geom, num_edges * num_comp_geom, g_strides, &restrict_geom));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_geom, &geom, NULL));
+    PetscCallCEED(CeedVectorSetValue(geom, 0.0));
+    CeedScalar(*g)[4];
+    PetscCallCEED(CeedVectorGetArray(geom, CEED_MEM_HOST, (CeedScalar **)&g));
+    for (CeedInt e = 0, owned_edge = 0; e < mesh->num_internal_edges; e++) {
+      CeedInt iedge = edges->internal_edge_ids[e];
+      if (!edges->is_owned[iedge]) continue;
+      CeedInt l        = edges->cell_ids[2 * iedge];
+      CeedInt r        = edges->cell_ids[2 * iedge + 1];
+      g[owned_edge][0] = edges->sn[iedge];
+      g[owned_edge][1] = edges->cn[iedge];
+      g[owned_edge][2] = -edges->lengths[iedge] / cells->areas[l];
+      g[owned_edge][3] = edges->lengths[iedge] / cells->areas[r];
+      owned_edge++;
+    }
+    PetscCallCEED(CeedVectorRestoreArray(geom, (CeedScalar **)&g));
+
+    // create a vector to store flux divergences
+    CeedInt f_strides[] = {num_comp, 1, num_comp};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_edges, 1, num_comp, num_edges * num_comp, f_strides, &restrict_flux));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_flux, &flux, NULL));
+    PetscCallCEED(CeedVectorSetValue(flux, 0.0));
+
+    // create a vector to store the courant number for each edge
+    CeedInt cnum_strides[] = {num_comp_cnum, 1, num_comp_cnum};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_edges, 1, num_comp_cnum, num_edges * num_comp_cnum, cnum_strides, &restrict_cnum));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_cnum, &cnum, NULL));
+    PetscCallCEED(CeedVectorSetValue(cnum, 0.0));
+
+    // create element restrictions for (active) left and right input/output states
+    CeedInt *q_offset_l, *q_offset_r, *c_offset_l, *c_offset_r;
+    PetscCall(PetscMalloc2(num_edges, &q_offset_l, num_edges, &q_offset_r));
+    PetscCall(PetscMalloc2(num_edges, &c_offset_l, num_edges, &c_offset_r));
+    for (CeedInt e = 0, owned_edge = 0; e < mesh->num_internal_edges; e++) {
+      CeedInt iedge = edges->internal_edge_ids[e];
+      if (!edges->is_owned[iedge]) continue;
+      CeedInt l              = edges->cell_ids[2 * iedge];
+      CeedInt r              = edges->cell_ids[2 * iedge + 1];
+      q_offset_l[owned_edge] = l * num_comp;
+      q_offset_r[owned_edge] = r * num_comp;
+      c_offset_l[owned_edge] = cells->local_to_owned[l] * num_comp;
+      c_offset_r[owned_edge] = cells->local_to_owned[r] * num_comp;
+      owned_edge++;
+    }
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, q_offset_l,
+                                            &q_restrict_l));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, q_offset_r,
+                                            &q_restrict_r));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, c_offset_l,
+                                            &c_restrict_l));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, c_offset_r,
+                                            &c_restrict_r));
+    PetscCall(PetscFree2(q_offset_l, q_offset_r));
+    PetscCall(PetscFree2(c_offset_l, c_offset_r));
+    if (0) {
+      PetscCallCEED(CeedElemRestrictionView(q_restrict_l, stdout));
+      PetscCallCEED(CeedElemRestrictionView(q_restrict_r, stdout));
+      PetscCallCEED(CeedElemRestrictionView(c_restrict_l, stdout));
+      PetscCallCEED(CeedElemRestrictionView(c_restrict_r, stdout));
+    }
+  }
+
+  // create the operator itself and assign its active/passive inputs/outputs
+  PetscCallCEED(CeedOperatorCreate(ceed, qf, NULL, NULL, ceed_op));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "geom", restrict_geom, CEED_BASIS_COLLOCATED, geom));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "q_left", q_restrict_l, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "q_right", q_restrict_r, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "cell_left", c_restrict_l, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "cell_right", c_restrict_r, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "flux", restrict_flux, CEED_BASIS_COLLOCATED, flux));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "courant_number", restrict_cnum, CEED_BASIS_COLLOCATED, cnum));
+
+  // clean up
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_geom));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_flux));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_cnum));
+  PetscCallCEED(CeedElemRestrictionDestroy(&q_restrict_l));
+  PetscCallCEED(CeedElemRestrictionDestroy(&q_restrict_r));
+  PetscCallCEED(CeedElemRestrictionDestroy(&c_restrict_l));
+  PetscCallCEED(CeedElemRestrictionDestroy(&c_restrict_r));
+  PetscCallCEED(CeedVectorDestroy(&geom));
+  PetscCallCEED(CeedVectorDestroy(&flux));
+  PetscCallCEED(CeedVectorDestroy(&cnum));
+  PetscCallCEED(CeedQFunctionDestroy(&qf));
+
+  PetscFunctionReturn(CEED_ERROR_SUCCESS);
+}
+
+PetscErrorCode CreateSedimentCeedBoundaryFluxOperator(RDyMesh *mesh, const PetscInt num_flow_comp, const PetscInt num_sediment_comp,
+                                                      RDyBoundary boundary, RDyCondition boundary_condition, PetscReal tiny_h,
+                                                      CeedOperator *ceed_op) {
+  PetscFunctionBeginUser;
+
+  Ceed ceed = CeedContext();
+
+  PetscCheck((num_sediment_comp == 1), PETSC_COMM_WORLD, PETSC_ERR_USER, "Ceed version of sediment only support one sediment class");
+  CeedInt   num_comp = num_flow_comp + num_sediment_comp;
+  RDyCells *cells    = &mesh->cells;
+  RDyEdges *edges    = &mesh->edges;
+
+  // create the Q-function that underlies the operator, and set its inputs and outputs
+  // NOTE: the order in which these inputs and outputs are specified determines
+  // NOTE: their indexing within the Q-function's implementation (swe_ceed_impl.h)
+  CeedQFunctionUser func;
+  const char       *func_loc;
+  switch (boundary_condition.flow->type) {
+    case CONDITION_DIRICHLET:
+      func     = SedimentBoundaryFlux_Dirichlet_Roe;
+      func_loc = SedimentBoundaryFlux_Dirichlet_Roe_loc;
+      break;
+    case CONDITION_REFLECTING:
+      func     = SedimentBoundaryFlux_Reflecting_Roe;
+      func_loc = SedimentBoundaryFlux_Reflecting_Roe_loc;
+      break;
+    case CONDITION_CRITICAL_OUTFLOW:
+      PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "CONDITION_CRITICAL_OUTFLOW not implemented");
+      break;
+    default:
+      PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Invalid boundary condition encountered for boundary %" PetscInt_FMT "\n",
+                 boundary.id);
+  }
+  CeedQFunction qf;
+  CeedInt       num_comp_geom = 3, num_comp_cnum = 1;
+  PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, func, func_loc, &qf));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "geom", num_comp_geom, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "q_left", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "cell_left", num_comp, CEED_EVAL_NONE));
+  if (boundary_condition.flow->type == CONDITION_DIRICHLET) {
+    PetscCallCEED(CeedQFunctionAddInput(qf, "q_dirichlet", num_comp, CEED_EVAL_NONE));
+  }
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "flux", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "courant_number", num_comp_cnum, CEED_EVAL_NONE));
+
+  // create a context for the Q-function
+  CeedQFunctionContext qf_context;
+  PetscReal            xq2018_threshold_dummy = 0.0;
+  PetscCall(CreateSedimentQFunctionContext(ceed, tiny_h, xq2018_threshold_dummy, &qf_context));
+  if (0) PetscCallCEED(CeedQFunctionContextView(qf_context, stdout));
+  PetscCallCEED(CeedQFunctionSetContext(qf, qf_context));
+  PetscCallCEED(CeedQFunctionContextDestroy(&qf_context));
+
+  // create vectors (and their supporting restrictions) for the operator
+  CeedElemRestriction q_restrict_l, c_restrict_l, restrict_dirichlet, restrict_geom, restrict_flux, restrict_cnum;
+  CeedVector          geom, flux, dirichlet, cnum;
+  {
+    CeedInt num_edges = boundary.num_edges;
+
+    // create element restrictions for left and right input/output states
+    CeedInt *q_offset_l, *c_offset_l, *offset_dirichlet = NULL;
+    PetscCall(PetscMalloc1(num_edges, &q_offset_l));
+    PetscCall(PetscMalloc1(num_edges, &c_offset_l));
+    if (boundary_condition.flow->type == CONDITION_DIRICHLET) {
+      PetscCall(PetscMalloc1(num_edges, &offset_dirichlet));
+    }
+
+    // create a vector of geometric factors that transform fluxes to cell states
+    CeedInt num_owned_edges = 0;
+    for (CeedInt e = 0; e < boundary.num_edges; e++) {
+      CeedInt iedge = boundary.edge_ids[e];
+      if (edges->is_owned[iedge]) num_owned_edges++;
+    }
+    CeedInt g_strides[] = {num_comp_geom, 1, num_comp_geom};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_owned_edges, 1, num_comp_geom, num_edges * num_comp_geom, g_strides, &restrict_geom));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_geom, &geom, NULL));
+    PetscCallCEED(CeedVectorSetValue(geom, 0.0));
+    CeedScalar(*g)[3];
+    PetscCallCEED(CeedVectorGetArray(geom, CEED_MEM_HOST, (CeedScalar **)&g));
+    for (CeedInt e = 0, owned_edge = 0; e < num_edges; e++) {
+      CeedInt iedge = boundary.edge_ids[e];
+      if (!edges->is_owned[iedge]) continue;
+      CeedInt l        = edges->cell_ids[2 * iedge];
+      g[owned_edge][0] = edges->sn[iedge];
+      g[owned_edge][1] = edges->cn[iedge];
+      g[owned_edge][2] = -edges->lengths[iedge] / cells->areas[l];
+      owned_edge++;
+    }
+    PetscCallCEED(CeedVectorRestoreArray(geom, (CeedScalar **)&g));
+
+    // create a vector to store accumulated fluxes (flux divergences)
+    CeedInt f_strides[] = {num_comp, 1, num_comp};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_owned_edges, 1, num_comp, num_edges * num_comp, f_strides, &restrict_flux));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_flux, &flux, NULL));
+    PetscCallCEED(CeedVectorSetValue(flux, 0.0));
+
+    // create a vector to store the courant number for each edge
+    CeedInt cnum_strides[] = {num_comp_cnum, 1, num_comp_cnum};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_owned_edges, 1, num_comp_cnum, num_edges * num_comp_cnum, cnum_strides, &restrict_cnum));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_cnum, &cnum, NULL));
+    PetscCallCEED(CeedVectorSetValue(cnum, 0.0));
+
+    // create an element restriction for the (active) "left" (interior) input/output states
+    for (CeedInt e = 0, owned_edge = 0; e < num_edges; e++) {
+      CeedInt iedge = boundary.edge_ids[e];
+      if (!edges->is_owned[iedge]) continue;
+      CeedInt l              = edges->cell_ids[2 * iedge];
+      q_offset_l[owned_edge] = l * num_comp;
+      c_offset_l[owned_edge] = cells->local_to_owned[l] * num_comp;
+      if (offset_dirichlet) {  // Dirichlet boundary values
+        offset_dirichlet[owned_edge] = e * num_comp;
+      }
+      owned_edge++;
+    }
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES,
+                                            q_offset_l, &q_restrict_l));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES,
+                                            c_offset_l, &c_restrict_l));
+    PetscCall(PetscFree(q_offset_l));
+    PetscCall(PetscFree(c_offset_l));
+    if (0) {
+      PetscCallCEED(CeedElemRestrictionView(q_restrict_l, stdout));
+      PetscCallCEED(CeedElemRestrictionView(c_restrict_l, stdout));
+    }
+
+    // create a vector to store (Dirichlet) boundary values if needed
+    if (offset_dirichlet) {
+      PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_edges, 1, num_comp, 1, num_edges * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES,
+                                              offset_dirichlet, &restrict_dirichlet));
+      PetscCall(PetscFree(offset_dirichlet));
+      if (0) PetscCallCEED(CeedElemRestrictionView(restrict_dirichlet, stdout));
+      PetscCallCEED(CeedElemRestrictionCreateVector(restrict_dirichlet, &dirichlet, NULL));
+      PetscCallCEED(CeedVectorSetValue(dirichlet, 0.0));
+    }
+  }
+
+  // create the operator itself and assign its active/passive inputs/outputs
+  PetscCallCEED(CeedOperatorCreate(ceed, qf, NULL, NULL, ceed_op));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "geom", restrict_geom, CEED_BASIS_COLLOCATED, geom));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "q_left", q_restrict_l, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  if (boundary_condition.flow->type == CONDITION_DIRICHLET) {
+    PetscCallCEED(CeedOperatorSetField(*ceed_op, "q_dirichlet", restrict_dirichlet, CEED_BASIS_COLLOCATED, dirichlet));
+  }
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "cell_left", c_restrict_l, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "flux", restrict_flux, CEED_BASIS_COLLOCATED, flux));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "courant_number", restrict_cnum, CEED_BASIS_COLLOCATED, cnum));
+
+  // clean up
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_geom));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_flux));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_cnum));
+  PetscCallCEED(CeedElemRestrictionDestroy(&q_restrict_l));
+  PetscCallCEED(CeedElemRestrictionDestroy(&c_restrict_l));
+  PetscCallCEED(CeedVectorDestroy(&geom));
+  PetscCallCEED(CeedVectorDestroy(&flux));
+  PetscCallCEED(CeedVectorDestroy(&cnum));
+  PetscCallCEED(CeedQFunctionDestroy(&qf));
+
+  PetscFunctionReturn(CEED_ERROR_SUCCESS);
+}
+
+PetscErrorCode CreateSedimentCeedSourceOperator(RDyMesh *mesh, PetscInt num_flow_comp, const PetscInt num_sediment_comp, RDyFlowSourceMethod method,
+                                                PetscReal tiny_h, PetscReal xq2018_threshold, CeedOperator *ceed_op) {
+  PetscFunctionBeginUser;
+
+  Ceed ceed = CeedContext();
+
+  PetscCheck((num_sediment_comp == 1), PETSC_COMM_WORLD, PETSC_ERR_USER, "Ceed version of sediment only support one sediment class");
+  CeedInt   num_comp = num_flow_comp + num_sediment_comp;
+  RDyCells *cells    = &mesh->cells;
+
+  // create the Q-function that underlies the operator, and set its inputs and outputs
+  // NOTE: the order in which these inputs and outputs are specified determines
+  // NOTE: their indexing within the Q-function's implementation (swe_ceed_impl.h)
+  CeedQFunction qf;
+  CeedInt       num_comp_geom = 2, num_comp_sediment_src = 4, num_comp_mannings_n = 1;
+  switch (method) {
+    case SOURCE_SEMI_IMPLICIT:
+      PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SedimentSourceTermSemiImplicit, SedimentSourceTermSemiImplicit_loc, &qf));
+      break;
+    case SOURCE_IMPLICIT_XQ2018:
+      PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "SOURCE_IMPLICIT_XQ2018 is not supported in sediment CEED version");
+      break;
+    default:
+      PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Only semi_implicit source-term is supported in the CEED version");
+      break;
+  }
+
+  PetscCallCEED(CeedQFunctionAddInput(qf, "geom", num_comp_geom, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "swe_src", num_comp_sediment_src, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "mannings_n", num_comp_mannings_n, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "riemannf", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "q", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "cell", num_comp, CEED_EVAL_NONE));
+
+  // create a context for the Q-function
+  CeedQFunctionContext qf_context;
+  PetscCall(CreateSedimentQFunctionContext(ceed, tiny_h, xq2018_threshold, &qf_context));
+  if (0) PetscCallCEED(CeedQFunctionContextView(qf_context, stdout));
+  PetscCallCEED(CeedQFunctionSetContext(qf, qf_context));
+  PetscCallCEED(CeedQFunctionContextDestroy(&qf_context));
+
+  // create vectors (and their supporting restrictions) for the operator
+  CeedElemRestriction restrict_c, restrict_q, restrict_geom, restrict_swe, restrict_mannings_n;
+  CeedVector          geom, swe_src, mannings_n;
+  {
+    PetscInt num_local_cells = mesh->num_cells;
+    PetscInt num_owned_cells = mesh->num_owned_cells;
+
+    // create a vector of geometric factors (elevation function derivatives)
+    CeedScalar(*g)[num_comp_geom];
+    CeedInt strides_geom[] = {num_comp_geom, 1, num_comp_geom};
+    PetscCallCEED(
+        CeedElemRestrictionCreateStrided(ceed, num_owned_cells, 1, num_comp_geom, num_owned_cells * num_comp_geom, strides_geom, &restrict_geom));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_geom, &geom, NULL));
+    PetscCallCEED(CeedVectorSetValue(geom, 0.0));
+    PetscCallCEED(CeedVectorGetArray(geom, CEED_MEM_HOST, (CeedScalar **)&g));
+    for (CeedInt c = 0, owned_cell = 0; c < num_local_cells; ++c) {
+      if (!cells->is_owned[c]) continue;
+      g[owned_cell][0] = cells->dz_dx[c];
+      g[owned_cell][1] = cells->dz_dy[c];
+      ++owned_cell;
+    }
+    PetscCallCEED(CeedVectorRestoreArray(geom, (CeedScalar **)&g));
+
+    // create a vector of external source terms
+    CeedInt strides_swe_src[] = {num_comp_sediment_src, 1, num_comp_sediment_src};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_owned_cells, 1, num_comp_sediment_src, num_owned_cells * num_comp_sediment_src,
+                                                   strides_swe_src, &restrict_swe));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_swe, &swe_src, NULL));
+    PetscCallCEED(CeedVectorSetValue(swe_src, 0.0));
+
+    // create a vector that stores Manning's coefficient for the region of interest
+    // NOTE: we zero-initialize this coefficient here; it must be set before use
+    // NOTE: using (Get/Restore)OperatorMaterialProperty
+    CeedInt strides_mannings_n[] = {num_comp_mannings_n, 1, num_comp_mannings_n};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_owned_cells, 1, num_comp_mannings_n, num_owned_cells * num_comp_mannings_n,
+                                                   strides_mannings_n, &restrict_mannings_n));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_mannings_n, &mannings_n, NULL));
+    PetscCallCEED(CeedVectorSetValue(mannings_n, 0.0));
+
+    // create element restrictions for (active) input/output cell states
+    CeedInt *offset_c, *offset_q;
+    PetscCall(PetscMalloc1(num_owned_cells, &offset_q));
+    PetscCall(PetscMalloc1(num_owned_cells, &offset_c));
+    for (CeedInt c = 0, owned_cell = 0; c < num_local_cells; ++c) {
+      if (!cells->is_owned[c]) continue;
+      offset_q[owned_cell] = c * num_comp;
+      offset_c[owned_cell] = cells->local_to_owned[c] * num_comp;
+      ++owned_cell;
+    }
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_cells, 1, num_comp, 1, num_local_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES,
+                                            offset_q, &restrict_q));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_owned_cells, 1, num_comp, 1, num_owned_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES,
+                                            offset_c, &restrict_c));
+    PetscCall(PetscFree(offset_c));
+    PetscCall(PetscFree(offset_q));
+    if (0) {
+      PetscCallCEED(CeedElemRestrictionView(restrict_q, stdout));
+      PetscCallCEED(CeedElemRestrictionView(restrict_c, stdout));
+    }
+  }
+
+  // create the operator itself and assign its active/passive inputs/outputs
+  PetscCallCEED(CeedOperatorCreate(ceed, qf, NULL, NULL, ceed_op));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "geom", restrict_geom, CEED_BASIS_COLLOCATED, geom));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "swe_src", restrict_swe, CEED_BASIS_COLLOCATED, swe_src));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "mannings_n", restrict_mannings_n, CEED_BASIS_COLLOCATED, mannings_n));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "q", restrict_q, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "cell", restrict_c, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+
+  // clean up
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_swe));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_geom));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_mannings_n));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_c));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_q));
+  PetscCallCEED(CeedVectorDestroy(&geom));
+  PetscCallCEED(CeedVectorDestroy(&swe_src));
+  PetscCallCEED(CeedVectorDestroy(&mannings_n));
+  PetscCallCEED(CeedQFunctionDestroy(&qf));
+
+  PetscFunctionReturn(CEED_ERROR_SUCCESS);
+}
+
+#pragma GCC diagnostic   pop
+#pragma clang diagnostic pop

--- a/src/sediment/sediment_ceed_impl.h
+++ b/src/sediment/sediment_ceed_impl.h
@@ -35,6 +35,8 @@ typedef struct SedimentState_ SedimentState;
 
 #define MAX_NUM_SECTION_FIELD_COMPONENTS 10
 
+/// computes the flux across an edge using Roe's approximate Riemann solver
+/// for flow and sediment transport
 CEED_QFUNCTION_HELPER void SedimentRiemannFlux_Roe(const CeedScalar gravity, const CeedScalar tiny_h, SedimentState qL, SedimentState qR,
                                                    CeedScalar sn, CeedScalar cn, CeedInt sed_ncomp, CeedScalar flux[], CeedScalar *amax) {
   const CeedScalar sqrt_gravity = sqrt(gravity);
@@ -157,7 +159,7 @@ CEED_QFUNCTION_HELPER void SedimentRiemannFlux_Roe(const CeedScalar gravity, con
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wvla"
 
-// sediment interior flux operator Q-function
+// flow and sediment flux operator Q-function for interior edges
 CEED_QFUNCTION(SedimentFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L, weight_R
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
@@ -194,7 +196,7 @@ CEED_QFUNCTION(SedimentFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const i
   return 0;
 }
 
-// SWE boundary flux operator Q-function (Dirichlet condition)
+// flow and sediment flux operator Q-function for boundary edges on which dirichlet condition is applied
 CEED_QFUNCTION(SedimentBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
@@ -228,7 +230,7 @@ CEED_QFUNCTION(SedimentBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const C
   return 0;
 }
 
-// SWE boundary flux operator Q-function (reflecting condition)
+// flow and sediment flux operator Q-function for boundary edges on which reflecting wall condition is applied
 CEED_QFUNCTION(SedimentBoundaryFlux_Reflecting_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
@@ -262,7 +264,7 @@ CEED_QFUNCTION(SedimentBoundaryFlux_Reflecting_Roe)(void *ctx, CeedInt Q, const 
   return 0;
 }
 
-// SWE regional source operator Q-function
+// flow and sediment regional source operator Q-function
 CEED_QFUNCTION(SedimentSourceTermSemiImplicit)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   const CeedScalar(*geom)[CEED_Q_VLA]       = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // dz/dx, dz/dy
   const CeedScalar(*swe_src)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[1];  // external source (e.g. rain rate)

--- a/src/sediment/sediment_ceed_impl.h
+++ b/src/sediment/sediment_ceed_impl.h
@@ -1,0 +1,334 @@
+#ifndef SEDIMENT_CEED_IMPL_H
+#define SEDIMENT_CEED_IMPL_H
+
+#include <ceed/types.h>
+
+#define Square(x) ((x) * (x))
+#define SafeDiv(a, b, tiny) ((b) > (tiny) ? (a) / (b) : 0.0)
+
+// we disable compiler warnings for implicitly-declared math functions known to
+// the JIT compiler
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-function-declaration"
+
+// Q-function context with data attached
+typedef struct SedimentContext_ *SedimentContext;
+struct SedimentContext_ {
+  CeedScalar dtime;
+  CeedScalar tiny_h;
+  CeedScalar gravity;
+  CeedScalar xq2018_threshold;
+  CeedScalar kp_constant;
+  CeedScalar settling_velocity;
+  CeedScalar tau_critical_erosion;
+  CeedScalar tau_critical_deposition;
+  CeedScalar rhow;
+};
+
+struct SedimentState_ {
+  CeedScalar h, hu, hv, hci;
+};
+typedef struct SedimentState_ SedimentState;
+
+#define MAX_NUM_SECTION_FIELD_COMPONENTS 10
+
+CEED_QFUNCTION_HELPER void SedimentRiemannFlux_Roe(const CeedScalar gravity, const CeedScalar tiny_h, SedimentState qL, SedimentState qR,
+                                                   CeedScalar sn, CeedScalar cn, CeedInt sed_ncomp, CeedScalar flux[], CeedScalar *amax) {
+  const CeedScalar sqrt_gravity = sqrt(gravity);
+  const CeedScalar hl = qL.h, hr = qR.h;
+
+  const CeedScalar ul = SafeDiv(qL.hu, hl, tiny_h), vl = SafeDiv(qL.hv, hl, tiny_h), cil = SafeDiv(qL.hci, hl, tiny_h);
+  const CeedScalar ur = SafeDiv(qR.hu, hr, tiny_h), vr = SafeDiv(qR.hv, hr, tiny_h), cir = SafeDiv(qR.hci, hr, tiny_h);
+
+  CeedScalar cihat[MAX_NUM_SECTION_FIELD_COMPONENTS]                               = {0};
+  CeedScalar dch[MAX_NUM_SECTION_FIELD_COMPONENTS]                                 = {0};
+  CeedScalar dW[MAX_NUM_SECTION_FIELD_COMPONENTS]                                  = {0};
+  CeedScalar R[MAX_NUM_SECTION_FIELD_COMPONENTS][MAX_NUM_SECTION_FIELD_COMPONENTS] = {0};
+  CeedScalar A[MAX_NUM_SECTION_FIELD_COMPONENTS][MAX_NUM_SECTION_FIELD_COMPONENTS] = {0};
+  CeedScalar FL[MAX_NUM_SECTION_FIELD_COMPONENTS]                                  = {0};
+  CeedScalar FR[MAX_NUM_SECTION_FIELD_COMPONENTS]                                  = {0};
+
+  CeedScalar duml  = sqrt(hl);
+  CeedScalar dumr  = sqrt(hr);
+  CeedScalar cl    = sqrt_gravity * duml;
+  CeedScalar cr    = sqrt_gravity * dumr;
+  CeedScalar hhat  = duml * dumr;
+  CeedScalar uhat  = (duml * ul + dumr * ur) / (duml + dumr);
+  CeedScalar vhat  = (duml * vl + dumr * vr) / (duml + dumr);
+  CeedScalar chat  = sqrt(0.5 * gravity * (hl + hr));
+  CeedScalar uperp = uhat * cn + vhat * sn;
+
+  CeedScalar dh     = hr - hl;
+  CeedScalar du     = ur - ul;
+  CeedScalar dv     = vr - vl;
+  CeedScalar dupar  = -du * sn + dv * cn;
+  CeedScalar duperp = du * cn + dv * sn;
+
+  for (CeedInt j = 0; j < sed_ncomp; j++) {
+    cihat[j] = (duml * cil + dumr * cir) / (duml + dumr);  // FIXME: Use cil[j] and cir[j] when sed_ncomp > 1
+    dch[j]   = cir * hr - cil * hl;                        // FIXME: Use cil[j] and cir[j] when sed_ncomp > 1
+  }
+
+  dW[0] = 0.5 * (dh - hhat * duperp / chat);
+  dW[1] = hhat * dupar;
+  dW[2] = 0.5 * (dh + hhat * duperp / chat);
+  for (CeedInt j = 0; j < sed_ncomp; j++) {
+    dW[j + 3] = dch[j] - cihat[j] * dh;
+  }
+
+  CeedScalar uperpl = ul * cn + vl * sn;
+  CeedScalar uperpr = ur * cn + vr * sn;
+  CeedScalar al1    = uperpl - cl;
+  CeedScalar al3    = uperpl + cl;
+  CeedScalar ar1    = uperpr - cr;
+  CeedScalar ar3    = uperpr + cr;
+
+  R[0][0] = 1.0;
+  R[0][1] = 0.0;
+  R[0][2] = 1.0;
+  R[1][0] = uhat - chat * cn;
+  R[1][1] = -sn;
+  R[1][2] = uhat + chat * cn;
+  R[2][0] = vhat - chat * sn;
+  R[2][1] = cn;
+  R[2][2] = vhat + chat * sn;
+  for (CeedInt j = 0; j < sed_ncomp; j++) {
+    R[j + 3][0]     = cihat[j];
+    R[j + 3][2]     = cihat[j];
+    R[j + 3][j + 3] = 1.0;
+  }
+
+  CeedScalar da1 = fmax(0.0, 2.0 * (ar1 - al1));
+  CeedScalar da3 = fmax(0.0, 2.0 * (ar3 - al3));
+  CeedScalar a1  = fabs(uperp - chat);
+  CeedScalar a2  = fabs(uperp);
+  CeedScalar a3  = fabs(uperp + chat);
+
+  // Critical flow fix
+  if (a1 < da1) {
+    a1 = 0.5 * (a1 * a1 / da1 + da1);
+  }
+  if (a3 < da3) {
+    a3 = 0.5 * (a3 * a3 / da3 + da3);
+  }
+
+  // Compute interface flux
+  A[0][0] = a1;
+  A[1][1] = a2;
+  A[2][2] = a3;
+  for (CeedInt j = 0; j < sed_ncomp; j++) {
+    A[j + 3][j + 3] = a2;
+  }
+
+  FL[0] = uperpl * hl;
+  FL[1] = ul * uperpl * hl + 0.5 * gravity * hl * hl * cn;
+  FL[2] = vl * uperpl * hl + 0.5 * gravity * hl * hl * sn;
+
+  FR[0] = uperpr * hr;
+  FR[1] = ur * uperpr * hr + 0.5 * gravity * hr * hr * cn;
+  FR[2] = vr * uperpr * hr + 0.5 * gravity * hr * hr * sn;
+
+  for (CeedInt j = 0; j < sed_ncomp; j++) {
+    FL[j + 3] = hl * uperpl * cil;  // FIXME: Use cil[j] when sed_ncomp > 1
+    FR[j + 3] = hr * uperpr * cir;  // FIXME: Use cir[j] when sed_ncomp > 1
+  }
+
+  // flux = 0.5*(FL + FR - matmul(R,matmul(A,dW))
+  CeedInt soln_ncomp = 3 + sed_ncomp;
+  for (CeedInt dof1 = 0; dof1 < soln_ncomp; dof1++) {
+    flux[dof1] = 0.5 * (FL[dof1] + FR[dof1]);
+
+    for (CeedInt dof2 = 0; dof2 < soln_ncomp; dof2++) {
+      flux[dof1] = flux[dof1] - 0.5 * R[dof1][dof2] * A[dof2][dof2] * dW[dof2];
+    }
+  }
+
+  *amax = chat + fabs(uperp);
+}
+
+// The following Q functions use C99 VLA features for shaping multidimensional
+// arrays, which don't have the same drawbacks as VLA allocations.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wvla"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wvla"
+
+// sediment interior flux operator Q-function
+CEED_QFUNCTION(SedimentFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L, weight_R
+  const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  const CeedScalar(*q_R)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[2];
+  CeedScalar(*cell_L)[CEED_Q_VLA]      = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  CeedScalar(*cell_R)[CEED_Q_VLA]      = (CeedScalar(*)[CEED_Q_VLA])out[1];
+  CeedScalar(*accum_flux)[CEED_Q_VLA]  = (CeedScalar(*)[CEED_Q_VLA])out[2];
+  CeedScalar(*courant_num)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[3];
+  const SedimentContext context        = (SedimentContext)ctx;
+
+  const CeedScalar dt      = context->dtime;
+  const CeedScalar tiny_h  = context->tiny_h;
+  const CeedScalar gravity = context->gravity;
+
+  const CeedInt ndof_flow     = 3;
+  const CeedInt ndof_sediment = 1;  // FIXME: Need to be part of 'context'
+  const CeedInt ndof_total    = ndof_flow + ndof_sediment;
+
+  for (CeedInt i = 0; i < Q; i++) {
+    SedimentState qL = {q_L[0][i], q_L[1][i], q_L[2][i], q_L[3][i]};
+    SedimentState qR = {q_R[0][i], q_R[1][i], q_R[2][i], q_R[3][i]};
+    CeedScalar    flux[ndof_total], amax;
+    if (qL.h > tiny_h || qR.h > tiny_h) {
+      SedimentRiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], ndof_sediment, flux, &amax);
+      for (CeedInt j = 0; j < ndof_total; j++) {
+        cell_L[j][i]     = flux[j] * geom[2][i];
+        cell_R[j][i]     = flux[j] * geom[3][i];
+        accum_flux[j][i] = flux[j];
+      }
+      courant_num[0][i] = -amax * geom[2][i] * dt;
+      courant_num[1][i] = amax * geom[3][i] * dt;
+    }
+  }
+  return 0;
+}
+
+// SWE boundary flux operator Q-function (Dirichlet condition)
+CEED_QFUNCTION(SedimentBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
+  const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  const CeedScalar(*q_R)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[2];  // Dirichlet boundary values
+  CeedScalar(*cell_L)[CEED_Q_VLA]      = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  CeedScalar(*accum_flux)[CEED_Q_VLA]  = (CeedScalar(*)[CEED_Q_VLA])out[1];
+  CeedScalar(*courant_num)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[2];
+  const SedimentContext context        = (SedimentContext)ctx;
+
+  const CeedScalar dt      = context->dtime;
+  const CeedScalar tiny_h  = context->tiny_h;
+  const CeedScalar gravity = context->gravity;
+
+  const CeedInt ndof_flow     = 3;
+  const CeedInt ndof_sediment = 1;  // FIXME: Need to be part of 'context'
+  const CeedInt ndof_total    = ndof_flow + ndof_sediment;
+
+  for (CeedInt i = 0; i < Q; i++) {
+    SedimentState qL = {q_L[0][i], q_L[1][i], q_L[2][i], q_L[3][i]};
+    SedimentState qR = {q_R[0][i], q_R[1][i], q_R[2][i], q_R[3][i]};
+    if (qL.h > tiny_h) {
+      CeedScalar flux[ndof_total], amax;
+      SedimentRiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], ndof_sediment, flux, &amax);
+      for (CeedInt j = 0; j < ndof_total; j++) {
+        cell_L[j][i]     = flux[j] * geom[2][i];
+        accum_flux[j][i] = flux[j];
+      }
+      courant_num[0][i] = -amax * geom[2][i] * dt;
+    }
+  }
+  return 0;
+}
+
+// SWE boundary flux operator Q-function (reflecting condition)
+CEED_QFUNCTION(SedimentBoundaryFlux_Reflecting_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
+  const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
+  CeedScalar(*cell_L)[CEED_Q_VLA]      = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  CeedScalar(*courant_num)[CEED_Q_VLA] = (CeedScalar(*)[CEED_Q_VLA])out[2];
+  const SedimentContext context        = (SedimentContext)ctx;
+
+  const CeedScalar dt      = context->dtime;
+  const CeedScalar tiny_h  = context->tiny_h;
+  const CeedScalar gravity = context->gravity;
+
+  const CeedInt ndof_flow     = 3;
+  const CeedInt ndof_sediment = 1;  // FIXME: Need to be part of 'context'
+  const CeedInt ndof_total    = ndof_flow + ndof_sediment;
+
+  for (CeedInt i = 0; i < Q; i++) {
+    CeedScalar    sn = geom[0][i], cn = geom[1][i];
+    SedimentState qL = {q_L[0][i], q_L[1][i], q_L[2][i], q_L[3][i]};
+    if (qL.h > tiny_h) {
+      CeedScalar    dum1 = sn * sn - cn * cn;
+      CeedScalar    dum2 = 2.0 * sn * cn;
+      SedimentState qR   = {qL.h, qL.hu * dum1 - qL.hv * dum2, -qL.hu * dum2 - qL.hv * dum1, qL.hci};
+      CeedScalar    flux[3], amax;
+      SedimentRiemannFlux_Roe(gravity, tiny_h, qL, qR, sn, cn, ndof_sediment, flux, &amax);
+      for (CeedInt j = 0; j < ndof_total; j++) {
+        cell_L[j][i] = flux[j] * geom[2][i];
+      }
+      courant_num[0][i] = -amax * geom[2][i] * dt;
+    }
+  }
+  return 0;
+}
+
+// SWE regional source operator Q-function
+CEED_QFUNCTION(SedimentSourceTermSemiImplicit)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  const CeedScalar(*geom)[CEED_Q_VLA]       = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // dz/dx, dz/dy
+  const CeedScalar(*swe_src)[CEED_Q_VLA]    = (const CeedScalar(*)[CEED_Q_VLA])in[1];  // external source (e.g. rain rate)
+  const CeedScalar(*mannings_n)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[2];  // mannings coefficient
+  const CeedScalar(*riemannf)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[3];  // riemann flux
+  const CeedScalar(*q)[CEED_Q_VLA]          = (const CeedScalar(*)[CEED_Q_VLA])in[4];
+  CeedScalar(*cell)[CEED_Q_VLA]             = (CeedScalar(*)[CEED_Q_VLA])out[0];
+  const SedimentContext context             = (SedimentContext)ctx;
+
+  const CeedScalar dt                      = context->dtime;
+  const CeedScalar tiny_h                  = context->tiny_h;
+  const CeedScalar gravity                 = context->gravity;
+  const CeedScalar kp_constant             = context->kp_constant;
+  const CeedScalar settling_velocity       = context->settling_velocity;
+  const CeedScalar tau_critical_erosion    = context->tau_critical_erosion;
+  const CeedScalar tau_critical_deposition = context->tau_critical_deposition;
+  const CeedScalar rhow                    = context->rhow;
+
+  for (CeedInt i = 0; i < Q; i++) {
+    SedimentState    state = {q[0][i], q[1][i], q[2][i], q[3][i]};
+    const CeedScalar h     = state.h;
+    const CeedScalar hu    = state.hu;
+    const CeedScalar hv    = state.hv;
+
+    const CeedScalar u = SafeDiv(state.hu, h, tiny_h);
+    const CeedScalar v = SafeDiv(state.hv, h, tiny_h);
+
+    const CeedScalar dz_dx = geom[0][i];
+    const CeedScalar dz_dy = geom[1][i];
+
+    const CeedScalar bedx = dz_dx * gravity * h;
+    const CeedScalar bedy = dz_dy * gravity * h;
+
+    const CeedScalar Fsum_x = riemannf[1][i];
+    const CeedScalar Fsum_y = riemannf[2][i];
+
+    CeedScalar tbx = 0.0, tby = 0.0;
+    if (h > tiny_h) {
+      const CeedScalar Cd = gravity * Square(mannings_n[0][i]) * pow(h, -1.0 / 3.0);
+
+      const CeedScalar velocity = sqrt(Square(u) + Square(v));
+
+      const CeedScalar tb = Cd * velocity / h;
+
+      const CeedScalar factor = tb / (1.0 + dt * tb);
+
+      tbx = (hu + dt * Fsum_x - dt * bedx) * factor;
+      tby = (hv + dt * Fsum_y - dt * bedy) * factor;
+
+      const CeedScalar ci    = SafeDiv(state.hci, h, tiny_h);
+      CeedScalar       tau_b = 0.5 * rhow * Cd * (Square(u) + Square(v));
+      CeedScalar       ei    = kp_constant * (tau_b - tau_critical_erosion) / tau_critical_erosion;
+      CeedScalar       di    = settling_velocity * ci * (1.0 - tau_b / tau_critical_deposition);
+      cell[3][i]             = riemannf[3][i] + (ei - di) + swe_src[3][i];
+    }
+
+    cell[0][i] = riemannf[0][i] + swe_src[0][i];
+    cell[1][i] = riemannf[1][i] - bedx - tbx + swe_src[1][i];
+    cell[2][i] = riemannf[2][i] - bedy - tby + swe_src[2][i];
+  }
+  return 0;
+}
+
+#pragma GCC diagnostic   pop
+#pragma GCC diagnostic   pop
+#pragma clang diagnostic pop
+#pragma clang diagnostic pop
+
+#endif

--- a/src/sediment/sediment_ceed_impl.h
+++ b/src/sediment/sediment_ceed_impl.h
@@ -251,7 +251,7 @@ CEED_QFUNCTION(SedimentBoundaryFlux_Reflecting_Roe)(void *ctx, CeedInt Q, const 
       CeedScalar    dum1 = sn * sn - cn * cn;
       CeedScalar    dum2 = 2.0 * sn * cn;
       SedimentState qR   = {qL.h, qL.hu * dum1 - qL.hv * dum2, -qL.hu * dum2 - qL.hv * dum1, qL.hci};
-      CeedScalar    flux[3], amax;
+      CeedScalar    flux[ndof_total], amax;
       SedimentRiemannFlux_Roe(gravity, tiny_h, qL, qR, sn, cn, ndof_sediment, flux, &amax);
       for (CeedInt j = 0; j < ndof_total; j++) {
         cell_L[j][i] = flux[j] * geom[2][i];


### PR DESCRIPTION
- This PR adds the CEED version of the PETSc solvers for sediment dynamics that were added
in #257.
- Following CEED tests are added:
   -  Two tests the perform forward simulations for sediments, and
   - One MMS convergence test.

Closes #266