### PR TITLE
Adds velocity regularization

### DIFF
--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -440,7 +440,7 @@ physics:
   flow:
     mode: swe
     tiny_h: 1e-7
-    h_anuga_reg_parameter: 1.e-3
+    h_anuga_regular: 1.e-3
     source:
       method: implicit_xq2018
       xq2018_threshold: 1e-10
@@ -461,9 +461,9 @@ parameters in this subsection are:
    not yet supported). This parameter is required and has no default value.
 * `tiny_h`, which is the water height below which a given point is assumed to
   be dry. Default value: `1e-7`
-* `h_anuga_reg_parameter`: is the water height used in velocity regularization using the
+* `h_anuga_regular`: is the water height used in velocity regularization using the
   approach implemented in the ANUGA hydrodynamic model. e.g., the velocity in x-dir from the
-  momentum in x-dir is computed as `u = (hu) * h / (h^2 + h_anuga_reg_parameter)`. The
+  momentum in x-dir is computed as `u = (hu) * h / (h^2 + h_anuga_regular^2)`. The
   default value is `0.0`.
 * `source`: this subsection controls parameters governing how the flow source
   term is integrated in time. Parameters are:

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -440,6 +440,7 @@ physics:
   flow:
     mode: swe
     tiny_h: 1e-7
+    h_anuga_reg_parameter: 1.e-3
     source:
       method: implicit_xq2018
       xq2018_threshold: 1e-10
@@ -460,6 +461,10 @@ parameters in this subsection are:
    not yet supported). This parameter is required and has no default value.
 * `tiny_h`, which is the water height below which a given point is assumed to
   be dry. Default value: `1e-7`
+* `h_anuga_reg_parameter`: is the water height used in velocity regularization using the
+  approach implemented in the ANUGA hydrodynamic model. e.g., the velocity in x-dir from the
+  momentum in x-dir is computed as `u = (hu) * h / (h^2 + h_anuga_reg_parameter)`. The
+  default value is `0.0`.
 * `source`: this subsection controls parameters governing how the flow source
   term is integrated in time. Parameters are:
   * `method`: the method for integrating the flow source term. Options are

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -59,8 +59,9 @@ typedef struct {
 
 // physics flow parameters
 typedef struct {
-  RDyPhysicsFlowMode mode;    // flow mode
-  PetscReal          tiny_h;  // depth below which no flow occurs
+  RDyPhysicsFlowMode mode;             // flow mode
+  PetscReal          tiny_h;           // depth below which no flow occurs
+  PetscReal          h_anuga_regular;  // ANUGA height parameter used for velocity regularization.
   RDyFlowSource      source;
 } RDyPhysicsFlow;
 

--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -6,13 +6,13 @@
 #include <private/rdycoreimpl.h>
 #include <private/rdyoperatorimpl.h>
 
-PETSC_INTERN PetscErrorCode CreateSWECeedInteriorFluxOperator(RDyMesh *, PetscReal, CeedOperator *);
-PETSC_INTERN PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, PetscReal, CeedOperator *);
-PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, RDyFlowSourceMethod, PetscReal, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedInteriorFluxOperator(RDyMesh *, PetscReal, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, PetscReal, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, RDyFlowSourceMethod, PetscReal, PetscReal, PetscReal, CeedOperator *);
 
-PETSC_INTERN PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *, OperatorDiagnostics *, PetscReal, PetscOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *, OperatorDiagnostics *, PetscReal, PetscReal, PetscOperator *);
 PETSC_INTERN PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, Vec, Vec, OperatorDiagnostics *, PetscReal,
