### PR TITLE
Adding some workarounds for Fortran-related difficulties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 3.14.0)
 
 # Configurable options
 option(ENABLE_DRIVER   "Enable stand-alone RDycore driver program(s)" ON)
+option(ENABLE_FORTRAN  "Enable Fortran library bindings" ON)
 option(ENABLE_TESTS    "Enable unit and driver tests" ON)
 option(ENABLE_COVERAGE "Enable code coverage instrumentation" OFF)
 option(ENABLE_SANITIZERS "Enable available sanitizers (ASan, MSan, UBSan)" OFF)
@@ -26,7 +27,9 @@ set(CLANG_FORMAT_VERSION 14)
 
 project(rdycore)
 enable_language(C)
-enable_language(Fortran)
+if (ENABLE_FORTRAN)
+  enable_language(Fortran)
+endif()
 
 # Make sure PETSc can be found with pkgconfig
 set(PETSC_DIR $ENV{PETSC_DIR})
@@ -38,7 +41,6 @@ find_package(PkgConfig REQUIRED)
 # PETSc
 pkg_check_modules(PETSc REQUIRED IMPORTED_TARGET PETSc)
 pkg_get_variable(PETSc_C_COMPILER PETSc ccompiler)
-pkg_get_variable(PETSc_Fortran_COMPILER PETSc fcompiler)
 include_directories(${PETSc_INCLUDE_DIRS})
 link_directories(${PETSc_LIBRARY_DIRS})
 list(APPEND CMAKE_BUILD_RPATH ${PETSC_DIR}/${PETSC_ARCH}/lib)
@@ -113,25 +115,28 @@ if (ENABLE_SANITIZERS)
 endif()
 
 # Fortran settings
-include(CheckFortranCompilerFlag)
-set(CMAKE_Fortran_COMPILER ${PETSc_Fortran_COMPILER})
-if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-  list(APPEND fflags "-fallow-argument-mismatch")
-  list(APPEND fflags "-Wno-allow-argument-mismatch")
-  list(APPEND fflags "-ffree-line-length-none")
-  foreach(fflag ${fflags})
-    check_fortran_compiler_flag(${fflag} result)
-    if (result)
-      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${fflag}")
-    endif()
-  endforeach()
+if (ENABLE_FORTRAN)
+  pkg_get_variable(PETSc_Fortran_COMPILER PETSc fcompiler)
+  include(CheckFortranCompilerFlag)
+  set(CMAKE_Fortran_COMPILER ${PETSc_Fortran_COMPILER})
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    list(APPEND fflags "-fallow-argument-mismatch")
+    list(APPEND fflags "-Wno-allow-argument-mismatch")
+    list(APPEND fflags "-ffree-line-length-none")
+    foreach(fflag ${fflags})
+      check_fortran_compiler_flag(${fflag} result)
+      if (result)
+        set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${fflag}")
+      endif()
+    endforeach()
 
-  # make sure libgfortran appears in our rpath
-  execute_process(COMMAND ${CMAKE_Fortran_COMPILER} -print-file-name=libgfortran${CMAKE_SHARED_LIBRARY_SUFFIX}
-                  OUTPUT_VARIABLE gfortran_library_location)
-  get_filename_component(gfortran_library_dir ${gfortran_library_location} DIRECTORY)
-  list(APPEND CMAKE_BUILD_RPATH ${gfortran_library_dir})
-  list(APPEND CMAKE_INSTALL_RPATH ${gfortran_library_dir})
+    # make sure libgfortran appears in our rpath
+    execute_process(COMMAND ${CMAKE_Fortran_COMPILER} -print-file-name=libgfortran${CMAKE_SHARED_LIBRARY_SUFFIX}
+                    OUTPUT_VARIABLE gfortran_library_location)
+    get_filename_component(gfortran_library_dir ${gfortran_library_location} DIRECTORY)
+    list(APPEND CMAKE_BUILD_RPATH ${gfortran_library_dir})
+    list(APPEND CMAKE_INSTALL_RPATH ${gfortran_library_dir})
+  endif()
 endif()
 
 # By default, we build a Debug configuration.
