### PR TITLE
Adding the ability to select which fields (components) appear in output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(ENABLE_SANITIZERS "Enable available sanitizers (ASan, MSan, UBSan)" OFF)
 
 set(MAX_NAME_LEN              128 CACHE STRING "Maximum allowable length of field/variable names")
 set(MAX_NUM_SEDIMENT_CLASSES    5 CACHE STRING "Maximum number of sediment size classes")
-set(MAX_NUM_FIELDS              1 CACHE STRING "Maximum number of fields in a model's state")
+set(MAX_NUM_FIELDS             10 CACHE STRING "Maximum number of fields in a model's state")
 
 # Material property (integer) identifiers.
 # (we generate them here to allow GPU JIT compilers to see them)

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -424,7 +424,8 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
   array syntax (typically with hyphenated items on separate lines). This item is
   optional, and if omitted the selected fields are the components of the
   solution (e.g. `Height`, `MomentumX`, `MomentumY` for the shallow water
-  equations). Available options are
+  equations). **NOTE: This feature works only for XDMF output!** Available
+  options are
     * `Height`: water height $h$
     * `MomentumX`: $x$ momentum $hu$
     * `MomentumY`: $y$ velocity $hv$

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -407,7 +407,7 @@ output:
     - MomentumY
     - WaterSource
   format: xdmf
-  step_interval: 100
+  output_interval: 100
   batch_size: 1
   time_series:
     boundary_fluxes: 10
