### PR TITLE
Reorganized PETSc SWE and sediment operators to resemble reorganized CEED operators.

### DIFF
--- a/src/sediment/sediment_petsc_impl.h
+++ b/src/sediment/sediment_petsc_impl.h
@@ -1,0 +1,28 @@
+#ifndef SEDIMENT_PETSC_IMPL_H
+#define SEDIMENT_PETSC_IMPL_H
+
+#include <petscsys.h>
+
+// GRAVITY is already defined in the PETSc SWE code, which we use
+// static const PetscReal GRAVITY          = 9.806;   // gravitational acceleration [m/s^2]
+static const PetscReal DENSITY_OF_WATER = 1000.0;  // [kg/m^3]
+
+// riemann left and right states
+typedef struct {
+  PetscInt   num_states;         // number of states
+  PetscInt   num_flow_comp;      // number of flow components
+  PetscInt   num_sediment_comp;  // number of sediment components
+  PetscReal *h, *hu, *hv, *hci;  // prognostic variables
+  PetscReal *u, *v, *ci;         // diagnostic variables
+} SedimentRiemannStateData;
+
+typedef struct {
+  PetscInt   num_edges;          // number of edges
+  PetscInt   num_flow_comp;      // number of flow components
+  PetscInt   num_sediment_comp;  // number of sediment components
+  PetscReal *cn, *sn;            // cosine and sine of the angle between edges and y-axis
+  PetscReal *fluxes;             // fluxes through the edge
+  PetscReal *amax;               // courant number on edges
+} SedimentRiemannEdgeData;
+
+#endif  // SEDIMENT_PETSC_IMPL_H