@@ -143,7 +148,9 @@ endif()
 message(STATUS "Configuring RDycore (${CMAKE_BUILD_TYPE})")
 message(STATUS "Generating project files in build directory: ${PROJECT_BINARY_DIR}")
 message(STATUS "C compiler is ${CMAKE_C_COMPILER} (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION})")
-message(STATUS "Fortran compiler is ${CMAKE_Fortran_COMPILER} (${CMAKE_Fortran_COMPILER_ID} ${CMAKE_Fortran_COMPILER_VERSION})")
+if (ENABLE_FORTRAN)
+  message(STATUS "Fortran compiler is ${CMAKE_Fortran_COMPILER} (${CMAKE_Fortran_COMPILER_ID} ${CMAKE_Fortran_COMPILER_VERSION})")
+endif()
 
 # Version numbers (written to private/config.h).
 set(RDYCORE_MAJOR_VERSION 0)
@@ -199,7 +206,9 @@ if (ENABLE_COVERAGE)
 
   # Add code coverage compiler flags
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} --coverage")
+  if (ENABLE_FORTRAN)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} --coverage")
+  endif()
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
 
   # Add a "make coverage" target.

--- a/docs/common/installation.md
+++ b/docs/common/installation.md
@@ -111,6 +111,9 @@ Step 3 above. Here are the options supported by RDycore:
 * **`CMAKE_VERBOSE_MAKEFILE=ON|OFF`**: if `ON`, displays compiler and linker
   output while building. Otherwise displays only the file being built.
 * **`ENABLE_COVERAGE=ON|OFF`**: if `ON`, enables code coverage instrumentation.
+* **`ENABLE_FORTRAN=ON|OFF`**: if `ON`, enables Fortran 90 bindings. This is `ON`
+  by default, but can be used to work around situations in which Fortran compilers
+  are causing issues.
 
 Since RDycore gets most of its configuration information from PETSc, we don't
 need to use most other CMake options.

--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -18,25 +18,22 @@ install(
 )
 
 # Fortran driver
-add_executable(rdycore_f90_exe
-  main.F90
-)
-set_target_properties(rdycore_f90_exe PROPERTIES OUTPUT_NAME rdycore_f90)
-target_include_directories(rdycore_f90_exe PRIVATE ${PROJECT_BINARY_DIR}/src/f90-mod)
-target_link_libraries(rdycore_f90_exe PRIVATE rdycore_f90)
+if (ENABLE_FORTRAN)
+  add_executable(rdycore_f90_exe main.F90)
+  set_target_properties(rdycore_f90_exe PROPERTIES OUTPUT_NAME rdycore_f90)
+  target_include_directories(rdycore_f90_exe PRIVATE ${PROJECT_BINARY_DIR}/src/f90-mod)
+  target_link_libraries(rdycore_f90_exe PRIVATE rdycore_f90)
 
-# MMS Fortran driver
-add_executable(rdycore_mms_f90
-  mms.F90
-)
-set_target_properties(rdycore_mms_f90 PROPERTIES OUTPUT_NAME rdycore_mms_f90)
-target_include_directories(rdycore_mms_f90 PRIVATE ${PROJECT_BINARY_DIR}/src/f90-mod)
-target_link_libraries(rdycore_mms_f90 PRIVATE rdycore_f90)
+  add_executable(rdycore_mms_f90 mms.F90)
+  set_target_properties(rdycore_mms_f90 PROPERTIES OUTPUT_NAME rdycore_mms_f90)
+  target_include_directories(rdycore_mms_f90 PRIVATE ${PROJECT_BINARY_DIR}/src/f90-mod)
+  target_link_libraries(rdycore_mms_f90 PRIVATE rdycore_f90)
 
-install(
-  TARGETS rdycore_mms_f90 rdycore_f90_exe
-  DESTINATION bin
-)
+  install(
+    TARGETS rdycore_mms_f90 rdycore_f90_exe
+    DESTINATION bin
+  )
+endif()
 
 # Tests for the driver.
 if (ENABLE_TESTS)

