### PR TITLE
Cleans up SWE operator constructors, similar to sediment operators

### DIFF
--- a/include/private/rdysweimpl.h
+++ b/include/private/rdysweimpl.h
@@ -6,13 +6,13 @@
 #include <private/rdycoreimpl.h>
 #include <private/rdyoperatorimpl.h>
 
-PETSC_INTERN PetscErrorCode CreateSWECeedInteriorFluxOperator(RDyMesh *, PetscReal, PetscReal, CeedOperator *);
-PETSC_INTERN PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, PetscReal, PetscReal, CeedOperator *);
-PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, RDyFlowSourceMethod, PetscReal, PetscReal, PetscReal, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedInteriorFluxOperator(RDyMesh *, const RDyConfig, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedBoundaryFluxOperator(RDyMesh *, const RDyConfig, RDyBoundary, RDyCondition, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateSWECeedSourceOperator(RDyMesh *, const RDyConfig, CeedOperator *);
 
-PETSC_INTERN PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *, OperatorDiagnostics *, PetscReal, PetscReal, PetscOperator *);
-PETSC_INTERN PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *, RDyBoundary, RDyCondition, Vec, Vec, OperatorDiagnostics *, PetscReal,
-                                                               PetscReal, PetscOperator *);
-PETSC_INTERN PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *, Vec, Vec, RDyFlowSourceMethod, PetscReal, PetscReal, PetscOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEPetscInteriorFluxOperator(RDyMesh *, const RDyConfig, OperatorDiagnostics *, PetscOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEPetscBoundaryFluxOperator(RDyMesh *, const RDyConfig, RDyBoundary, RDyCondition, Vec, Vec, OperatorDiagnostics *,
+                                                               PetscOperator *);
+PETSC_INTERN PetscErrorCode CreateSWEPetscSourceOperator(RDyMesh *, const RDyConfig, Vec, Vec, PetscOperator *);
 
 #endif


### PR DESCRIPTION
This PR cleans up the SWE operator constructor functions, passing the entire RDyConfig struct, which contains everything one might need to construct an operator. This prevents us from having to keep updating these functions with new parameters every time we add something to the mix. The signatures for these functions were already getting complicated, so this cleans things up a bit.