### PR TITLE
CEED Q function reorganization, part 2: refactoring SWE and sediment Q functions

### DIFF
--- a/docs/theory/swe.md
+++ b/docs/theory/swe.md
@@ -272,8 +272,8 @@ where
 
 \begin{eqnarray}
   \hat{h} & = & \sqrt{h_i h_j} \\
-  \hat{u} & = & \frac{ \sqrt{h_i} u_i + \sqrt{h_j} u_j{ \sqrt{h_i} + \sqrt{h_j}} \\
-  \hat{v} & = & \frac{ \sqrt{h_i} v_i + \sqrt{h_j} v_j{ \sqrt{h_i} + \sqrt{h_j}} \\
+  \hat{u} & = & \frac{ \sqrt{h_i} u_i + \sqrt{h_j} u_j}{ \sqrt{h_i} + \sqrt{h_j}} \\
+  \hat{v} & = & \frac{ \sqrt{h_i} v_i + \sqrt{h_j} v_j}{ \sqrt{h_i} + \sqrt{h_j}} \\
   \hat{a} & = & \sqrt{\frac{g}{2} \left( h_i + h_j \right)},
 \end{eqnarray}
 

--- a/src/sediment/sediment_ceed_impl.h
+++ b/src/sediment/sediment_ceed_impl.h
@@ -45,7 +45,7 @@ typedef struct SedimentState_ SedimentState;
 #pragma clang diagnostic ignored "-Wvla"
 
 // flow and sediment flux operator Q-function for interior edges
-CEED_QFUNCTION(SedimentFlux)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
+CEED_QFUNCTION_HELPER int SedimentFlux(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L, weight_R
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   const CeedScalar(*q_R)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[2];
@@ -94,8 +94,8 @@ CEED_QFUNCTION(SedimentFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const i
 }
 
 // flow and sediment flux operator Q-function for boundary edges on which dirichlet condition is applied
-CEED_QFUNCTION(SedimentBoundaryFlux_Dirichlet)
-(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
+CEED_QFUNCTION_HELPER int SedimentBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[],
+                                                         RiemannFluxType flux_type) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   const CeedScalar(*q_R)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[2];  // Dirichlet boundary values
@@ -141,8 +141,8 @@ CEED_QFUNCTION(SedimentBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const C
 }
 
 // flow and sediment flux operator Q-function for boundary edges on which reflecting wall condition is applied
-CEED_QFUNCTION(SedimentBoundaryFlux_Reflecting)
-(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
+CEED_QFUNCTION_HELPER int SedimentBoundaryFlux_Reflecting(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[],
+                                                          RiemannFluxType flux_type) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   CeedScalar(*cell_L)[CEED_Q_VLA]      = (CeedScalar(*)[CEED_Q_VLA])out[0];

--- a/src/sediment/sediment_roe_ceed_impl.h
+++ b/src/sediment/sediment_roe_ceed_impl.h
@@ -1,0 +1,110 @@
+#ifndef SEDIMENT_ROE_CEED_IMPL_H
+#define SEDIMENT_ROE_CEED_IMPL_H
+
+#include "../swe/swe_ceed_impl.h"
+
+// we disable compiler warnings for implicitly-declared math functions known to
+// the JIT compiler
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-function-declaration"
+
+/// computes the flux across an edge using Roe's approximate Riemann solver
+/// for flow and sediment transport
+CEED_QFUNCTION_HELPER void SedimentRiemannFlux_Roe(const CeedScalar gravity, const CeedScalar tiny_h, SedimentState qL, SedimentState qR,
+                                                   CeedScalar sn, CeedScalar cn, CeedInt flow_ndof, CeedInt sed_ndof, CeedScalar flux[],
+                                                   CeedScalar *amax) {
+  const CeedScalar hl = qL.h, hr = qR.h;
+  const CeedScalar ul = SafeDiv(qL.hu, hl, hl, tiny_h);
+  const CeedScalar vl = SafeDiv(qL.hv, hl, hl, tiny_h);
+  CeedScalar       cil[MAX_NUM_SEDIMENT_CLASSES], cir[MAX_NUM_SEDIMENT_CLASSES];
+  for (CeedInt j = 0; j < sed_ndof; ++j) {
+    cil[j] = SafeDiv(qL.hci[j], hl, hl, tiny_h);
+    cir[j] = SafeDiv(qR.hci[j], hr, hl, tiny_h);
+  }
+  const CeedScalar ur = SafeDiv(qR.hu, hr, hr, tiny_h);
+  const CeedScalar vr = SafeDiv(qR.hv, hr, hr, tiny_h);
+
+  // compute the eigenspectrum for the shallow water equations
+  CeedScalar A_swe[3], R_swe[3][3], dW_swe[3], amax_swe;
+  ComputeSWEEigenspectrum_Roe(hl, ul, vl, hr, ur, vr, sn, cn, gravity, A_swe, R_swe, dW_swe, &amax_swe);
+
+  // compute sediment contributions
+  CeedScalar cihat[MAX_NUM_FIELD_COMPONENTS]                       = {0};
+  CeedScalar dch[MAX_NUM_FIELD_COMPONENTS]                         = {0};
+  CeedScalar dW[MAX_NUM_FIELD_COMPONENTS]                          = {0};
+  CeedScalar R[MAX_NUM_FIELD_COMPONENTS][MAX_NUM_FIELD_COMPONENTS] = {0};
+  CeedScalar A[MAX_NUM_FIELD_COMPONENTS]                           = {0};
+  CeedScalar FL[MAX_NUM_FIELD_COMPONENTS]                          = {0};
+  CeedScalar FR[MAX_NUM_FIELD_COMPONENTS]                          = {0};
+
+  CeedScalar duml   = sqrt(hl);
+  CeedScalar dumr   = sqrt(hr);
+  CeedScalar dh     = hr - hl;
+  CeedScalar uperpl = ul * cn + vl * sn;
+  CeedScalar uperpr = ur * cn + vr * sn;
+
+  for (CeedInt j = 0; j < sed_ndof; j++) {
+    cihat[j] = (duml * cil[j] + dumr * cir[j]) / (duml + dumr);
+    dch[j]   = cir[j] * hr - cil[j] * hl;
+  }
+
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      R[i][j] = R_swe[i][j];
+    }
+  }
+  for (CeedInt j = 0; j < sed_ndof; j++) {
+    R[j + 3][0]     = cihat[j];
+    R[j + 3][2]     = cihat[j];
+    R[j + 3][j + 3] = 1.0;
+  }
+
+  A[0] = A_swe[0];
+  A[1] = A_swe[1];
+  A[2] = A_swe[2];
+  for (CeedInt j = 0; j < sed_ndof; j++) {
+    A[j + 3] = A[1];
+  }
+
+  dW[0] = dW_swe[0];
+  dW[1] = dW_swe[1];
+  dW[2] = dW_swe[2];
+  for (CeedInt j = 0; j < sed_ndof; j++) {
+    dW[j + 3] = dch[j] - cihat[j] * dh;
+  }
+
+  // compute interface fluxes
+  FL[0] = uperpl * hl;
+  FL[1] = ul * uperpl * hl + 0.5 * gravity * hl * hl * cn;
+  FL[2] = vl * uperpl * hl + 0.5 * gravity * hl * hl * sn;
+
+  FR[0] = uperpr * hr;
+  FR[1] = ur * uperpr * hr + 0.5 * gravity * hr * hr * cn;
+  FR[2] = vr * uperpr * hr + 0.5 * gravity * hr * hr * sn;
+
+  for (CeedInt j = 0; j < sed_ndof; j++) {
+    FL[j + 3] = hl * uperpl * cil[j];
+    FR[j + 3] = hr * uperpr * cir[j];
+  }
+
+  // flux = 0.5*(FL + FR - matmul(R,matmul(A,dW))
+  CeedInt soln_ncomp = flow_ndof + sed_ndof;
+  for (CeedInt dof1 = 0; dof1 < soln_ncomp; dof1++) {
+    flux[dof1] = 0.5 * (FL[dof1] + FR[dof1]);
+
+    for (CeedInt dof2 = 0; dof2 < soln_ncomp; dof2++) {
+      flux[dof1] = flux[dof1] - 0.5 * R[dof1][dof2] * A[dof2] * dW[dof2];
+    }
+  }
+
+  // max wave speed
+  *amax = amax_swe;
+}
+
+#pragma GCC diagnostic   pop
+#pragma clang diagnostic pop
+
+#endif

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -48,7 +48,7 @@ typedef enum {
 #pragma clang diagnostic ignored "-Wvla"
 
 // SWE interior flux operator Q-function
-CEED_QFUNCTION(SWEFlux)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
+CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L, weight_R
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   const CeedScalar(*q_R)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[2];
@@ -90,7 +90,8 @@ CEED_QFUNCTION(SWEFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], 
 }
 
 // SWE boundary flux operator Q-function (Dirichlet condition)
-CEED_QFUNCTION(SWEBoundaryFlux_Dirichlet)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
+CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[],
+                                                    RiemannFluxType flux_type) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   const CeedScalar(*q_R)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[2];  // Dirichlet boundary values
@@ -129,7 +130,8 @@ CEED_QFUNCTION(SWEBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const CeedSc
 }
 
 // SWE boundary flux operator Q-function (reflecting condition)
-CEED_QFUNCTION(SWEBoundaryFlux_Reflecting)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
+CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Reflecting(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[],
+                                                     RiemannFluxType flux_type) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   CeedScalar(*cell_L)[CEED_Q_VLA]      = (CeedScalar(*)[CEED_Q_VLA])out[0];
@@ -168,7 +170,8 @@ CEED_QFUNCTION(SWEBoundaryFlux_Reflecting_Roe)(void *ctx, CeedInt Q, const CeedS
 }
 
 // SWE boundary flux operator Q-function (outflow condition)
-CEED_QFUNCTION(SWEBoundaryFlux_Outflow)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[], RiemannFluxType flux_type) {
+CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Outflow(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[],
+                                                  RiemannFluxType flux_type) {
   const CeedScalar(*geom)[CEED_Q_VLA]  = (const CeedScalar(*)[CEED_Q_VLA])in[0];  // sn, cn, weight_L
   const CeedScalar(*q_L)[CEED_Q_VLA]   = (const CeedScalar(*)[CEED_Q_VLA])in[1];
   CeedScalar(*cell_L)[CEED_Q_VLA]      = (CeedScalar(*)[CEED_Q_VLA])out[0];

--- a/src/swe/swe_roe_ceed_impl.h
+++ b/src/swe/swe_roe_ceed_impl.h
@@ -1,0 +1,118 @@
+#ifndef SWE_ROE_CEED_IMPL_H
+#define SWE_ROE_CEED_IMPL_H
+
+#include <ceed/types.h>
+
+// disable compiler warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wimplicit-function-declaration"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wimplicit-function-declaration"
+
+// computes eigenvalues lambda, right eigenvectors R, parameter change dW, and
+// the maximum wave speed for the shallow water equations
+CEED_QFUNCTION_HELPER void ComputeSWEEigenspectrum_Roe(const CeedScalar hl, const CeedScalar ul, const CeedScalar vl, const CeedScalar hr,
+                                                       const CeedScalar ur, const CeedScalar vr, CeedScalar sn, CeedScalar cn,
+                                                       const CeedScalar gravity, CeedScalar lambda[3], CeedScalar R[3][3], CeedScalar dW[3],
+                                                       CeedScalar *amax) {
+  const CeedScalar sqrt_gravity = sqrt(gravity);
+
+  CeedScalar duml  = sqrt(hl);
+  CeedScalar dumr  = sqrt(hr);
+  CeedScalar cl    = sqrt_gravity * duml;
+  CeedScalar cr    = sqrt_gravity * dumr;
+  CeedScalar hhat  = duml * dumr;
+  CeedScalar uhat  = (duml * ul + dumr * ur) / (duml + dumr);
+  CeedScalar vhat  = (duml * vl + dumr * vr) / (duml + dumr);
+  CeedScalar chat  = sqrt(0.5 * gravity * (hl + hr));
+  CeedScalar uperp = uhat * cn + vhat * sn;
+
+  CeedScalar dh     = hr - hl;
+  CeedScalar du     = ur - ul;
+  CeedScalar dv     = vr - vl;
+  CeedScalar dupar  = -du * sn + dv * cn;
+  CeedScalar duperp = du * cn + dv * sn;
+
+  // compute right eigenvectors
+  R[0][0] = 1.0;
+  R[0][1] = 0.0;
+  R[0][2] = 1.0;
+  R[1][0] = uhat - chat * cn;
+  R[1][1] = -sn;
+  R[1][2] = uhat + chat * cn;
+  R[2][0] = vhat - chat * sn;
+  R[2][1] = cn;
+  R[2][2] = vhat + chat * sn;
+
+  // compute eigenvalues
+  CeedScalar uperpl = ul * cn + vl * sn;
+  CeedScalar uperpr = ur * cn + vr * sn;
+  CeedScalar a1     = fabs(uperp - chat);
+  CeedScalar a2     = fabs(uperp);
+  CeedScalar a3     = fabs(uperp + chat);
+
+  // apply critical flow fix
+  CeedScalar al1 = uperpl - cl;
+  CeedScalar ar1 = uperpr - cr;
+  CeedScalar da1 = fmax(0.0, 2.0 * (ar1 - al1));
+  if (a1 < da1) {
+    a1 = 0.5 * (a1 * a1 / da1 + da1);
+  }
+  CeedScalar al3 = uperpl + cl;
+  CeedScalar ar3 = uperpr + cr;
+  CeedScalar da3 = fmax(0.0, 2.0 * (ar3 - al3));
+  if (a3 < da3) {
+    a3 = 0.5 * (a3 * a3 / da3 + da3);
+  }
+  lambda[0] = a1;
+  lambda[1] = a2;
+  lambda[2] = a3;
+
+  // compute dW
+  dW[0] = 0.5 * (dh - hhat * duperp / chat);
+  dW[1] = hhat * dupar;
+  dW[2] = 0.5 * (dh + hhat * duperp / chat);
+
+  // max wave speed
+  *amax = chat + fabs(uperp);
+}
+
+// riemann solver -- called by other Q-functions
+CEED_QFUNCTION_HELPER void SWERiemannFlux_Roe(const CeedScalar gravity, const CeedScalar tiny_h, const CeedScalar h_anuga, SWEState qL, SWEState qR,
+                                              CeedScalar sn, CeedScalar cn, CeedScalar flux[], CeedScalar *amax) {
+  const CeedScalar hl = qL.h, hr = qR.h;
+
+  const CeedScalar denom_l = Square(hl) + Square(h_anuga);
+  const CeedScalar denom_r = Square(hr) + Square(h_anuga);
+
+  const CeedScalar ul = SafeDiv(qL.hu * hl, denom_l, hl, tiny_h);
+  const CeedScalar vl = SafeDiv(qL.hv * hl, denom_l, hl, tiny_h);
+  const CeedScalar ur = SafeDiv(qR.hu * hr, denom_r, hr, tiny_h);
+  const CeedScalar vr = SafeDiv(qR.hv * hr, denom_r, hr, tiny_h);
+
+  // compute eigenspectrum
+  CeedScalar A[3], R[3][3], dW[3];
+  ComputeSWEEigenspectrum_Roe(hl, ul, vl, hr, ur, vr, sn, cn, gravity, A, R, dW, amax);
+
+  // compute interface fluxes
+  CeedScalar uperpl = ul * cn + vl * sn;
+  CeedScalar uperpr = ur * cn + vr * sn;
+  CeedScalar FL[3]  = {
+       uperpl * hl,
+       ul * uperpl * hl + 0.5 * gravity * hl * hl * cn,
+       vl * uperpl * hl + 0.5 * gravity * hl * hl * sn,
+  };
+  CeedScalar FR[3] = {
+      uperpr * hr,
+      ur * uperpr * hr + 0.5 * gravity * hr * hr * cn,
+      vr * uperpr * hr + 0.5 * gravity * hr * hr * sn,
+  };
+
+  // fij = 0.5*(FL + FR - matmul(R,matmul(A,dW))
+  flux[0] = 0.5 * (FL[0] + FR[0] - R[0][0] * A[0] * dW[0] - R[0][1] * A[1] * dW[1] - R[0][2] * A[2] * dW[2]);
+  flux[1] = 0.5 * (FL[1] + FR[1] - R[1][0] * A[0] * dW[0] - R[1][1] * A[1] * dW[1] - R[1][2] * A[2] * dW[2]);
+  flux[2] = 0.5 * (FL[2] + FR[2] - R[2][0] * A[0] * dW[0] - R[2][1] * A[1] * dW[1] - R[2][2] * A[2] * dW[2]);
+}
+
+#endif


### PR DESCRIPTION
This PR breaks up our existing Q functions to allow us to reuse certain helper functions, and to isolate Riemann-solver-specific logic to certain files.

After this, I'll do a quick cleanup of the PETSc SWE/sediment operators to give it a similar structure.

Closes #278