--- a/driver/tests/CMakeLists.txt
+++ b/driver/tests/CMakeLists.txt
@@ -3,12 +3,16 @@
 # location of built driver executables
 set(rdycore_driver ${CMAKE_CURRENT_BINARY_DIR}/../rdycore)
 set(mms_driver ${CMAKE_CURRENT_BINARY_DIR}/../rdycore_mms)
-
-set(rdycore_f90_driver ${CMAKE_CURRENT_BINARY_DIR}/../rdycore_f90)
-set(mms_f90_driver ${CMAKE_CURRENT_BINARY_DIR}/../rdycore_mms_f90)
-
 add_test(c_driver_usage ${MPIEXEC} ${MPIEXEC_OPTIONS} -n 1 ${rdycore_driver})
-add_test(f90_driver_usage ${MPIEXEC} ${MPIEXEC_OPTIONS} -n 1 ${rdycore_f90_driver})
+set(supported_languages c)
+
+if (ENABLE_FORTRAN)
+  set(rdycore_f90_driver ${CMAKE_CURRENT_BINARY_DIR}/../rdycore_f90)
+  set(mms_f90_driver ${CMAKE_CURRENT_BINARY_DIR}/../rdycore_mms_f90)
+  add_test(f90_driver_usage ${MPIEXEC} ${MPIEXEC_OPTIONS} -n 1 ${rdycore_f90_driver})
+
+  list(APPEND supported_languages f90)
+endif()
 
 # shallow water equations with roe riemann solver
 add_subdirectory(swe_roe)

--- a/driver/tests/sediment/CMakeLists.txt
+++ b/driver/tests/sediment/CMakeLists.txt
@@ -7,14 +7,13 @@ set(mms_c_driver ${mms_driver})
 set(ceed_args -ceed /cpu/self)
 set(preload_args -preload)
 
-# mms driver (C and Fortran)
 file(COPY
      ${CMAKE_CURRENT_SOURCE_DIR}/sediment_mms_conv_study.yaml
      ${MESH_DIR}/mms_triangles_dx1.exo
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 2) # test on 1, 2 processes
   foreach(config basic ceed)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(sediment_mms_conv_study_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${mms_${lang}_driver} sediment_mms_conv_study.yaml ${${config}_args})
     endforeach()
   endforeach()
@@ -28,7 +27,7 @@ file(COPY
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 2) # test on 1, 2 processes
   foreach(config basic ceed)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(sediment_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} sediment.yaml ${${config}_args})
     endforeach()
   endforeach()

--- a/driver/tests/swe_roe/CMakeLists.txt
+++ b/driver/tests/swe_roe/CMakeLists.txt
@@ -16,7 +16,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ex2b.yaml ${MESH_DIR}/planar_dam_10x5.msh
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1 2) # test on 1, 2 processes
   foreach(config basic ceed preload)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       foreach(chkpt_fmt binary hdf5)
         add_test(swe_roe_ex2b_${lang}_chkpt_${chkpt_fmt}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} ex2b.yaml ${${config}_args} -checkpoint_format ${chkpt_fmt})
       endforeach()
@@ -29,7 +29,7 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ex2b_dirichlet_bc.yaml ${MESH_DIR}/planar_
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1 2) # test on 1, 2 processes
   foreach(config basic ceed)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(swe_roe_ex2b_dirichlet_bc_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} ex2b_dirichlet_bc.yaml ${${config}_args})
     endforeach()
   endforeach()
@@ -40,7 +40,7 @@ endforeach()
 foreach(np 1 2) # test on 1, 2 processes
   set(cgns_output_args -ts_monitor_solution cgns:output/ex2b-%d.cgns -viewer_cgns_batch_size 20 -ts_monitor_solution_interval 100)
   foreach(config basic ceed preload)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(swe_roe_ex2b_cgns_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} ex2b.yaml ${cgns_output_args} ${${config}_args})
     endforeach()
   endforeach()