@@ -439,7 +439,7 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
     * `binary`: output is written using PETSc's binary data format
     * `xdmf`: output is written to the [XDMF](https://xdmf.org/index.php/XDMF_Model_and_Format) format
     * `cgns`: output is written to the [CFD General Notation System (CGNS)](https://cgns.github.io/) format
-* `step_interval`: the number of time steps between output dumps. Default value: 0 (no output)
+* `output_interval`: the number of time steps between output dumps. Default value: 0 (no output)
 * `time_interval`: the temporal frequency between output dumps. The is an integer with a minimum value of 1 second. Default value: 0 (no output)
 * `time_unit`: units of temporal frequency output.
 * `batch_size`: the number of time steps for which output data is stored in a

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -401,6 +401,8 @@ RDycore. The parameters that define these discretizations are
 ```yaml
 output:
   directory: output
+  fields:
+    - 
   format: xdmf
   step_interval: 100
   batch_size: 1
@@ -409,10 +411,24 @@ output:
   separate_grid_file: true
 ```
 
-The `output` section control simulation output, including visualization and
-time series data (and excluding checkpoint data). Relevant parameters are
+The `output` section controls simulation output, including visualization and
+time series data (**but excluding checkpoint data**). Relevant parameters are
 
-* `directory`: the name of the directory to which output is written. It can be a relative or absolute path, and is created if it doesn't already exist. Default value: `output`
+* `directory`: the name of the directory to which output is written. It can be
+  a relative or absolute path, and is created if it doesn't already exist.
+  Default value: `output`
+* `fields`: a list of fields to include in each output file, expressed in YAML
+  array syntax (typically with hyphenated items on separate lines). This item is
+  optional, and if omitted the included fields are the components of the
+  solution (e.g. `Height`, `MomentumX`, `MomentumY` for the shallow water
+  equations). Available options:
+    * `Height`: water height $h$
+    * `MomentumX`: $x$ momentum $hu$
+    * `MomentumY`: $y$ velocity $hv$
+    * `Concentration_I`: the concentration for sediment class $I$ (0, 1, 2, ...)
+    * `WaterSource`: the value of the source term for $h$
+    * `MomentumXSource`: the value of the source term for $hu$
+    * `MomentumYSource`: the value of the source term for $hv$
 * `format`: the format of the output written. Available options are
     * `none`: no output is written. This is the default value.
     * `binary`: output is written using PETSc's binary data format

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -428,10 +428,11 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
     * `Height`: water height $h$
     * `MomentumX`: $x$ momentum $hu$
     * `MomentumY`: $y$ velocity $hv$
-    * `Concentration_I`: the concentration for sediment class $I$ (0, 1, 2, ...)
+    * `ConcentrationI`: the concentration for sediment class $I$ (0, 1, 2, ...)
     * `WaterSource`: the value of the source term for $h$
     * `MomentumXSource`: the value of the source term for $hu$
     * `MomentumYSource`: the value of the source term for $hv$
+    * `ConcentrationISource`: the value of the source term for sediment class $I$
 * `format`: the format of the output written. Available options are
     * `none`: no output is written. This is the default value.
     * `binary`: output is written using PETSc's binary data format

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -402,7 +402,10 @@ RDycore. The parameters that define these discretizations are
 output:
   directory: output
   fields:
-    - 
+    - Height
+    - MomentumX
+    - MomentumY
+    - WaterSource
   format: xdmf
   step_interval: 100
   batch_size: 1
@@ -419,9 +422,9 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
   Default value: `output`
 * `fields`: a list of fields to include in each output file, expressed in YAML
   array syntax (typically with hyphenated items on separate lines). This item is
-  optional, and if omitted the included fields are the components of the
+  optional, and if omitted the selected fields are the components of the
   solution (e.g. `Height`, `MomentumX`, `MomentumY` for the shallow water
-  equations). Available options:
+  equations). Available options are
     * `Height`: water height $h$
     * `MomentumX`: $x$ momentum $hu$
     * `MomentumY`: $y$ velocity $hv$

--- a/driver/tests/amr/amr_dx1.yaml
+++ b/driver/tests/amr/amr_dx1.yaml
@@ -18,7 +18,7 @@ time:
 
 #output:
 #  format: xdmf
-#  step_interval: 100
+#  output_interval: 100
 
 grid:
   file: mms_triangles_dx1.exo

--- a/driver/tests/bad_input/nonexistent_boundary.yaml
+++ b/driver/tests/bad_input/nonexistent_boundary.yaml
@@ -21,7 +21,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 10000
+  output_interval: 10000
   batch_size: 20
   time_series:
     boundary_fluxes: 1

--- a/driver/tests/sediment/sediment.yaml
+++ b/driver/tests/sediment/sediment.yaml
@@ -22,7 +22,7 @@ time:
 
 #output:
 #  format: xdmf
-#  step_interval: 100
+#  output_interval: 100
 
 grid:
   file: DamBreak_grid5x10.exo

--- a/driver/tests/sediment/sediment_ic_file.yaml
+++ b/driver/tests/sediment/sediment_ic_file.yaml
@@ -22,7 +22,7 @@ time:
 
 #output:
 #  format: xdmf
-#  step_interval: 100
+#  output_interval: 100
 
 grid:
   file: DamBreak_grid5x10.exo

--- a/driver/tests/sediment/sediment_mms_conv_study.yaml
+++ b/driver/tests/sediment/sediment_mms_conv_study.yaml
@@ -95,7 +95,7 @@ time:
 
 #output:
 #  format: xdmf
-#  step_interval: 500
+#  output_interval: 500
 
 grid:
   file: mms_triangles_dx1.exo # z coordinates overwritten by z(x, y) above

--- a/driver/tests/swe_roe/Houston1km.DirichletBC.adaptive_timestep.yaml
+++ b/driver/tests/swe_roe/Houston1km.DirichletBC.adaptive_timestep.yaml
@@ -22,7 +22,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 10000
+  output_interval: 10000
   time_interval: 600
   time_unit: seconds
   batch_size: 20

--- a/driver/tests/swe_roe/Houston1km.DirichletBC.yaml
+++ b/driver/tests/swe_roe/Houston1km.DirichletBC.yaml
@@ -17,8 +17,13 @@ time:
   unit             : seconds
 
 output:
+  fields:
+    - Height
+    - MomentumX
+    - MomentumY
+    - WaterSource
   format: xdmf
-  step_interval: 10000
+  output_interval: 10000
   time_interval: 600
   time_unit: seconds
   batch_size: 20

--- a/driver/tests/swe_roe/Simons.OceanDirichletBC.yaml
+++ b/driver/tests/swe_roe/Simons.OceanDirichletBC.yaml
@@ -18,7 +18,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 20
+  output_interval: 20
   batch_size: 20
   time_series:
     boundary_fluxes: 1

--- a/driver/tests/swe_roe/ex2b-ensemble.yaml
+++ b/driver/tests/swe_roe/ex2b-ensemble.yaml
@@ -37,7 +37,7 @@ checkpoint:
 
 output:
   format: xdmf
-  step_interval: 100
+  output_interval: 100
   batch_size: 20
   time_series:
     boundary_fluxes: 10

--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -25,12 +25,7 @@ checkpoint:
 
 output:
   format: xdmf
-  fields:
-    - Height
-    - MomentumX
-    - MomentumY
-    - WaterSource
-  step_interval: 100
+  output_interval: 100
   batch_size: 20
   time_series:
     boundary_fluxes: 10

--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -25,6 +25,11 @@ checkpoint:
 
 output:
   format: xdmf
+  fields:
+    - Height
+    - MomentumX
+    - MomentumY
+    - WaterSource
   step_interval: 100
   batch_size: 20
   time_series:

--- a/driver/tests/swe_roe/ex2b_dirichlet_bc.yaml
+++ b/driver/tests/swe_roe/ex2b_dirichlet_bc.yaml
@@ -18,7 +18,7 @@ time:
 output:
   directory: dirichlet-bc-output
   format: xdmf
-  step_interval: 100
+  output_interval: 100
   batch_size: 20
   time_series:
     boundary_fluxes: 10

--- a/driver/tests/swe_roe/ex2b_ic_file.yaml
+++ b/driver/tests/swe_roe/ex2b_ic_file.yaml
@@ -20,7 +20,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 100
+  output_interval: 100
 
 grid:
   file: DamBreak_grid5x10.exo

--- a/driver/tests/swe_roe/four_mounds_60x24.yaml
+++ b/driver/tests/swe_roe/four_mounds_60x24.yaml
@@ -49,6 +49,6 @@ flow_conditions:
 
 output:
   format: xdmf
-  step_interval: 10
+  output_interval: 10
 
 

--- a/driver/tests/swe_roe/mixed_elements_ic_file.yaml
+++ b/driver/tests/swe_roe/mixed_elements_ic_file.yaml
@@ -21,7 +21,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 100
+  output_interval: 100
   batch_size: 20
   time_series:
     boundary_fluxes: 10

--- a/driver/tests/swe_roe/mms_conv_study.yaml
+++ b/driver/tests/swe_roe/mms_conv_study.yaml
@@ -74,7 +74,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 500
+  output_interval: 500
 
 grid:
   file: mms_triangles_dx1.exo # z coordinates overwritten by z(x, y) above

--- a/driver/tests/swe_roe/mms_single_run.yaml
+++ b/driver/tests/swe_roe/mms_single_run.yaml
@@ -58,7 +58,7 @@ time:
 
 output: # for plotting the error vector
   format: xdmf
-  step_interval: 50
+  output_interval: 50
   batch_size: 20
 
 grid:

--- a/driver/tests/swe_roe/quad_tri_mesh.yaml
+++ b/driver/tests/swe_roe/quad_tri_mesh.yaml
@@ -21,7 +21,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 1
+  output_interval: 1
   batch_size: 20
   time_series:
     boundary_fluxes: 1

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -174,6 +174,8 @@ typedef struct {
 typedef struct {
   PetscBool       enable;                         // true if output is requested
   char            directory[PETSC_MAX_PATH_LEN];  // output directory
+  char          **fields;                         // array of selected output field names
+  PetscInt        fields_count;                   // number of selected output fields
   RDyOutputFormat format;                         // file format
   PetscInt        step_interval;                  // output interval [steps between outputs]
   PetscInt        time_interval;                  // temporal interval at which output is written

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -177,7 +177,7 @@ typedef struct {
   char          **fields;                         // array of selected output field names
   PetscInt        fields_count;                   // number of selected output fields
   RDyOutputFormat format;                         // file format
-  PetscInt        step_interval;                  // output interval [steps between outputs]
+  PetscInt        output_interval;                // output interval [steps between outputs]
   PetscInt        time_interval;                  // temporal interval at which output is written
   RDyTimeUnit     time_unit;                      // unit of time for temporal interval
   PetscInt        batch_size;                     // number of timesteps per output file (if available)

--- a/src/f90-mod/tests/coupling.yaml
+++ b/src/f90-mod/tests/coupling.yaml
@@ -19,7 +19,7 @@ time:
 
 output:
   format: xdmf
-  step_interval: 100
+  output_interval: 100
   batch_size: 20
   time_series:
     boundary_fluxes: 10

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -228,72 +228,6 @@ static PetscErrorCode CalibrateSolverTimers(RDy rdy) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// Updates diagnostic fields in the auxiliary DM
-static PetscErrorCode UpdateDiagnosticFields(RDy rdy) {
-  PetscFunctionBegin;
-
-  // construct a set of available source fields (with a zero-length terminus)
-  static char diagnostics_names[3 + MAX_NUM_SEDIMENT_CLASSES + 1][MAX_NAME_LEN] = {
-      "WaterSource",
-      "MomentumXSource",
-      "MomentumYSource",
-  };
-  static PetscBool first_time = PETSC_TRUE;
-  if (first_time) {
-    for (PetscInt i = 0; i < rdy->config.physics.sediment.num_classes; ++i) {
-      snprintf(diagnostics_names[3 + i], MAX_NAME_LEN, "Concentration%" PetscInt_FMT "Source", i);
-    }
-    first_time = PETSC_FALSE;
-  }
-
-  // Fetch diagnostics from the operator.
-  OperatorData diagnostics = {0};
-  PetscCall(GetOperatorDomainExternalSource(rdy->operator, & diagnostics));
-
-  PetscSection section;
-  PetscCall(DMGetLocalSection(rdy->aux_dm, &section));
-
-  PetscInt num_fields;
-  PetscCall(PetscSectionGetNumFields(section, &num_fields));
-  for (PetscInt f = 0; f < num_fields; ++f) {
-    // NOTE: at present, all diagnostic fields have a single component
-    // NOTE: and are stored in global ordering (no halo cells)
-    const char *name;
-    PetscCall(PetscSectionGetFieldName(section, f, &name));
-
-    int diag_index;
-    for (diag_index = 0; diagnostics_names[diag_index][0]; ++diag_index) {
-      if (!strcmp(name, diagnostics_names[diag_index])) {
-        // if our aux_dm is refined, diagnostics are stored in global
-        // vectors; if not, they are in natural vectors
-        if (rdy->num_refinements > 0) {
-          // global -> global
-          PetscReal *diag_data;
-          PetscCall(VecGetArrayWrite(rdy->diags_vec, &diag_data));
-          memcpy(diag_data, diagnostics.values[diag_index], rdy->mesh.num_owned_cells * sizeof(PetscReal));
-          PetscCall(VecRestoreArrayWrite(rdy->diags_vec, &diag_data));
-        } else {
-          // global -> natural
-          Vec global;
-          PetscCall(DMCreateGlobalVector(rdy->aux_dm, &global));
-          PetscReal *diag_data;
-          PetscCall(VecGetArrayWrite(global, &diag_data));
-          memcpy(diag_data, diagnostics.values[diag_index], rdy->mesh.num_owned_cells * sizeof(PetscReal));
-          PetscCall(VecRestoreArrayWrite(global, &diag_data));
-          PetscCall(DMPlexGlobalToNaturalBegin(rdy->aux_dm, global, rdy->diags_vec));
-          PetscCall(DMPlexGlobalToNaturalEnd(rdy->aux_dm, global, rdy->diags_vec));
-          PetscCall(VecDestroy(&global));
-        }
-      }
-    }
-  }
-
-  // put toys away
-  PetscCall(RestoreOperatorDomainExternalSource(rdy->operator, & diagnostics));
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
 /// Advances the solution by the coupling interval specified in the input
 /// configuration.
 PetscErrorCode RDyAdvance(RDy rdy) {
@@ -398,8 +332,6 @@ PetscErrorCode RDyAdvance(RDy rdy) {
       PetscCall(UpdateOperatorDiagnostics(rdy->operator));
     }
   }
-
-  PetscCall(UpdateDiagnosticFields(rdy));
 
   // are we finished?
   PetscCall(TSGetTime(rdy->ts, &time));

--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -100,10 +100,10 @@ PetscErrorCode DetermineOutputFile(RDy rdy, PetscInt step, PetscReal time, const
         snprintf(filename, PETSC_MAX_PATH_LEN - 1, "%s/%s-%" PetscInt_FMT ".%s", output_dir, prefix, step, suffix);
       } else {
         // output data is grouped into batches of a fixed number of time steps
-        PetscInt batch_size    = rdy->config.output.batch_size;
-        PetscInt step_interval = rdy->config.output.step_interval;
-        PetscInt batch         = step / step_interval / batch_size;
-        PetscInt max_batch     = rdy->config.time.max_step / step_interval / batch_size;
+        PetscInt batch_size      = rdy->config.output.batch_size;
+        PetscInt output_interval = rdy->config.output.output_interval;
+        PetscInt batch           = step / output_interval / batch_size;
+        PetscInt max_batch       = rdy->config.time.max_step / output_interval / batch_size;
         if (max_batch < 1) max_batch = 1;
         PetscCall(GenerateIndexedFilename(output_dir, prefix, batch, max_batch, suffix, filename));
       }
@@ -136,7 +136,7 @@ PetscErrorCode DestroyOutputViewer(RDy rdy) {
 PetscErrorCode WriteOutputLogMessage(TS ts, PetscInt step, PetscReal time, Vec X, void *ctx) {
   PetscFunctionBegin;
   RDy rdy = ctx;
-  if (step % rdy->config.output.step_interval == 0) {
+  if (step % rdy->config.output.output_interval == 0) {
     static const char *formats[4] = {"none", "binary", "XDMF", "CGNS"};
     const char        *format     = formats[rdy->config.output.format];
     const char        *units      = TimeUnitAsString(rdy->config.time.unit);
@@ -154,8 +154,8 @@ static PetscErrorCode CreateOutputViewer(RDy rdy) {
 
   PetscViewerFormat format = PETSC_VIEWER_DEFAULT;
   if (rdy->config.output.enable) {
-    if (rdy->config.output.step_interval) {
-      RDyLogDebug(rdy, "Writing output every %" PetscInt_FMT " timestep(s)", rdy->config.output.step_interval);
+    if (rdy->config.output.output_interval) {
+      RDyLogDebug(rdy, "Writing output every %" PetscInt_FMT " timestep(s)", rdy->config.output.output_interval);
     }
 
     if (rdy->config.output.time_interval) {

--- a/src/rdydm.c
+++ b/src/rdydm.c
@@ -170,7 +170,7 @@ PetscErrorCode CreateAuxiliaryDM(RDy rdy) {
 
 /// @brief  This function creates a DM for sediments
 /// @param rdy
-/// @return PETSC_SUCESS on success
+/// @return PETSC_SUCCESS on success
 PetscErrorCode CreateSedimentDM(RDy rdy) {
   PetscFunctionBegin;
   PetscInt num_sediment_class = rdy->config.physics.sediment.num_classes;

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -196,7 +196,7 @@ PetscErrorCode RDyMMSSetup(RDy rdy) {
       }},
   };
   for (PetscInt i = 0; i < rdy->num_sediment_classes; ++i) {
-    snprintf(rdy->soln_fields.field_component_names[0][3 + i], MAX_NAME_LEN, "Concentration_%" PetscInt_FMT, i);
+    snprintf(rdy->soln_fields.field_component_names[0][3 + i], MAX_NAME_LEN, "Concentration%" PetscInt_FMT, i);
   }
 
   PetscCall(CreateDM(rdy));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -1257,7 +1257,7 @@ PetscErrorCode RDySetup(RDy rdy) {
       }},
   };
   for (PetscInt i = 0; i < rdy->num_sediment_classes; ++i) {
-    snprintf(rdy->soln_fields.field_component_names[0][3 + i], MAX_NAME_LEN, "Concentration_%" PetscInt_FMT, i);
+    snprintf(rdy->soln_fields.field_component_names[0][3 + i], MAX_NAME_LEN, "Concentration%" PetscInt_FMT, i);
   }
 
   PetscCall(CreateDM(rdy));

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -1269,16 +1269,20 @@ PetscErrorCode RDySetup(RDy rdy) {
       // a diagnostic field is a requested output field that doesn't belong
       // to the solution vector
       PetscBool is_diag_field = PETSC_TRUE;
-      for (PetscInt j = 0; j < rdy->soln_fields.num_fields; ++j) {
-        if (!strcmp(rdy->soln_fields.field_names[j], rdy->config.output.fields[i])) {
+      for (PetscInt j = 0; j < rdy->soln_fields.num_field_components[0]; ++j) {
+        if (!strcmp(rdy->soln_fields.field_component_names[0][j], rdy->config.output.fields[i])) {
           is_diag_field = PETSC_FALSE;
           break;
         }
       }
       if (is_diag_field) {
-        strcpy(rdy->diag_fields.field_names[rdy->diag_fields.num_fields], rdy->config.output.fields[i]);
-        rdy->diag_fields.num_field_components[rdy->diag_fields.num_fields] = 1;
-        ++rdy->diag_fields.num_fields;
+        if (!rdy->diag_fields.num_fields) {
+          rdy->diag_fields.num_fields = 1;
+          strcpy(rdy->diag_fields.field_names[0], "Diagnostics");
+          rdy->diag_fields.num_field_components[0] = 0;
+        }
+        strcpy(rdy->diag_fields.field_component_names[0][rdy->diag_fields.num_field_components[0]], rdy->config.output.fields[i]);
+        ++rdy->diag_fields.num_field_components[0];
       }
     }
   } else {  // default diagnostics

--- a/src/xdmf_output.c
+++ b/src/xdmf_output.c
@@ -201,7 +201,7 @@ static PetscErrorCode WriteXDMFHDF5Data(RDy rdy, PetscInt step, PetscReal time) 
   const char *units = TimeUnitAsString(rdy->config.time.unit);
 
   // create or append to a file depending on whether this step is the first in a dataset
-  PetscInt      dataset   = step / rdy->config.output.step_interval;
+  PetscInt      dataset   = step / rdy->config.output.output_interval;
   PetscFileMode file_mode = (dataset % rdy->config.output.batch_size == 0) ? FILE_MODE_WRITE : FILE_MODE_APPEND;
 
   RDyLogDetail(rdy, "Step %" PetscInt_FMT ": writing XDMF HDF5 output at t = %g %s to %s", step, time, units, file_name);
@@ -391,8 +391,8 @@ PetscErrorCode WriteXDMFOutput(TS ts, PetscInt step, PetscReal time, Vec X, void
     }
 
     // check if it is time to output based on step interval
-    if (output->step_interval > 0 && !write_output) {
-      if (step % output->step_interval == 0) write_output = PETSC_TRUE;
+    if (output->output_interval > 0 && !write_output) {
+      if (step % output->output_interval == 0) write_output = PETSC_TRUE;
     }
 
     // write output

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -1351,13 +1351,13 @@ PetscErrorCode DetermineConfigPrefix(RDy rdy, char *prefix) {
   PetscFunctionBegin;
 
   memset(prefix, 0, sizeof(char) * (strlen(rdy->config_file) + 1));
-  char *p = strcasestr(rdy->config_file, ".yaml");
+  char *p = strstr(rdy->config_file, ".yaml");
   if (!p) {  // could be .yml, I suppose (Windows habits die hard!)
-    p = strcasestr(rdy->config_file, ".yml");
+    p = strstr(rdy->config_file, ".yml");
   }
   if (p) {
     size_t prefix_len = p - rdy->config_file;
-    strlcpy(prefix, rdy->config_file, prefix_len);
+    strncpy(prefix, rdy->config_file, prefix_len);
   } else {
     strcpy(prefix, rdy->config_file);
   }

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -823,8 +823,8 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
 
   // check sediment dynamics settings
   PetscCheck(config->physics.sediment.num_classes <= MAX_NUM_SEDIMENT_CLASSES, comm, PETSC_ERR_USER,
-             "The specified number of sediment classes (%" PetscInt_FMT ") exceeds the maximum (%d)",
-             config->physics.sediment.num_classes, MAX_NUM_SEDIMENT_CLASSES);
+             "The specified number of sediment classes (%" PetscInt_FMT ") exceeds the maximum (%d)", config->physics.sediment.num_classes,
+             MAX_NUM_SEDIMENT_CLASSES);
 
   // check numerics settings
   if (config->numerics.spatial != SPATIAL_FV) {

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -823,7 +823,7 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
 
   // check sediment dynamics settings
   PetscCheck(config->physics.sediment.num_classes <= MAX_NUM_SEDIMENT_CLASSES, comm, PETSC_ERR_USER,
-             "The specified number of sediment classes (%" PetscInt_FMT ") exceeds the maximum (%" PetscInt_FMT ")",
+             "The specified number of sediment classes (%" PetscInt_FMT ") exceeds the maximum (%d)",
              config->physics.sediment.num_classes, MAX_NUM_SEDIMENT_CLASSES);
 
   // check numerics settings

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -823,8 +823,8 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
 
   // check sediment dynamics settings
   PetscCheck(config->physics.sediment.num_classes <= MAX_NUM_SEDIMENT_CLASSES, comm, PETSC_ERR_USER,
-             "The specified number of sediment classes (%" PetscInt_FMT ") exceeds the maximum (%d)", config->physics.sediment.num_classes,
-             MAX_NUM_SEDIMENT_CLASSES);
+             "The specified number of sediment classes (%" PetscInt_FMT ") exceeds the maximum (%" PetscInt_FMT ")",
+             config->physics.sediment.num_classes, MAX_NUM_SEDIMENT_CLASSES);
 
   // check numerics settings
   if (config->numerics.spatial != SPATIAL_FV) {
@@ -1008,7 +1008,9 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
 
     if (config->output.fields_count > 0) {
       static const char *valid_output_fields[] = {
-          "Height", "MomentumX", "MomentumY", "Concentration%d", "WaterSource", "MomentumXSource", "MomentumYSource", "Concentration%dSource", NULL,
+          "Height",      "MomentumX",       "MomentumY",       "Concentration%" PetscInt_FMT,
+          "WaterSource", "MomentumXSource", "MomentumYSource", "Concentration%" PetscInt_FMT "Source",
+          NULL,
       };
       for (PetscInt f = 0; f < config->output.fields_count; ++f) {
         PetscBool valid = PETSC_FALSE;

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -237,7 +237,7 @@ static const cyaml_schema_field_t restart_fields_schema[] = {
 //   directory: <output-directory>
 //   fields: <list-of-output-fields>
 //   format: <binary|xdmf|cgns>
-//   step_interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
+//   output_interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
 //   batch_size: <number-of-steps-stored-in-each-output-file> # default: 1
 //   time_series:
 //     boundary_fluxes: <number-of-steps-between-flux-dumps>
@@ -268,7 +268,7 @@ static const cyaml_schema_field_t output_fields_schema[] = {
     CYAML_FIELD_SEQUENCE("fields", CYAML_FLAG_OPTIONAL | CYAML_FLAG_POINTER, RDyOutputSection, fields, &output_field_schema, 0, MAX_NUM_MATERIALS),
     CYAML_FIELD_ENUM("fields", CYAML_FLAG_OPTIONAL, RDyOutputSection, format, output_file_formats, CYAML_ARRAY_LEN(output_file_formats)),
     CYAML_FIELD_ENUM("format", CYAML_FLAG_OPTIONAL, RDyOutputSection, format, output_file_formats, CYAML_ARRAY_LEN(output_file_formats)),
-    CYAML_FIELD_INT("step_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, step_interval),
+    CYAML_FIELD_INT("output_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, output_interval),
     CYAML_FIELD_INT("time_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_interval),
     CYAML_FIELD_ENUM("time_unit", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_unit, time_units, CYAML_ARRAY_LEN(time_units)),
     CYAML_FIELD_INT("batch_size", CYAML_FLAG_OPTIONAL, RDyOutputSection, batch_size),
@@ -974,7 +974,7 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
   }
 
   // validate output options
-  if (config->output.format != OUTPUT_NONE || config->output.step_interval > 0 || config->output.time_interval > 0) {
+  if (config->output.format != OUTPUT_NONE || config->output.output_interval > 0 || config->output.time_interval > 0) {
     config->output.enable           = PETSC_TRUE;
     config->output.prev_output_time = -1.0;
   } else {
@@ -983,9 +983,9 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
 
   if (config->output.enable) {
     PetscCheck((config->output.format != OUTPUT_NONE), comm, PETSC_ERR_USER, "Output requested, but the format is not specified.");
-    PetscCheck(!(config->output.step_interval == 0 && config->output.time_interval == 0), comm, PETSC_ERR_USER,
-               "Output requested, but neither step_interval nor time_interval specified.");
-    PetscCheck((config->output.step_interval >= 0), comm, PETSC_ERR_USER, "Output step interval must be specified as a positive number of steps.");
+    PetscCheck(!(config->output.output_interval == 0 && config->output.time_interval == 0), comm, PETSC_ERR_USER,
+               "Output requested, but neither output_interval nor time_interval specified.");
+    PetscCheck((config->output.output_interval >= 0), comm, PETSC_ERR_USER, "Output step interval must be specified as a positive number of steps.");
     PetscCheck((config->output.time_interval >= 0), comm, PETSC_ERR_USER, "Output time interval must be specified as a positive number of steps.");
     PetscCheck((config->output.batch_size == 0) || (config->output.format != OUTPUT_BINARY), comm, PETSC_ERR_USER,
                "Binary output does not support output batching");
@@ -1194,10 +1194,10 @@ static PetscErrorCode SetAdditionalOptions(RDy rdy) {
   //--------
 
   // set the solution monitoring interval (except for XDMF, which does its own thing)
-  if ((rdy->config.output.step_interval > 0) && (rdy->config.output.format != OUTPUT_XDMF)) {
+  if ((rdy->config.output.output_interval > 0) && (rdy->config.output.format != OUTPUT_XDMF)) {
     PetscCall(PetscOptionsHasName(NULL, NULL, "-ts_monitor_solution_interval", &has_param));
     if (!has_param) {
-      snprintf(value, VALUE_LEN, "%" PetscInt_FMT "", rdy->config.output.step_interval);
+      snprintf(value, VALUE_LEN, "%" PetscInt_FMT "", rdy->config.output.output_interval);
       PetscOptionsSetValue(NULL, "-ts_monitor_solution_interval", value);
     }
   }
@@ -1243,10 +1243,10 @@ static PetscErrorCode SetAdditionalOptions(RDy rdy) {
   }
 
   // set the solution monitoring interval (except for XDMF, which does its own thing)
-  if ((rdy->config.output.step_interval > 0) && (rdy->config.output.format != OUTPUT_XDMF)) {
+  if ((rdy->config.output.output_interval > 0) && (rdy->config.output.format != OUTPUT_XDMF)) {
     PetscCall(PetscOptionsHasName(NULL, NULL, "-ts_monitor_solution_interval", &has_param));
     if (!has_param) {
-      snprintf(value, VALUE_LEN, "%" PetscInt_FMT, rdy->config.output.step_interval);
+      snprintf(value, VALUE_LEN, "%" PetscInt_FMT, rdy->config.output.output_interval);
       PetscOptionsSetValue(NULL, "-ts_monitor_solution_interval", value);
     }
   }

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -234,9 +234,14 @@ static const cyaml_schema_field_t restart_fields_schema[] = {
 // output section
 // ---------------
 // output:
+//   directory: <output-directory>
+//   fields: <list-of-output-fields>
 //   format: <binary|xdmf|cgns>
-//   interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
+//   step_interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
 //   batch_size: <number-of-steps-stored-in-each-output-file> # default: 1
+//   time_series:
+//     boundary_fluxes: <number-of-steps-between-flux-dumps>
+//   separate_grid_file: <true|false>
 
 // mapping of strings to file formats
 static const cyaml_strval_t output_file_formats[] = {
@@ -244,6 +249,11 @@ static const cyaml_strval_t output_file_formats[] = {
     {"binary", OUTPUT_BINARY},
     {"xdmf",   OUTPUT_XDMF  },
     {"cgns",   OUTPUT_CGNS  },
+};
+
+// a single selected output field entry
+static const cyaml_schema_value_t output_field_schema = {
+	CYAML_VALUE_STRING(CYAML_FLAG_POINTER, char, 0, CYAML_UNLIMITED),
 };
 
 // mapping of time_series fields to members of RDyTimeSeries
@@ -255,6 +265,8 @@ static const cyaml_schema_field_t output_time_series_fields_schema[] = {
 // mapping of output fields to members of RDyOutputSection
 static const cyaml_schema_field_t output_fields_schema[] = {
     CYAML_FIELD_STRING("directory", CYAML_FLAG_OPTIONAL, RDyOutputSection, directory, 0),
+    CYAML_FIELD_SEQUENCE("fields", CYAML_FLAG_OPTIONAL | CYAML_FLAG_POINTER, RDyOutputSection, fields, &output_field_schema, 0, MAX_NUM_MATERIALS),
+    CYAML_FIELD_ENUM("fields", CYAML_FLAG_OPTIONAL, RDyOutputSection, format, output_file_formats, CYAML_ARRAY_LEN(output_file_formats)),
     CYAML_FIELD_ENUM("format", CYAML_FLAG_OPTIONAL, RDyOutputSection, format, output_file_formats, CYAML_ARRAY_LEN(output_file_formats)),
     CYAML_FIELD_INT("step_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, step_interval),
     CYAML_FIELD_INT("time_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_interval),


### PR DESCRIPTION
This PR adds a `fields` subsection to the `output` section of the input specfication. This new subsection contains a list of desired output field components for the solution and diagnostic vectors. By default, all components of the solution vector appear in output. More details appear in the documentation.

I made a few adjustments to logic to try to make this less confusing, and I've tested it a little bit, but I welcome more of that! :-)

Closes #294