### PR TITLE
Fixes mesh output

### DIFF
--- a/src/rdymesh.c
+++ b/src/rdymesh.c
@@ -1019,7 +1019,7 @@ static PetscErrorCode CreateCellConnectionVector(DM dm, RDyMesh *mesh) {
   PetscCheck(n == mesh->num_owned_cells * max_num_vertices, PETSC_COMM_SELF, PETSC_ERR_ARG_WRONG,
              "Vector local size %" PetscInt_FMT " != %" PetscInt_FMT " * %" PetscInt_FMT "\n", n, mesh->num_owned_cells, max_num_vertices);
   PetscCall(VecSet(global_vec, -1));
-  PetscCall(VecGetArrayWrite(global_vec, &vec_ptr));
+  PetscCall(VecGetArray(global_vec, &vec_ptr));
 
   RDyCells    *cells    = &mesh->cells;
   RDyVertices *vertices = &mesh->vertices;
@@ -1033,7 +1033,7 @@ static PetscErrorCode CreateCellConnectionVector(DM dm, RDyMesh *mesh) {
     }
   }
 
-  PetscCall(VecRestoreArrayWrite(global_vec, &vec_ptr));
+  PetscCall(VecRestoreArray(global_vec, &vec_ptr));
 
   PetscCall(DMPlexGlobalToNaturalBegin(local_dm, global_vec, natural_vec));
   PetscCall(DMPlexGlobalToNaturalEnd(local_dm, global_vec, natural_vec));


### PR DESCRIPTION
Uses `VecGetArray` instead of `VecGetArrayWrite` to fix the output of the mesh
when running on GPUs.

Fixes #292