-                                                               PetscOperator *);
+                                                               PetscReal, PetscOperator *);
 PETSC_INTERN PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *, Vec, Vec, RDyFlowSourceMethod, PetscReal, PetscReal, PetscOperator *);
 
 #endif

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -35,8 +35,8 @@ CEED_QFUNCTION_HELPER void SWERiemannFlux_Roe(const CeedScalar gravity, const Ce
   const CeedScalar sqrt_gravity = sqrt(gravity);
   const CeedScalar hl = qL.h, hr = qR.h;
 
-  const CeedScalar denom_l = Square(hl) + h_anuga;
-  const CeedScalar denom_r = Square(hr) + h_anuga;
+  const CeedScalar denom_l = Square(hl) + Square(h_anuga);
+  const CeedScalar denom_r = Square(hr) + Square(h_anuga);
 
   const CeedScalar ul = SafeDiv(qL.hu * hl, denom_l, hl, tiny_h), vl = SafeDiv(qL.hv * hl, denom_l, hl, tiny_h);
   const CeedScalar ur = SafeDiv(qR.hu * hr, denom_r, hr, tiny_h), vr = SafeDiv(qR.hv * hr, denom_r, hr, tiny_h);
@@ -274,7 +274,7 @@ CEED_QFUNCTION(SWESourceTermSemiImplicit)(void *ctx, CeedInt Q, const CeedScalar
     const CeedScalar h     = state.h;
     const CeedScalar hu    = state.hu;
     const CeedScalar hv    = state.hv;
-    const CeedScalar denom = Square(h) + h_anuga;
+    const CeedScalar denom = Square(h) + Square(h_anuga);
 
     const CeedScalar u = SafeDiv(state.hu * h, denom, h, tiny_h);
     const CeedScalar v = SafeDiv(state.hv * h, denom, h, tiny_h);

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -85,7 +85,7 @@ static PetscErrorCode ComputeRiemannVelocities(PetscReal tiny_h, PetscReal h_anu
       data->u[n] = 0.0;
       data->v[n] = 0.0;
     } else {
-      denom      = Square(data->h[n]) + h_anuga;
+      denom      = Square(data->h[n]) + Square(h_anuga);
       data->u[n] = data->hu[n] * data->h[n] / denom;
       data->v[n] = data->hv[n] * data->h[n] / denom;
     }

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -76,16 +76,18 @@ static PetscErrorCode DestroyRiemannEdgeData(RiemannEdgeData data) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-static PetscErrorCode ComputeRiemannVelocities(PetscReal tiny_h, RiemannStateData *data) {
+static PetscErrorCode ComputeRiemannVelocities(PetscReal tiny_h, PetscReal h_anuga, RiemannStateData *data) {
   PetscFunctionBeginUser;
+  PetscReal denom;
 
   for (PetscInt n = 0; n < data->num_states; n++) {
     if (data->h[n] < tiny_h) {
       data->u[n] = 0.0;
       data->v[n] = 0.0;
     } else {
-      data->u[n] = data->hu[n] / data->h[n];
-      data->v[n] = data->hv[n] / data->h[n];
+      denom      = Square(data->h[n]) + h_anuga;
+      data->u[n] = data->hu[n] * data->h[n] / denom;
+      data->v[n] = data->hv[n] * data->h[n] / denom;
     }
   }
 
@@ -206,12 +208,13 @@ static PetscErrorCode ComputeRoeFlux(RiemannStateData *datal, RiemannStateData *
 //------------------------
 
 typedef struct {
-  RDyMesh             *mesh;          // domain mesh
-  PetscReal            tiny_h;        // minimum water height for wet conditions
-  RiemannStateData     left_states;   // "left" riemann states on interior edges
-  RiemannStateData     right_states;  // "right" riemann states on interior edges
-  RiemannEdgeData      edges;         // riemann fluxes on interior edges
-  OperatorDiagnostics *diagnostics;   // courant number, etc
+  RDyMesh             *mesh;             // domain mesh
+  PetscReal            tiny_h;           // minimum water height for wet conditions
+  PetscReal            h_anuga_regular;  // ANUGA height parameter used in velocity regularization
+  RiemannStateData     left_states;      // "left" riemann states on interior edges
+  RiemannStateData     right_states;     // "right" riemann states on interior edges
+  RiemannEdgeData      edges;            // riemann fluxes on interior edges
+  OperatorDiagnostics *diagnostics;      // courant number, etc
 } InteriorFluxOperator;
 
 static PetscErrorCode ApplyInteriorFlux(void *context, PetscOperatorFields fields, PetscReal dt, Vec u_local, Vec f_global) {
@@ -260,9 +263,10 @@ static PetscErrorCode ApplyInteriorFlux(void *context, PetscOperatorFields field
     }
   }
 
-  const PetscReal tiny_h = interior_flux_op->tiny_h;
-  PetscCall(ComputeRiemannVelocities(tiny_h, datal));
-  PetscCall(ComputeRiemannVelocities(tiny_h, datar));
+  const PetscReal tiny_h  = interior_flux_op->tiny_h;
+  const PetscReal h_anuga = interior_flux_op->h_anuga_regular;
+  PetscCall(ComputeRiemannVelocities(tiny_h, h_anuga, datal));
+  PetscCall(ComputeRiemannVelocities(tiny_h, h_anuga, datar));
 
   // call Riemann solver (only Roe currently supported)
   PetscCall(ComputeRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
@@ -330,7 +334,8 @@ static PetscErrorCode DestroyInteriorFlux(void *context) {
 /// @param [inout] diagnostics a set of diagnostics that can be updated by the PetscOperator
 /// @param [in]    tiny_h      the water height below which dry conditions are assumed
 /// @param [out]   petsc_op    the newly created PetscOperator
-PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *mesh, OperatorDiagnostics *diagnostics, PetscReal tiny_h, PetscOperator *petsc_op) {
+PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *mesh, OperatorDiagnostics *diagnostics, PetscReal tiny_h, PetscReal h_anuga_regular,
+                                                  PetscOperator *petsc_op) {
   PetscFunctionBegin;
 
   const PetscInt num_comp = 3;
@@ -338,9 +343,10 @@ PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *mesh, OperatorDiagnos
   InteriorFluxOperator *interior_flux_op;
   PetscCall(PetscCalloc1(1, &interior_flux_op));
   *interior_flux_op = (InteriorFluxOperator){
-      .mesh        = mesh,
-      .diagnostics = diagnostics,
-      .tiny_h      = tiny_h,
+      .mesh            = mesh,
+      .diagnostics     = diagnostics,
+      .tiny_h          = tiny_h,
+      .h_anuga_regular = h_anuga_regular,
   };
 
   // allocate left/right/edge Riemann data structures
@@ -377,6 +383,7 @@ typedef struct {
   Vec                  boundary_fluxes;     // boundary flux values vector
   OperatorDiagnostics *diagnostics;         // courant number, boundary fluxes
   PetscReal            tiny_h;              // minimum water height for wet conditions
+  PetscReal            h_anuga_regular;     // ANUGA height parameter used in velocity regularization
   RiemannStateData     left_states;
   RiemannStateData     right_states;
   RiemannEdgeData      edges;
@@ -478,8 +485,10 @@ static PetscErrorCode ApplyBoundaryFlux(void *context, PetscOperatorFields field
   RiemannEdgeData  *data_edge = &boundary_flux_op->edges;
 
   // copy the "left cell" values into the "left states"
-  const PetscReal tiny_h = boundary_flux_op->tiny_h;
-  RDyEdges       *edges  = &boundary_flux_op->mesh->edges;
+  const PetscReal tiny_h  = boundary_flux_op->tiny_h;
+  const PetscReal h_anuga = boundary_flux_op->h_anuga_regular;
+
+  RDyEdges *edges = &boundary_flux_op->mesh->edges;
   for (PetscInt e = 0; e < boundary.num_edges; ++e) {
     PetscInt edge_id            = boundary.edge_ids[e];
     PetscInt left_local_cell_id = edges->cell_ids[2 * edge_id];
@@ -487,7 +496,7 @@ static PetscErrorCode ApplyBoundaryFlux(void *context, PetscOperatorFields field
     datal->hu[e]                = u_ptr[n_dof * left_local_cell_id + 1];
     datal->hv[e]                = u_ptr[n_dof * left_local_cell_id + 2];
   }
-  PetscCall(ComputeRiemannVelocities(tiny_h, datal));
+  PetscCall(ComputeRiemannVelocities(tiny_h, h_anuga, datal));
 
   // compute the "right" Riemann cell values using the boundary condition
   switch (boundary_condition.flow->type) {
@@ -498,7 +507,7 @@ static PetscErrorCode ApplyBoundaryFlux(void *context, PetscOperatorFields field
         datar->hu[e] = boundary_values_ptr[n_dof * e + 1];
         datar->hv[e] = boundary_values_ptr[n_dof * e + 2];
       }
-      PetscCall(ComputeRiemannVelocities(tiny_h, datar));
+      PetscCall(ComputeRiemannVelocities(tiny_h, h_anuga, datar));
       break;
     case CONDITION_REFLECTING:
       PetscCall(ApplyReflectingBC(boundary_flux_op->mesh, boundary, datal, datar, data_edge));
@@ -570,7 +579,8 @@ static PetscErrorCode DestroyBoundaryFlux(void *context) {
 /// @param [in]    tiny_h             the water height below which dry conditions are assumed
 /// @param [out]   petsc_op           the newly created PetscOperator
 PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *mesh, RDyBoundary boundary, RDyCondition boundary_condition, Vec boundary_values,
-                                                  Vec boundary_fluxes, OperatorDiagnostics *diagnostics, PetscReal tiny_h, PetscOperator *petsc_op) {
+                                                  Vec boundary_fluxes, OperatorDiagnostics *diagnostics, PetscReal tiny_h, PetscReal h_anuga_regular,
+                                                  PetscOperator *petsc_op) {
   PetscFunctionBegin;
   BoundaryFluxOperator *boundary_flux_op;
   PetscCall(PetscCalloc1(1, &boundary_flux_op));
@@ -582,6 +592,7 @@ PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *mesh, RDyBoundary bou
       .boundary_fluxes    = boundary_fluxes,
       .diagnostics        = diagnostics,
       .tiny_h             = tiny_h,
+      .h_anuga_regular    = h_anuga_regular,
   };
 
   // allocate left/right/edge Riemann data structures

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -40,6 +40,7 @@
 //   flow:
 //     mode: <swe|diffusion> # swe by default
 //     tiny_h: <value> # 1e-7 by default
+//     h_anuga_reg_parameter: <value> # 0.0 by default
 //     source:
 //       method: <semi_implicit|implicit_xq2018> # semi_implicit by default
 //       xq2018_threshold: <value> # 1e-10 by default
@@ -68,6 +69,7 @@ static const cyaml_schema_field_t source_fields_schema[] = {
 static const cyaml_schema_field_t physics_flow_fields_schema[] = {
     CYAML_FIELD_ENUM("mode", CYAML_FLAG_DEFAULT, RDyPhysicsFlow, mode, physics_flow_modes, CYAML_ARRAY_LEN(physics_flow_modes)),
     CYAML_FIELD_FLOAT("tiny_h", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, tiny_h),
+    CYAML_FIELD_FLOAT("h_anuga_reg_parameter", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, h_anuga_regular),
     CYAML_FIELD_MAPPING("source", CYAML_FLAG_OPTIONAL, RDyPhysicsFlow, source, source_fields_schema),
     CYAML_FIELD_END
 };
@@ -780,6 +782,7 @@ static PetscErrorCode SetMissingValues(RDyConfig *config) {
   PetscFunctionBegin;
 
   SET_MISSING_PARAMETER(config->physics.flow.tiny_h, 1e-7);
+  SET_MISSING_PARAMETER(config->physics.flow.h_anuga_regular, 0.0);
   SET_MISSING_PARAMETER(config->physics.flow.source.method, SOURCE_SEMI_IMPLICIT);
   if (config->physics.flow.source.method == SOURCE_IMPLICIT_XQ2018) {
     SET_MISSING_PARAMETER(config->physics.flow.source.xq2018_threshold, 1e-10);


### PR DESCRIPTION
- Introduces a new parameter, `h_anuga_reg_parameter`, in the .yaml file to 
 support the velocity regularization approach used by the ANUGA hydrodynamic model.

- The velocity in x direction is computed as `u = (hu) * h / (h^2 + h_anuga_regular^2)`. 
  The same approach is used for velocity in y direction.

- The default value of `h_anuga_reg_parameter` is `0.0`.