### PR TITLE
Fixes for running the Amazon lake problem in parallel

### DIFF
--- a/driver/main.c
+++ b/driver/main.c
@@ -1458,25 +1458,25 @@ PetscErrorCode ApplyRainfallDataset(RDy rdy, PetscReal time, SourceSink *rain_da
     case CONSTANT:
       if (rain_dataset->ndata) {
         PetscCall(SetConstantRainfall(rain_dataset->constant.rate, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 1, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case HOMOGENEOUS:
       if (rain_dataset->ndata) {
         PetscCall(SetHomogeneousData(&rain_dataset->homogeneous, time, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 1, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case RASTER:
       if (rain_dataset->ndata) {
         PetscCall(SetRasterData(&rain_dataset->raster, time, rain_dataset->ndata, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 1, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case UNSTRUCTURED:
       if (rain_dataset->ndata) {
         PetscCall(SetUnstructuredData(&rain_dataset->unstructured, time, rain_dataset->data_for_rdycore));
-        PetscCall(RDySetRegionalWaterSource(rdy, 0, rain_dataset->ndata, rain_dataset->data_for_rdycore));
+        PetscCall(RDySetRegionalWaterSource(rdy, 1, rain_dataset->ndata, rain_dataset->data_for_rdycore));
       }
       break;
     case MULTI_HOMOGENEOUS:

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -444,9 +444,9 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
       }
     }
 
-    PetscCall(RDySetRegionalWaterSource(rdy, 0, N, h_source));
-    PetscCall(RDySetRegionalXMomentumSource(rdy, 0, N, hu_source));
-    PetscCall(RDySetRegionalYMomentumSource(rdy, 0, N, hv_source));
+    PetscCall(RDySetRegionalWaterSource(rdy, 1, N, h_source));
+    PetscCall(RDySetRegionalXMomentumSource(rdy, 1, N, hu_source));
+    PetscCall(RDySetRegionalYMomentumSource(rdy, 1, N, hv_source));
 
     if (rdy->config.physics.sediment.num_classes) {
       PetscReal *ci[MAX_NUM_SEDIMENT_CLASSES], *dcidx[MAX_NUM_SEDIMENT_CLASSES], *dcidy[MAX_NUM_SEDIMENT_CLASSES], *dcidt[MAX_NUM_SEDIMENT_CLASSES];
@@ -491,7 +491,7 @@ PetscErrorCode RDyMMSComputeSourceTerms(RDy rdy, PetscReal time) {
             ++l;
           }
         }
-        PetscCall(RDySetRegionalSedimentSource(rdy, 0, i, N, hci_source));
+        PetscCall(RDySetRegionalSedimentSource(rdy, 1, i, N, hci_source));
       }
 
       for (PetscInt i = 0; i < rdy->num_sediment_classes; ++i) {


### PR DESCRIPTION
This PR includes two fixes:
1. A source term that might be applied to a region that is absent on a given MPI rank
   due to domain decomposition. In this case, we skip the application of the source
   value for the region.
2. After domain decomposition, a rank may have no boundary cells. So, we need
    only apply the code to identify boundary cells is a boundary edge has been identified.