### PR TITLE
Adding support for trapping floating point exceptions.

### DIFF
--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -154,6 +154,10 @@ struct _p_RDy {
   PetscViewerAndFormat *output_vf;
 };
 
+// floating point exceptions (GNU-specific)
+PETSC_INTERN PetscErrorCode EnableFloatingPointExceptions(void);
+PETSC_INTERN PetscErrorCode DisableFloatingPointExceptions(void);
+
 // these are used by both the main (RDycore) driver and the MMS driver
 PETSC_INTERN PetscErrorCode DetermineConfigPrefix(RDy, char *);
 PETSC_INTERN PetscErrorCode ReadConfigFile(RDy);     // for RDycore driver only!

--- a/src/rdycore.c
+++ b/src/rdycore.c
@@ -7,6 +7,42 @@
 static PetscBool initialized_ = PETSC_FALSE;
 PetscClassId     RDY_CLASSID;
 
+// set up floating point exception trapping on GNU compilers where supported
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+#if !defined(NDEBUG) && defined(__GNUC__)
+
+#define _GNU_SOURCE
+#include <fenv.h>
+
+PetscErrorCode EnableFloatingPointExceptions(void) {
+  PetscFunctionBegin;
+  feenableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+PetscErrorCode DisableFloatingPointExceptions(void) {
+  PetscFunctionBegin;
+  fedisableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+#pragma GCC diagnostic pop
+
+#else  // non-GNU compiler
+
+PetscErrorCode EnableFloatingPointExceptions(void) {
+  PetscFunctionBegin;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+PetscErrorCode DisableFloatingPointExceptions(void) {
+  PetscFunctionBegin;
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+#endif
+
 /// Initializes a process for use by RDycore. Call this at the beginning of
 /// your program.
 PetscErrorCode RDyInit(int argc, char *argv[], const char *help) {
@@ -26,6 +62,10 @@ PetscErrorCode RDyInit(int argc, char *argv[], const char *help) {
 
     // initialize our Courant number diagnostics MPI datatype / operator
     PetscCall(InitCourantNumberDiagnostics());
+
+#ifndef NDEBUG
+    EnableFloatingPointExceptions();
+#endif
 
     initialized_ = PETSC_TRUE;
   }
@@ -54,6 +94,10 @@ PetscErrorCode RDyInitFortran(void) {
 
     // initialize our Courant number diagnostics MPI datatype / operator
     PetscCall(InitCourantNumberDiagnostics());
+
+#ifndef NDEBUG
+    EnableFloatingPointExceptions();
+#endif
 
     initialized_ = PETSC_TRUE;
   }


### PR DESCRIPTION
With these changes, RDycore will trap the most common floating point exceptions in Debug builds using the GNU C compiler. This can help us understand how and where NaNs get generated. I'm using this to unravel the SWE and sediment operators so they can be combined in a way that reduces duplicate code.