@@ -49,7 +49,7 @@ endforeach()
 # Checkpoint/restart tests
 foreach(np 1 2) # test on 1, 2 processes
   foreach(config basic ceed preload)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       foreach(chkpt_fmt binary hdf5)
         if (chkpt_fmt STREQUAL "binary")
           set(chkpt_sfx "bin")
@@ -84,7 +84,7 @@ file(COPY
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1 2) # test on 1, 2 processes
   foreach(config basic ceed preload)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(swe_roe_ex2b_ic_file_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} ex2b_ic_file.yaml ${${config}_args})
     endforeach()
   endforeach()
@@ -93,7 +93,7 @@ endforeach()
 # ex2b ensemble test
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ex2b-ensemble.yaml
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
-foreach(lang c f90)
+foreach(lang ${supported_languages})
   foreach(config basic ceed preload)
     add_test(swe_ensemble_${lang}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n 2 ${rdycore_${lang}_driver} ex2b-ensemble.yaml ${${config}_args})
   endforeach()
@@ -108,7 +108,7 @@ file (COPY
       DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1 2)
   foreach(config basic ceed preload)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(swe_roe_four_mounds_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} four_mounds_60x24.yaml ${${config}_args})
     endforeach()
   endforeach()
@@ -166,7 +166,7 @@ file(COPY
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1 2) # test on 1, 2 processes
   foreach(config basic ceed)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(swe_mms_single_run_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${mms_${lang}_driver} mms_single_run.yaml ${${config}_args})
       add_test(swe_mms_conv_study_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${mms_${lang}_driver} mms_conv_study.yaml ${${config}_args})
     endforeach()
@@ -182,7 +182,7 @@ file(COPY
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1 2) # test on 1 processes
   foreach(config basic ceed preload)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(swe_roe_mixed_elements_ic_file_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} mixed_elements_ic_file.yaml ${${config}_args})
     endforeach()
   endforeach()
@@ -219,7 +219,7 @@ file(COPY
      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 foreach(np 1) # test on 1 processes
   foreach(config basic ceed preload)
-    foreach(lang c f90)
+    foreach(lang ${supported_languages})
       add_test(swe_roe_quad_tri_mesh_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${rdycore_${lang}_driver} quad_tri_mesh.yaml -homogeneous_rain_files Houston1km.rain.${PETSC_ID_TYPE}.bin,Houston1km.rain.${PETSC_ID_TYPE}.bin -homogeneous_rain_region_ids 1,3 -homogeneous_bc_files Houston1km.bc.${PETSC_ID_TYPE}.bin,Houston1km.bc.${PETSC_ID_TYPE}.bin,Houston1km.bc.${PETSC_ID_TYPE}.bin -homogeneous_bc_region_ids   1,2,4 ${${config}_args})
     endforeach()
   endforeach()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,4 +50,6 @@ if (ENABLE_TESTS)
   add_subdirectory(tests)
 endif()
 
-add_subdirectory(f90-mod)
+if (ENABLE_FORTRAN)
+  add_subdirectory(f90-mod)
+endif()

--- a/tools/Dockerfile.petsc
+++ b/tools/Dockerfile.petsc
@@ -51,7 +51,6 @@ RUN \
     --with-cc=mpicc \
     --with-cxx=mpic++ \
     --with-fc=mpif90 \
-    --CFLAGS='-g -O0' --CXXFLAGS='-g -O0' --FFLAGS='-g -O0 -Wno-unused-function' \
     --with-clanguage=c \
     --with-debug=1 \
     --with-shared-libraries=1 \


### PR DESCRIPTION
This PR adds an `ENABLE_FORTRAN` switch that is `ON` by default but that can be turned `OFF` to disable Fortran 90 bindings. CMake is having issues (#299) generating dependencies for PETSc's new Fortran bindings, and this PR unblocks team members who don't rely on Fortran.

@jedbrown , you can cherry-pick commit `c05f909` to get this switch, and add `-DENABLE_FORTRAN=OFF` to your configuration command. I'm going to see if I can get [Ninja](https://ninja-build.org/) working as an alternative to Make, since it seems to follow a different code path for generating dependencies and doesn't exhibit the hang we're observing.