### PR TITLE
Single/Double Communication option in flux calculations

### DIFF
--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -89,3 +89,6 @@ flow_conditions:
     type: reflecting
   - name: outflow_bc
     type: critical-outflow
+
+rdy_flux_single_comm: true
+

--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -10,6 +10,7 @@ numerics:
   spatial: fv
   temporal: euler
   riemann: roe
+  flux_single_comm: true
 
 logging:
   level: detail
@@ -90,5 +91,5 @@ flow_conditions:
   - name: outflow_bc
     type: critical-outflow
 
-rdy_flux_single_comm: true
+
 

--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -90,6 +90,3 @@ flow_conditions:
     type: reflecting
   - name: outflow_bc
     type: critical-outflow
-
-
-

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -394,6 +394,9 @@ typedef struct {
   // MMS-specific section (used only by the MMS driver)
   RDyMMSSection mms;
 
+  // handle different flux communication patterns
+  PetscBool rdy_flux_single_comm;
+
 } RDyConfig;
 
 // ensemble member configuration (see ensemble.c)

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -104,6 +104,7 @@ typedef struct {
   RDyNumericsSpatial  spatial;
   RDyNumericsTemporal temporal;
   RDyNumericsRiemann  riemann;
+  PetscBool flux_single_comm;
 } RDyNumericsSection;
 
 // ------------
@@ -393,9 +394,6 @@ typedef struct {
 
   // MMS-specific section (used only by the MMS driver)
   RDyMMSSection mms;
-
-  // handle different flux communication patterns
-  PetscBool rdy_flux_single_comm;
 
 } RDyConfig;
 

