### PR TITLE
Adopt Jed's suggestion for avoiding C99/C++20 features in headers.

### DIFF
--- a/src/sediment/sediment_ceed_impl.h
+++ b/src/sediment/sediment_ceed_impl.h
@@ -64,8 +64,8 @@ CEED_QFUNCTION_HELPER int SedimentFlux(void *ctx, CeedInt Q, const CeedScalar *c
   const CeedInt tot_ndof  = flow_ndof + sed_ndof;
 
   for (CeedInt i = 0; i < Q; i++) {
-    SedimentState qL = {.h = q_L[0][i], .hu = q_L[1][i], .hv = q_L[2][i]};
-    SedimentState qR = {.h = q_R[0][i], .hu = q_R[1][i], .hv = q_R[2][i]};
+    SedimentState qL = {q_L[0][i], q_L[1][i], q_L[2][i]};
+    SedimentState qR = {q_R[0][i], q_R[1][i], q_R[2][i]};
     for (CeedInt j = 0; j < sed_ndof; ++j) {
       qL.hci[j] = q_L[flow_ndof + j][i];
       qR.hci[j] = q_R[3 + j][i];
@@ -113,8 +113,8 @@ CEED_QFUNCTION_HELPER int SedimentBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, c
   const CeedInt tot_ndof  = flow_ndof + ѕed_ndof;
 
   for (CeedInt i = 0; i < Q; i++) {
-    SedimentState qL = {.h = q_L[0][i], .hu = q_L[1][i], .hv = q_L[2][i]};
-    SedimentState qR = {.h = q_R[0][i], .hu = q_R[1][i], .hv = q_R[2][i]};
+    SedimentState qL = {q_L[0][i], q_L[1][i], q_L[2][i]};
+    SedimentState qR = {q_R[0][i], q_R[1][i], q_R[2][i]};
     for (CeedInt j = 0; j < ѕed_ndof; ++j) {
       qL.hci[j] = q_L[3 + j][i];
       qR.hci[j] = q_R[3 + j][i];
@@ -159,7 +159,7 @@ CEED_QFUNCTION_HELPER int SedimentBoundaryFlux_Reflecting(void *ctx, CeedInt Q, 
 
   for (CeedInt i = 0; i < Q; i++) {
     CeedScalar    sn = geom[0][i], cn = geom[1][i];
-    SedimentState qL = {.h = q_L[0][i], .hu = q_L[1][i], .hv = q_L[2][i]};
+    SedimentState qL = {q_L[0][i], q_L[1][i], q_L[2][i]};
     for (CeedInt j = 0; j < sed_ndof; ++j) {
       qL.hci[j] = q_L[3 + j][i];
     }
@@ -213,7 +213,7 @@ CEED_QFUNCTION(SedimentSourceTermSemiImplicit)(void *ctx, CeedInt Q, const CeedS
   const CeedScalar rhow                    = context->rhow;
 
   for (CeedInt i = 0; i < Q; i++) {
-    SedimentState state = {.h = q[0][i], .hu = q[1][i], .hv = q[2][i]};
+    SedimentState state = {q[0][i], q[1][i], q[2][i]};
     for (CeedInt j = 0; j < context->sed_ndof; ++j) {
       state.hci[j] = q[3 + j][i];
     }

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -64,8 +64,8 @@ CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const 
   const CeedScalar gravity = context->gravity;
 
   for (CeedInt i = 0; i < Q; i++) {
-    SWEState   qL = {.h = q_L[0][i], .hu = q_L[1][i], .hv = q_L[2][i]};
-    SWEState   qR = {.h = q_R[0][i], .hu = q_R[1][i], .hv = q_R[2][i]};
+    SWEState   qL = {q_L[0][i], q_L[1][i], q_L[2][i]};
+    SWEState   qR = {q_R[0][i], q_R[1][i], q_R[2][i]};
     CeedScalar flux[3], amax;
     if (qL.h > tiny_h || qR.h > tiny_h) {
       switch (flux_type) {
@@ -106,8 +106,8 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, const 
   const CeedScalar gravity = context->gravity;
 
   for (CeedInt i = 0; i < Q; i++) {
-    SWEState qL = {.h = q_L[0][i], .hu = q_L[1][i], .hv = q_L[2][i]};
-    SWEState qR = {.h = q_R[0][i], .hu = q_R[1][i], .hv = q_R[2][i]};
+    SWEState qL = {q_L[0][i], q_L[1][i], q_L[2][i]};
+    SWEState qR = {q_R[0][i], q_R[1][i], q_R[2][i]};
     if (qL.h > tiny_h) {
       CeedScalar flux[3], amax;
       switch (flux_type) {
@@ -145,7 +145,7 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Reflecting(void *ctx, CeedInt Q, const
 
   for (CeedInt i = 0; i < Q; i++) {
     CeedScalar sn = geom[0][i], cn = geom[1][i];
-    SWEState   qL = {.h = q_L[0][i], .hu = q_L[1][i], .hv = q_L[2][i]};
+    SWEState   qL = {q_L[0][i], q_L[1][i], q_L[2][i]};
     if (qL.h > tiny_h) {
       CeedScalar dum1 = sn * sn - cn * cn;
       CeedScalar dum2 = 2.0 * sn * cn;
@@ -186,7 +186,7 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Outflow(void *ctx, CeedInt Q, const Ce
 
   for (CeedInt i = 0; i < Q; i++) {
     CeedScalar sn = geom[0][i], cn = geom[1][i];
-    SWEState   qL    = {.h = q_L[0][i], .hu = q_L[1][i], .hv = q_L[2][i]};
+    SWEState   qL    = {q_L[0][i], q_L[1][i], q_L[2][i]};
     CeedScalar q     = fabs(qL.hu * cn + qL.hv * sn);
     CeedScalar hR    = pow(q * q / gravity, 1.0 / 3.0);
     CeedScalar speed = sqrt(gravity * hR);
@@ -228,7 +228,7 @@ CEED_QFUNCTION(SWESourceTermSemiImplicit)(void *ctx, CeedInt Q, const CeedScalar
   const CeedScalar gravity = context->gravity;
 
   for (CeedInt i = 0; i < Q; i++) {
-    SWEState         state = {.h = q[0][i], .hu = q[1][i], .hv = q[2][i]};
+    SWEState         state = {q[0][i], q[1][i], q[2][i]};
     const CeedScalar h     = state.h;
     const CeedScalar hu    = state.hu;
     const CeedScalar hv    = state.hv;
@@ -287,7 +287,7 @@ CEED_QFUNCTION(SWESourceTermImplicitXQ2018)(void *ctx, CeedInt Q, const CeedScal
   const CeedScalar xq2018_threshold = context->xq2018_threshold;
 
   for (CeedInt i = 0; i < Q; i++) {
-    SWEState         state = {.h = q[0][i], .hu = q[1][i], .hv = q[2][i]};
+    SWEState         state = {q[0][i], q[1][i], q[2][i]};
     const CeedScalar h     = state.h;
     const CeedScalar hu    = state.hu;
     const CeedScalar hv    = state.hv;


### PR DESCRIPTION
Specifically, we're removing designated initializers. This is important for running on machines with (C++) CUDA backends, for example.