--- a/src/sediment/sediment_roe_petsc_impl.h
+++ b/src/sediment/sediment_roe_petsc_impl.h
@@ -1,0 +1,120 @@
+#ifndef SEDIMENT_ROE_PETSC_IMPL_H
+#define SEDIMENT_ROE_PETSC_IMPL_H
+
+#include <rdycore.h>
+
+#include "../swe/swe_roe_petsc_impl.h"
+#include "sediment_petsc_impl.h"
+
+/// @brief Computes the flux for SWE and sediments across the edge using Roe's approximate Riemann solve
+/// @param [in] *datal A SedimentRiemannStateData for values left of the edges
+/// @param [in] *datar A SedimentRiemannStateData for values right of the edges
+/// @param [in] sn array containing sines of the angles between edges and y-axis
+/// @param [in] cn array containing cosines of the angles between edges and y-axis
+/// @param [out] fij array containing fluxes through edges
+/// @param [out] amax array storing maximum courant number on edges
+/// @return 0 on success, or a non-zero error code on failure
+static PetscErrorCode ComputeSedimentRoeFlux(SedimentRiemannStateData *datal, SedimentRiemannStateData *datar, const PetscReal *sn,
+                                             const PetscReal *cn, PetscReal *fij, PetscReal *amax) {
+  PetscFunctionBeginUser;
+
+  PetscReal *hl  = datal->h;
+  PetscReal *ul  = datal->u;
+  PetscReal *vl  = datal->v;
+  PetscReal *cil = datal->ci;
+
+  PetscReal *hr  = datar->h;
+  PetscReal *ur  = datar->u;
+  PetscReal *vr  = datar->v;
+  PetscReal *cir = datar->ci;
+
+  PetscAssert(datal->num_states == datar->num_states, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ, "Size of data left and right of edges is not the same!");
+
+  PetscInt num_states = datal->num_states;
+  PetscInt flow_ncomp = datal->num_flow_comp;
+  PetscInt sed_ncomp  = datal->num_sediment_comp;
+  PetscInt soln_ncomp = flow_ncomp + sed_ncomp;
+
+  PetscInt ci_index_offset;
+
+  PetscReal cihat[MAX_NUM_FIELD_COMPONENTS]                       = {0};
+  PetscReal dch[MAX_NUM_FIELD_COMPONENTS]                         = {0};
+  PetscReal R[MAX_NUM_FIELD_COMPONENTS][MAX_NUM_FIELD_COMPONENTS] = {0};
+  PetscReal A[MAX_NUM_FIELD_COMPONENTS]                           = {0};
+  PetscReal dW[MAX_NUM_FIELD_COMPONENTS]                          = {0};
+  PetscReal FL[MAX_NUM_FIELD_COMPONENTS]                          = {0};
+  PetscReal FR[MAX_NUM_FIELD_COMPONENTS]                          = {0};
+
+  for (PetscInt i = 0; i < num_states; ++i) {
+    // compute the eigenspectrum for the shallow water equations
+    PetscReal A_swe[3], R_swe[3][3], dW_swe[3], amax_swe;
+    ComputeSWERoeEigenspectrum(hl[i], ul[i], vl[i], hr[i], ur[i], vr[i], sn[i], cn[i], A_swe, R_swe, dW_swe, &amax_swe);
+
+    PetscReal duml   = sqrt(hl[i]);
+    PetscReal dumr   = sqrt(hr[i]);
+    PetscReal dh     = hr[i] - hl[i];
+    PetscReal uperpl = ul[i] * cn[i] + vl[i] * sn[i];
+    PetscReal uperpr = ur[i] * cn[i] + vr[i] * sn[i];
+
+    ci_index_offset = i * sed_ncomp;
+    for (PetscInt j = 0; j < sed_ncomp; j++) {
+      cihat[j] = (duml * cil[ci_index_offset + j] + dumr * cir[ci_index_offset + j]) / (duml + dumr);
+      dch[j]   = cir[ci_index_offset + j] * hr[i] - cil[ci_index_offset + j] * hl[i];
+    }
+
+    for (PetscInt i = 0; i < 3; ++i) {
+      for (PetscInt j = 0; j < 3; ++j) {
+        R[i][j] = R_swe[i][j];
+      }
+    }
+    for (PetscInt j = 0; j < sed_ncomp; j++) {
+      R[j + 3][0]     = cihat[j];
+      R[j + 3][2]     = cihat[j];
+      R[j + 3][j + 3] = 1.0;
+    }
+
+    A[0] = A_swe[0];
+    A[1] = A_swe[1];
+    A[2] = A_swe[2];
+    for (PetscInt j = 0; j < sed_ncomp; j++) {
+      A[j + 3] = A[1];
+    }
+
+    dW[0] = dW_swe[0];
+    dW[1] = dW_swe[1];
+    dW[2] = dW_swe[2];
+    for (PetscInt j = 0; j < sed_ncomp; j++) {
+      dW[j + 3] = dch[j] - cihat[j] * dh;
+    }
+
+    // compute interface fluxes
+    FL[0] = uperpl * hl[i];
+    FL[1] = ul[i] * uperpl * hl[i] + 0.5 * GRAVITY * hl[i] * hl[i] * cn[i];
+    FL[2] = vl[i] * uperpl * hl[i] + 0.5 * GRAVITY * hl[i] * hl[i] * sn[i];
+
+    FR[0] = uperpr * hr[i];
+    FR[1] = ur[i] * uperpr * hr[i] + 0.5 * GRAVITY * hr[i] * hr[i] * cn[i];
+    FR[2] = vr[i] * uperpr * hr[i] + 0.5 * GRAVITY * hr[i] * hr[i] * sn[i];
+
+    ci_index_offset = i * sed_ncomp;
+    for (PetscInt j = 0; j < sed_ncomp; j++) {
+      FL[j + 3] = hl[i] * uperpl * cil[ci_index_offset + j];
+      FR[j + 3] = hr[i] * uperpr * cir[ci_index_offset + j];
+    }
+
+    // fij = 0.5*(FL + FR - matmul(R,matmul(A,dW))
+    for (PetscInt dof1 = 0; dof1 < soln_ncomp; dof1++) {
+      for (PetscInt dof2 = 0; dof2 < soln_ncomp; dof2++) {
+        if (dof2 == 0) {
+          fij[soln_ncomp * i + dof1] = 0.5 * (FL[dof1] + FR[dof1]);
+        }
+        fij[soln_ncomp * i + dof1] = fij[soln_ncomp * i + dof1] - 0.5 * R[dof1][dof2] * A[dof2] * dW[dof2];
+      }
+    }
+
+    amax[i] = amax_swe;
+  }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+#endif

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -340,8 +340,6 @@ CEED_QFUNCTION(SWESourceTermImplicitXQ2018)(void *ctx, CeedInt Q, const CeedScal
 }
 
 #pragma GCC diagnostic   pop
-#pragma GCC diagnostic   pop
-#pragma clang diagnostic pop
 #pragma clang diagnostic pop
 
 #endif

--- a/src/swe/swe_petsc_impl.h
+++ b/src/swe/swe_petsc_impl.h
@@ -1,0 +1,27 @@
+#ifndef SWE_PETSC_IMPL_H
+#define SWE_PETSC_IMPL_H
+
+#include <petscsys.h>
+
+// gravitational acceleration [m/s/s]
+static const PetscReal GRAVITY = 9.806;
+
+//----------------
+// Riemann Solver
+//----------------
+
+// riemann left and right states
+typedef struct {
+  PetscInt   num_states;   // number of states
+  PetscReal *h, *hu, *hv;  // prognostic SWE variables
+  PetscReal *u, *v;        // diagnostic SWE variables
+} RiemannStateData;
+
+typedef struct {
+  PetscInt   num_edges;  // number of edges
+  PetscReal *cn, *sn;    // cosine and sine of the angle between edges and y-axis
+  PetscReal *fluxes;     // fluxes through the edge
+  PetscReal *amax;       // courant number on edges
+} RiemannEdgeData;
+
+#endif  // SWE_PETSC_IMPL_H

--- a/src/swe/swe_roe_petsc_impl.h
+++ b/src/swe/swe_roe_petsc_impl.h
@@ -1,0 +1,127 @@
+#ifndef SWE_ROE_PETSC_IMPL_H
+#define SWE_ROE_PETSC_IMPL_H
+
+#include "swe_petsc_impl.h"
+
+// Computes eigenvalues lambda, right eigenvectors R, parameter change dW, and
+// the maximum wave speed for the shallow water equations
+static PetscErrorCode ComputeSWERoeEigenspectrum(const PetscReal hl, const PetscReal ul, const PetscReal vl, const PetscReal hr, const PetscReal ur,
+                                                 const PetscReal vr, PetscReal sn, PetscReal cn, PetscReal lambda[3], PetscReal R[3][3],
+                                                 PetscReal dW[3], PetscReal *amax) {
+  PetscFunctionBeginUser;
+
+  // compute Roe averages
+  PetscReal duml  = pow(hl, 0.5);
+  PetscReal dumr  = pow(hr, 0.5);
+  PetscReal cl    = pow(GRAVITY * hl, 0.5);
+  PetscReal cr    = pow(GRAVITY * hr, 0.5);
+  PetscReal hhat  = duml * dumr;
+  PetscReal uhat  = (duml * ul + dumr * ur) / (duml + dumr);
+  PetscReal vhat  = (duml * vl + dumr * vr) / (duml + dumr);
+  PetscReal chat  = pow(0.5 * GRAVITY * (hl + hr), 0.5);
+  PetscReal uperp = uhat * cn + vhat * sn;
+
+  PetscReal dh     = hr - hl;
+  PetscReal du     = ur - ul;
+  PetscReal dv     = vr - vl;
+  PetscReal dupar  = -du * sn + dv * cn;
+  PetscReal duperp = du * cn + dv * sn;
+
+  // compute right eigenvectors
+  R[0][0] = 1.0;
+  R[0][1] = 0.0;
+  R[0][2] = 1.0;
+  R[1][0] = uhat - chat * cn;
+  R[1][1] = -sn;
+  R[1][2] = uhat + chat * cn;
+  R[2][0] = vhat - chat * sn;
+  R[2][1] = cn;
+  R[2][2] = vhat + chat * sn;
+
+  // compute eigenvalues
+  PetscReal uperpl = ul * cn + vl * sn;
+  PetscReal uperpr = ur * cn + vr * sn;
+  PetscReal a1     = fabs(uperp - chat);
+  PetscReal a2     = fabs(uperp);
+  PetscReal a3     = fabs(uperp + chat);
+
+  // apply critical flow fix
+  PetscReal al1 = uperpl - cl;
+  PetscReal ar1 = uperpr - cr;
+  PetscReal da1 = fmax(0.0, 2.0 * (ar1 - al1));
+  if (a1 < da1) {
+    a1 = 0.5 * (a1 * a1 / da1 + da1);
+  }
+  PetscReal al3 = uperpl + cl;
+  PetscReal ar3 = uperpr + cr;
+  PetscReal da3 = fmax(0.0, 2.0 * (ar3 - al3));
+  if (a3 < da3) {
+    a3 = 0.5 * (a3 * a3 / da3 + da3);
+  }
+  lambda[0] = a1;
+  lambda[1] = a2;
+  lambda[2] = a3;
+
+  // compute dW
+  dW[0] = 0.5 * (dh - hhat * duperp / chat);
+  dW[1] = hhat * dupar;
+  dW[2] = 0.5 * (dh + hhat * duperp / chat);
+
+  // max wave speed
+  *amax = chat + fabs(uperp);
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Computes flux based on Roe solver
+/// @param [in] *datal A RiemannDataSWE for values left of the edges
+/// @param [in] *datar A RiemannDataSWE for values right of the edges
+/// @param [in] sn array containing sines of the angles between edges and y-axis (length N)
+/// @param [in] cn array containing cosines of the angles between edges and y-axis (length N)
+/// @param [out] fij array containing fluxes through edges (length 3*N)
+/// @param [out] amax array storing maximum courant number on edges (length N)
+/// @return 0 on success, or a non-zero error code on failure
+static PetscErrorCode ComputeSWERoeFlux(RiemannStateData *datal, RiemannStateData *datar, const PetscReal *sn, const PetscReal *cn, PetscReal *fij,
+                                        PetscReal *amax) {
+  PetscFunctionBeginUser;
+
+  PetscReal *hl = datal->h;
+  PetscReal *ul = datal->u;
+  PetscReal *vl = datal->v;
+
+  PetscReal *hr = datar->h;
+  PetscReal *ur = datar->u;
+  PetscReal *vr = datar->v;
+
+  PetscAssert(datal->num_states == datar->num_states, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ, "Size of data left and right of edges is not the same!");
+
+  PetscInt num_states = datal->num_states;
+  for (PetscInt i = 0; i < num_states; ++i) {
+    // compute eigenspectrum
+    PetscReal A[3], R[3][3], dW[3];
+    PetscCall(ComputeSWERoeEigenspectrum(hl[i], ul[i], vl[i], hr[i], ur[i], vr[i], sn[i], cn[i], A, R, dW, amax));
+
+    // compute interface fluxes
+    PetscReal uperpl = ul[i] * cn[i] + vl[i] * sn[i];
+    PetscReal uperpr = ur[i] * cn[i] + vr[i] * sn[i];
+    PetscReal FL[3]  = {
+         uperpl * hl[i],
+         ul[i] * uperpl * hl[i] + 0.5 * GRAVITY * hl[i] * hl[i] * cn[i],
+         vl[i] * uperpl * hl[i] + 0.5 * GRAVITY * hl[i] * hl[i] * sn[i],
+    };
+    PetscReal FR[3] = {
+        uperpr * hr[i],
+        ur[i] * uperpr * hr[i] + 0.5 * GRAVITY * hr[i] * hr[i] * cn[i],
+        vr[i] * uperpr * hr[i] + 0.5 * GRAVITY * hr[i] * hr[i] * sn[i],
+    };
+
+    // fij = 0.5*(FL + FR - matmul(R,matmul(A,dW))
+    fij[3 * i + 0] = 0.5 * (FL[0] + FR[0] - R[0][0] * A[0] * dW[0] - R[0][1] * A[1] * dW[1] - R[0][2] * A[2] * dW[2]);
+    fij[3 * i + 1] = 0.5 * (FL[1] + FR[1] - R[1][0] * A[0] * dW[0] - R[1][1] * A[1] * dW[1] - R[1][2] * A[2] * dW[2]);
+    fij[3 * i + 2] = 0.5 * (FL[2] + FR[2] - R[2][0] * A[0] * dW[0] - R[2][1] * A[1] * dW[1] - R[2][2] * A[2] * dW[2]);
+  }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+#endif  // SWE_ROE_PETSC_IMPL_H

--- a/src/swe/swe_roe_petsc_impl.h
+++ b/src/swe/swe_roe_petsc_impl.h
@@ -3,6 +3,13 @@
 
 #include "swe_petsc_impl.h"
 
+// silence unused function warnings
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+
 // Computes eigenvalues lambda, right eigenvectors R, parameter change dW, and
 // the maximum wave speed for the shallow water equations
 static PetscErrorCode ComputeSWERoeEigenspectrum(const PetscReal hl, const PetscReal ul, const PetscReal vl, const PetscReal hr, const PetscReal ur,
@@ -124,4 +131,6 @@ static PetscErrorCode ComputeSWERoeFlux(RiemannStateData *datal, RiemannStateDat
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+#pragma GCC diagnostic   pop
+#pragma clang diagnostic pop
 #endif  // SWE_ROE_PETSC_IMPL_H


### PR DESCRIPTION
With this PR, we now have a completely reorganized set of SWE and sediment operators, with separate files for different Riemann solvers. My next task is to document our redesigned operators to make it easier for the team to work with them.

This PR is in line behind #282 .