--- a/src/operator.c
+++ b/src/operator.c
@@ -325,7 +325,14 @@ static PetscErrorCode ApplyCeedOperator(Operator *op, PetscReal dt, Vec u_local,
 
     // accumulate f_local into f_global
     PetscCall(VecZeroEntries(f_global));
-    PetscCall(DMLocalToGlobal(op->dm, f_local, ADD_VALUES, f_global));
+    PetscBool compute_all_flux = PETSC_FALSE;
+    PetscCall(PetscOptionsGetBool(NULL, NULL, "-compute_all_flux", &compute_all_flux, NULL));
+
+    if (compute_all_flux) {
+      PetscCall(DMLocalToGlobal(op->dm, f_local, INSERT_VALUES, f_global));
+    } else {
+      PetscCall(DMLocalToGlobal(op->dm, f_local, ADD_VALUES, f_global));
+    }
 
     // reset our CeedVectors and restore our PETSc vectors
     PetscCallCEED(CeedVectorTakeArray(op->ceed.rhs, MemTypeP2C(mem_type), &f_local_ptr));

--- a/src/operator.c
+++ b/src/operator.c
@@ -324,9 +324,6 @@ static PetscErrorCode ApplyCeedOperator(Operator *op, PetscReal dt, Vec u_local,
 
     // accumulate f_local into f_global
     PetscCall(VecZeroEntries(f_global));
-    //PetscBool compute_all_flux = PETSC_FALSE;
-    //PetscCall(PetscOptionsGetBool(NULL, NULL, "-compute_all_flux", &compute_all_flux, NULL));
-
     if (op->config->numerics.flux_single_comm) {
       PetscCall(DMLocalToGlobal(op->dm, f_local, INSERT_VALUES, f_global));
     } else {

--- a/src/operator.c
+++ b/src/operator.c
@@ -327,7 +327,7 @@ static PetscErrorCode ApplyCeedOperator(Operator *op, PetscReal dt, Vec u_local,
     //PetscBool compute_all_flux = PETSC_FALSE;
     //PetscCall(PetscOptionsGetBool(NULL, NULL, "-compute_all_flux", &compute_all_flux, NULL));
 
-    if (op->config->rdy_flux_single_comm) {
+    if (op->config->numerics.flux_single_comm) {
       PetscCall(DMLocalToGlobal(op->dm, f_local, INSERT_VALUES, f_global));
     } else {
       PetscCall(DMLocalToGlobal(op->dm, f_local, ADD_VALUES, f_global));

--- a/src/operator.c
+++ b/src/operator.c
@@ -216,7 +216,6 @@ PetscErrorCode CreateOperator(RDyConfig *config, DM domain_dm, RDyMesh *domain_m
       PetscCall(PetscLogEventRegister("CeedOperatorApp", RDY_CLASSID, &RDY_CeedOperatorApply_));
       first_time = PETSC_FALSE;
     }
-
     PetscCall(CreateCeedFluxOperator((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
                                      (*operator)->boundary_conditions, &(*operator)->ceed.flux));
     PetscCall(CreateCeedSourceOperator((*operator)->config, (*operator)->mesh, &(*operator)->ceed.source));
@@ -325,10 +324,10 @@ static PetscErrorCode ApplyCeedOperator(Operator *op, PetscReal dt, Vec u_local,
 
     // accumulate f_local into f_global
     PetscCall(VecZeroEntries(f_global));
-    PetscBool compute_all_flux = PETSC_FALSE;
-    PetscCall(PetscOptionsGetBool(NULL, NULL, "-compute_all_flux", &compute_all_flux, NULL));
+    //PetscBool compute_all_flux = PETSC_FALSE;
+    //PetscCall(PetscOptionsGetBool(NULL, NULL, "-compute_all_flux", &compute_all_flux, NULL));
 
-    if (compute_all_flux) {
+    if (op->config->rdy_flux_single_comm) {
       PetscCall(DMLocalToGlobal(op->dm, f_local, INSERT_VALUES, f_global));
     } else {
       PetscCall(DMLocalToGlobal(op->dm, f_local, ADD_VALUES, f_global));

--- a/src/operator_ceed.c
+++ b/src/operator_ceed.c
@@ -5,6 +5,7 @@
 #include <private/rdysedimentimpl.h>
 #include <private/rdysweimpl.h>
 
+#include "petscsystypes.h"
 #include "sediment/sediment_ceed_impl.h"
 #include "swe/swe_ceed_impl.h"
 
@@ -604,9 +605,7 @@ PetscErrorCode CreateCeedFluxOperator(RDyConfig *config, RDyMesh *mesh, PetscInt
   // flux suboperator 0: fluxes between interior cells
 
   CeedOperator interior_flux_op;
-  PetscBool compute_all_flux = PETSC_FALSE;
-  PetscCall(PetscOptionsGetBool(NULL, NULL, "-compute_all_flux", &compute_all_flux, NULL));
-  if (compute_all_flux) {
+  if (config->rdy_flux_single_comm) {
     PetscCall(CreateCeedAllInteriorFluxOperator(*config, mesh, &interior_flux_op));
   } else {
     PetscCall(CreateCeedInteriorFluxOperator(*config, mesh, &interior_flux_op));

--- a/src/operator_ceed.c
+++ b/src/operator_ceed.c
@@ -5,7 +5,7 @@
 #include <private/rdysedimentimpl.h>
 #include <private/rdysweimpl.h>
 
-#include "petscsystypes.h"
+#include <petscsystypes.h>
 #include "sediment/sediment_ceed_impl.h"
 #include "swe/swe_ceed_impl.h"
 

--- a/src/operator_ceed.c
+++ b/src/operator_ceed.c
@@ -110,6 +110,129 @@ static PetscErrorCode CreateInteriorFluxQFunction(Ceed ceed, const RDyConfig con
 /// @param [in]  mesh    mesh defining the computational domain of the operator
 /// @param [out] ceed_op a CeedOperator that is created and returned
 /// @return 0 on success, or a non-zero error code on failure
+
+static PetscErrorCode CreateCeedAllInteriorFluxOperator(const RDyConfig config, RDyMesh *mesh, CeedOperator *ceed_op) {
+  PetscFunctionBeginUser;
+
+  Ceed ceed = CeedContext();
+
+  CeedInt num_sediment_comp = config.physics.sediment.num_classes;
+  CeedInt num_flow_comp     = 3;  // NOTE: SWE assumed!
+  CeedInt num_comp          = num_flow_comp + num_sediment_comp;
+
+  RDyCells *cells = &mesh->cells;
+  RDyEdges *edges = &mesh->edges;
+
+  CeedQFunction qf;
+  PetscCall(CreateInteriorFluxQFunction(ceed, config, &qf));
+
+  // add inputs and outputs
+  // NOTE: the order in which these inputs and outputs are specified determines
+  // NOTE: their indexing within the Q-function's implementation (swe_ceed_impl.h)
+  CeedInt num_comp_geom = 4, num_comp_cnum = 2;
+  PetscCallCEED(CeedQFunctionAddInput(qf, "geom", num_comp_geom, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "q_left", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddInput(qf, "q_right", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "cell_left", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "cell_right", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "flux", num_comp, CEED_EVAL_NONE));
+  PetscCallCEED(CeedQFunctionAddOutput(qf, "courant_number", num_comp_cnum, CEED_EVAL_NONE));
+
+  // create vectors (and their supporting restrictions) for the operator
+  CeedElemRestriction q_restrict_l, q_restrict_r, c_restrict_l, c_restrict_r, restrict_geom, restrict_flux, restrict_cnum;
+  CeedVector          geom, flux, cnum;
+  {
+    CeedInt num_edges = mesh->num_internal_edges;
+
+    // create a vector of geometric factors that transform fluxes to cell states
+    CeedInt g_strides[] = {num_comp_geom, 1, num_comp_geom};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_edges, 1, num_comp_geom, num_edges * num_comp_geom, g_strides, &restrict_geom));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_geom, &geom, NULL));
+    PetscCallCEED(CeedVectorSetValue(geom, 0.0));
+    CeedScalar(*g)[4];
+    PetscCallCEED(CeedVectorGetArray(geom, CEED_MEM_HOST, (CeedScalar **)&g));
+    for (CeedInt e = 0; e < mesh->num_internal_edges; e++) {
+      CeedInt iedge = edges->internal_edge_ids[e];
+      //if (!edges->is_owned[iedge]) continue;
+      CeedInt l        = edges->cell_ids[2 * iedge];
+      CeedInt r        = edges->cell_ids[2 * iedge + 1];
+      g[e][0] = edges->sn[iedge];
+      g[e][1] = edges->cn[iedge];
+      g[e][2] = -edges->lengths[iedge] / cells->areas[l];
+      g[e][3] = edges->lengths[iedge] / cells->areas[r];
+    }
+    PetscCallCEED(CeedVectorRestoreArray(geom, (CeedScalar **)&g));
+
+    // create a vector to store inter-cell fluxes
+    CeedInt f_strides[] = {num_comp, 1, num_comp};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_edges, 1, num_comp, num_edges * num_comp, f_strides, &restrict_flux));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_flux, &flux, NULL));
+    PetscCallCEED(CeedVectorSetValue(flux, 0.0));
+
+    // create a vector to store the courant number for each edge
+    CeedInt cnum_strides[] = {num_comp_cnum, 1, num_comp_cnum};
+    PetscCallCEED(CeedElemRestrictionCreateStrided(ceed, num_edges, 1, num_comp_cnum, num_edges * num_comp_cnum, cnum_strides, &restrict_cnum));
+    PetscCallCEED(CeedElemRestrictionCreateVector(restrict_cnum, &cnum, NULL));
+    PetscCallCEED(CeedVectorSetValue(cnum, 0.0));
+
+    // create element restrictions for (active) left and right input/output states
+    CeedInt *q_offset_l, *q_offset_r, *c_offset_l, *c_offset_r;
+    PetscCall(PetscMalloc2(num_edges, &q_offset_l, num_edges, &q_offset_r));
+    PetscCall(PetscMalloc2(num_edges, &c_offset_l, num_edges, &c_offset_r));
+    for (CeedInt e = 0; e < mesh->num_internal_edges; e++) {
+      CeedInt iedge = edges->internal_edge_ids[e];
+      //if (!edges->is_owned[iedge]) continue;
+      CeedInt l              = edges->cell_ids[2 * iedge];
+      CeedInt r              = edges->cell_ids[2 * iedge + 1];
+      q_offset_l[e] = l * num_comp;
+      q_offset_r[e] = r * num_comp;
+      c_offset_l[e] = cells->local_to_owned[l] * num_comp;
+      c_offset_r[e] = cells->local_to_owned[r] * num_comp;
+    }
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, q_offset_l,
+                                            &q_restrict_l));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, q_offset_r,
+                                            &q_restrict_r));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, c_offset_l,
+                                            &c_restrict_l));
+    PetscCallCEED(CeedElemRestrictionCreate(ceed, num_edges, 1, num_comp, 1, mesh->num_cells * num_comp, CEED_MEM_HOST, CEED_COPY_VALUES, c_offset_r,
+                                            &c_restrict_r));
+    PetscCall(PetscFree2(q_offset_l, q_offset_r));
+    PetscCall(PetscFree2(c_offset_l, c_offset_r));
+    if (0) {
+      PetscCallCEED(CeedElemRestrictionView(q_restrict_l, stdout));
+      PetscCallCEED(CeedElemRestrictionView(q_restrict_r, stdout));
+      PetscCallCEED(CeedElemRestrictionView(c_restrict_l, stdout));
+      PetscCallCEED(CeedElemRestrictionView(c_restrict_r, stdout));
+    }
+  }
+
+  // create the operator itself and assign its active/passive inputs/outputs
+  PetscCallCEED(CeedOperatorCreate(ceed, qf, NULL, NULL, ceed_op));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "geom", restrict_geom, CEED_BASIS_COLLOCATED, geom));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "q_left", q_restrict_l, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "q_right", q_restrict_r, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "cell_left", c_restrict_l, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "cell_right", c_restrict_r, CEED_BASIS_COLLOCATED, CEED_VECTOR_ACTIVE));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "flux", restrict_flux, CEED_BASIS_COLLOCATED, flux));
+  PetscCallCEED(CeedOperatorSetField(*ceed_op, "courant_number", restrict_cnum, CEED_BASIS_COLLOCATED, cnum));
+
+  // clean up
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_geom));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_flux));
+  PetscCallCEED(CeedElemRestrictionDestroy(&restrict_cnum));
+  PetscCallCEED(CeedElemRestrictionDestroy(&q_restrict_l));
+  PetscCallCEED(CeedElemRestrictionDestroy(&q_restrict_r));
+  PetscCallCEED(CeedElemRestrictionDestroy(&c_restrict_l));
+  PetscCallCEED(CeedElemRestrictionDestroy(&c_restrict_r));
+  PetscCallCEED(CeedVectorDestroy(&geom));
+  PetscCallCEED(CeedVectorDestroy(&flux));
+  PetscCallCEED(CeedVectorDestroy(&cnum));
+  PetscCallCEED(CeedQFunctionDestroy(&qf));
+
+  PetscFunctionReturn(CEED_ERROR_SUCCESS);
+}
+
 static PetscErrorCode CreateCeedInteriorFluxOperator(const RDyConfig config, RDyMesh *mesh, CeedOperator *ceed_op) {
   PetscFunctionBeginUser;
 
@@ -481,7 +604,13 @@ PetscErrorCode CreateCeedFluxOperator(RDyConfig *config, RDyMesh *mesh, PetscInt
   // flux suboperator 0: fluxes between interior cells
 
   CeedOperator interior_flux_op;
-  PetscCall(CreateCeedInteriorFluxOperator(*config, mesh, &interior_flux_op));
+  PetscBool compute_all_flux = PETSC_FALSE;
+  PetscCall(PetscOptionsGetBool(NULL, NULL, "-compute_all_flux", &compute_all_flux, NULL));
+  if (compute_all_flux) {
+    PetscCall(CreateCeedAllInteriorFluxOperator(*config, mesh, &interior_flux_op));
+  } else {
+    PetscCall(CreateCeedInteriorFluxOperator(*config, mesh, &interior_flux_op));
+  }
   PetscCall(CeedCompositeOperatorAddSub(*flux_op, interior_flux_op));
 
   // flux suboperators 1 to num_boundaries: fluxes on boundary edges

--- a/src/operator_ceed.c
+++ b/src/operator_ceed.c
@@ -605,7 +605,7 @@ PetscErrorCode CreateCeedFluxOperator(RDyConfig *config, RDyMesh *mesh, PetscInt
   // flux suboperator 0: fluxes between interior cells
 
   CeedOperator interior_flux_op;
-  if (config->rdy_flux_single_comm) {
+  if (config->numerics.flux_single_comm) {
     PetscCall(CreateCeedAllInteriorFluxOperator(*config, mesh, &interior_flux_op));
   } else {
     PetscCall(CreateCeedInteriorFluxOperator(*config, mesh, &interior_flux_op));

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -690,6 +690,7 @@ static const cyaml_schema_field_t config_fields_schema[] = {
     CYAML_FIELD_SEQUENCE_COUNT("salinity_conditions", CYAML_FLAG_OPTIONAL, RDyConfig, salinity_conditions, num_salinity_conditions,
                                &salinity_condition_entry, 0, MAX_NUM_CONDITIONS),
     CYAML_FIELD_MAPPING("ensemble", CYAML_FLAG_OPTIONAL, RDyConfig, ensemble, ensemble_fields_schema),
+    CYAML_FIELD_BOOL("rdy_flux_single_comm", CYAML_FLAG_OPTIONAL, RDyConfig, rdy_flux_single_comm),
     CYAML_FIELD_END
 };
 

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -123,6 +123,7 @@ static const cyaml_schema_field_t numerics_fields_schema[] = {
     CYAML_FIELD_ENUM("spatial", CYAML_FLAG_DEFAULT, RDyNumericsSection, spatial, numerics_spatial_types, CYAML_ARRAY_LEN(numerics_spatial_types)),
     CYAML_FIELD_ENUM("temporal", CYAML_FLAG_DEFAULT, RDyNumericsSection, temporal, numerics_temporal_types, CYAML_ARRAY_LEN(numerics_temporal_types)),
     CYAML_FIELD_ENUM("riemann", CYAML_FLAG_DEFAULT, RDyNumericsSection, riemann, numerics_riemann_types, CYAML_ARRAY_LEN(numerics_riemann_types)),
+    CYAML_FIELD_BOOL("flux_single_comm", CYAML_FLAG_OPTIONAL, RDyNumericsSection, flux_single_comm),
     CYAML_FIELD_END
 };
 
@@ -690,7 +691,6 @@ static const cyaml_schema_field_t config_fields_schema[] = {
     CYAML_FIELD_SEQUENCE_COUNT("salinity_conditions", CYAML_FLAG_OPTIONAL, RDyConfig, salinity_conditions, num_salinity_conditions,
                                &salinity_condition_entry, 0, MAX_NUM_CONDITIONS),
     CYAML_FIELD_MAPPING("ensemble", CYAML_FLAG_OPTIONAL, RDyConfig, ensemble, ensemble_fields_schema),
-    CYAML_FIELD_BOOL("rdy_flux_single_comm", CYAML_FLAG_OPTIONAL, RDyConfig, rdy_flux_single_comm),
     CYAML_FIELD_END
 };
 


### PR DESCRIPTION
Added functionality to chose between single or double communication between cells during flux calculations. Under numerics, flux_single_comm now allows single communication. Though default remains the same. 