### PR TITLE
Implemented basic observations

### DIFF
--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -416,10 +416,6 @@ output:
       interval: 10
       sites:
         cells: [0, 1, 2, 3, 4, 5, 6]
-      quantities:
-        - Height
-        - MomentumX
-        - MomentumY
       time_sampling:
         instantaneous: true
 ```
@@ -462,24 +458,19 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
   is useful for inspection and possibly even coupling. Parameters:
     * `boundary_fluxes`: the interval (number of timesteps) at which boundary
       flux data is appended to a tab-delimited text file
-    * `observations`: allows the specification of **observation sites**: points in space at which
-      desired quantities are sampled and possible averaged. When using the RDycore driver,
-      observations are written to a tab-delimited text file. Parameters include:
+    * `observations`: allows the specification of **observation sites**--points in space at which
+      the components of the solution vector are sampled and possibly averaged. When using the
+      RDycore driver, observations are written to a tab-delimited text file. Parameters include:
         * `interval`: the number of steps between recorded observations
-        * `sites`: the mechanism by which observation sites are specified. There
-          are two ways to specify observation sites:
+        * `sites`: the mechanism by which observation sites are specified. There are two ways to
+          specify observation sites:
             * `cells`: accepts a list of **natural cell IDs** within the mesh, defining an
               observation site at the center of each given cell.
             * `file`: accepts a text file specifying **natural cell IDs** in the line-oriented
               format described below.
-        * `quantities`: a list of quantities to be sampled at each observation site.
-          Available options are
-            * `Height`: water height $h$
-            * `MomentumX`: $x$ momentum $hu$
-            * `MomentumY`: $y$ velocity $hv$
-        * `sampling`: the method by which each quantity is sampled at each observation site.
+        * `sampling`: the method by which each component is sampled at each observation site.
             * `instantaneous` (`false` by default) can be set to `true` to sample instantaneous
-              values of the desired quantities at each site.
+              values at each site.
             * Time averaging is not yet supported, but we plan to add an `averaged` parameter in
               the future.
 

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -36,6 +36,8 @@ broad categories:
       files or to the terminal
     * [output](input.md#output): configures simulation output, including
       scalable I/O formats and related parameters
+    * [observations](input.md#observations): configures observation points that
+      can report instantaneous or time-averaged quantities
     * [checkpoint](input.md#checkpoint): configures simulation checkpoint
       files, which are used for restarts
     * [restart](input.md#restart): configures whether a simulation is restarted
@@ -395,6 +397,47 @@ RDycore. The parameters that define these discretizations are
 * `riemann`: determines the form of the Riemann solver used for the shallow
   water equations. Can be `roe` for the Roe solver or `hllc` for the HLLC solver.
   Currently, only `roe` is implemented. Default value: `roe`
+
+## `observations`
+
+```yaml
+observations:
+  sites:
+    domain: false
+    cells: [0, 1, 2, 3, 4, 5, 6]
+  quantities:
+    - Height
+    - MomentumX
+    - MomentumY
+  sampling:
+    instantaneous: true
+    averaged: 0.083 # 1 month, in units of years (specified in time section)
+```
+
+The `observations` section allows the specification of **observation sites**:
+points in space at which desired quantities are sampled and possible averaged.
+Parameters include:
+
+* `sites`: the mechanism by which observation sites are determined.
+    * The `domain` parameter (`false` by default) defines an observation site
+      at the center of every cell in the unstructured mesh used by RDycore. This
+      is the easiest way to generate observation sites.
+    * The `cells` parameter accepts a list of global cell IDs within the mesh,
+      defining an observation site at the center of each given cell.
+* `quantities`: a list of quantities to be sampled at each observation site.
+  Available options are
+    * `Height`: water height $h$
+    * `MomentumX`: $x$ momentum $hu$
+    * `MomentumY`: $y$ velocity $hv$
+* `sampling`: the method by which each quantity is sampled at each observation
+  site.
+    * `instantaneous` (`false` by default) can be set to `true` to sample
+      instantaneous values of the desired quantities at each site.
+    * `averaged` (off by default) can be set to the desired time interval over
+      which each quantity is averaged at each site. This interval is specified
+      in the units given within the `[time](input.md#time)` section.
+
+When using the RDycore driver, output is written to a tab-delimited text file.
 
 ## `output`
 

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -403,27 +403,25 @@ RDycore. The parameters that define these discretizations are
 ```yaml
 observations:
   sites:
-    domain: false
     cells: [0, 1, 2, 3, 4, 5, 6]
   quantities:
     - Height
     - MomentumX
     - MomentumY
-  sampling:
+  time_sampling:
     instantaneous: true
-    averaged: 0.083 # 1 month, in units of years (specified in time section)
 ```
 
 The `observations` section allows the specification of **observation sites**:
 points in space at which desired quantities are sampled and possible averaged.
 Parameters include:
 
-* `sites`: the mechanism by which observation sites are determined.
-    * The `domain` parameter (`false` by default) defines an observation site
-      at the center of every cell in the unstructured mesh used by RDycore. This
-      is the easiest way to generate observation sites.
-    * The `cells` parameter accepts a list of global cell IDs within the mesh,
-      defining an observation site at the center of each given cell.
+* `sites`: the mechanism by which observation sites are specified. There
+  are two ways to specify observation sites:
+    * `cells`: accepts a list of global cell IDs within the mesh, defining an
+      observation site at the center of each given cell.
+    * `file`: accepts a text file specifying *natural cell IDs* in the line-
+      oriented format described below.
 * `quantities`: a list of quantities to be sampled at each observation site.
   Available options are
     * `Height`: water height $h$
@@ -433,9 +431,19 @@ Parameters include:
   site.
     * `instantaneous` (`false` by default) can be set to `true` to sample
       instantaneous values of the desired quantities at each site.
-    * `averaged` (off by default) can be set to the desired time interval over
-      which each quantity is averaged at each site. This interval is specified
-      in the units given within the `[time](input.md#time)` section.
+    * Time averaging is not yet supported, but we plan to add an `averaged`
+      parameter in the future.
+
+When specifying observation sites in a text file, use the following format:
+
+```
+number_of_observation_cells
+<natural_cell_id_0>
+<natural_cell_id_1>
+<natural_cell_id_2>
+...
+<natural_cell_id_N>
+```
 
 When using the RDycore driver, output is written to a tab-delimited text file.
 

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -413,6 +413,7 @@ output:
   time_series:
     boundary_fluxes: 10
     observations:
+      interval: 10
       sites:
         cells: [0, 1, 2, 3, 4, 5, 6]
       quantities:
@@ -464,12 +465,13 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
     * `observations`: allows the specification of **observation sites**: points in space at which
       desired quantities are sampled and possible averaged. When using the RDycore driver,
       observations are written to a tab-delimited text file. Parameters include:
+        * `interval`: the number of steps between recorded observations
         * `sites`: the mechanism by which observation sites are specified. There
           are two ways to specify observation sites:
-            * `cells`: accepts a list of global cell IDs within the mesh, defining an
+            * `cells`: accepts a list of **natural cell IDs** within the mesh, defining an
               observation site at the center of each given cell.
-            * `file`: accepts a text file specifying *natural cell IDs* in the line-
-              oriented format described below.
+            * `file`: accepts a text file specifying **natural cell IDs** in the line-oriented
+              format described below.
         * `quantities`: a list of quantities to be sampled at each observation site.
           Available options are
             * `Height`: water height $h$

--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -36,8 +36,6 @@ broad categories:
       files or to the terminal
     * [output](input.md#output): configures simulation output, including
       scalable I/O formats and related parameters
-    * [observations](input.md#observations): configures observation points that
-      can report instantaneous or time-averaged quantities
     * [checkpoint](input.md#checkpoint): configures simulation checkpoint
       files, which are used for restarts
     * [restart](input.md#restart): configures whether a simulation is restarted
@@ -398,55 +396,6 @@ RDycore. The parameters that define these discretizations are
   water equations. Can be `roe` for the Roe solver or `hllc` for the HLLC solver.
   Currently, only `roe` is implemented. Default value: `roe`
 
-## `observations`
-
-```yaml
-observations:
-  sites:
-    cells: [0, 1, 2, 3, 4, 5, 6]
-  quantities:
-    - Height
-    - MomentumX
-    - MomentumY
-  time_sampling:
-    instantaneous: true
-```
-
-The `observations` section allows the specification of **observation sites**:
-points in space at which desired quantities are sampled and possible averaged.
-Parameters include:
-
-* `sites`: the mechanism by which observation sites are specified. There
-  are two ways to specify observation sites:
-    * `cells`: accepts a list of global cell IDs within the mesh, defining an
-      observation site at the center of each given cell.
-    * `file`: accepts a text file specifying *natural cell IDs* in the line-
-      oriented format described below.
-* `quantities`: a list of quantities to be sampled at each observation site.
-  Available options are
-    * `Height`: water height $h$
-    * `MomentumX`: $x$ momentum $hu$
-    * `MomentumY`: $y$ velocity $hv$
-* `sampling`: the method by which each quantity is sampled at each observation
-  site.
-    * `instantaneous` (`false` by default) can be set to `true` to sample
-      instantaneous values of the desired quantities at each site.
-    * Time averaging is not yet supported, but we plan to add an `averaged`
-      parameter in the future.
-
-When specifying observation sites in a text file, use the following format:
-
-```
-number_of_observation_cells
-<natural_cell_id_0>
-<natural_cell_id_1>
-<natural_cell_id_2>
-...
-<natural_cell_id_N>
-```
-
-When using the RDycore driver, output is written to a tab-delimited text file.
-
 ## `output`
 
 ```yaml
@@ -460,9 +409,18 @@ output:
   format: xdmf
   output_interval: 100
   batch_size: 1
+  separate_grid_file: true
   time_series:
     boundary_fluxes: 10
-  separate_grid_file: true
+    observations:
+      sites:
+        cells: [0, 1, 2, 3, 4, 5, 6]
+      quantities:
+        - Height
+        - MomentumX
+        - MomentumY
+      time_sampling:
+        instantaneous: true
 ```
 
 The `output` section controls simulation output, including visualization and
@@ -496,14 +454,43 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
 * `batch_size`: the number of time steps for which output data is stored in a
   single file. For example, a batch size of 10 specifies that each individual
   output file stores data for 10 time steps. Default value: 1
-* `time_series`: this subsection controls time series simulation output, which
-  is useful for inspection and possibly even coupling. Currently, this subsection
-  has only one parameter:
-    * `boundary_fluxes`: the interval (number of timesteps) at which boundary
-      flux data is appended to a tab-delimited text file
 * `separate_grid_file`: this optional parameter specifies whether the grid is
   written to its own file, which saves space in very large simulations. Currently,
   this option is only supported for `xdmf` output.
+* `time_series`: this subsection controls time series simulation output, which
+  is useful for inspection and possibly even coupling. Parameters:
+    * `boundary_fluxes`: the interval (number of timesteps) at which boundary
+      flux data is appended to a tab-delimited text file
+    * `observations`: allows the specification of **observation sites**: points in space at which
+      desired quantities are sampled and possible averaged. When using the RDycore driver,
+      observations are written to a tab-delimited text file. Parameters include:
+        * `sites`: the mechanism by which observation sites are specified. There
+          are two ways to specify observation sites:
+            * `cells`: accepts a list of global cell IDs within the mesh, defining an
+              observation site at the center of each given cell.
+            * `file`: accepts a text file specifying *natural cell IDs* in the line-
+              oriented format described below.
+        * `quantities`: a list of quantities to be sampled at each observation site.
+          Available options are
+            * `Height`: water height $h$
+            * `MomentumX`: $x$ momentum $hu$
+            * `MomentumY`: $y$ velocity $hv$
+        * `sampling`: the method by which each quantity is sampled at each observation site.
+            * `instantaneous` (`false` by default) can be set to `true` to sample instantaneous
+              values of the desired quantities at each site.
+            * Time averaging is not yet supported, but we plan to add an `averaged` parameter in
+              the future.
+
+When specifying observation sites in a text file, use the following format:
+
+```
+number_of_observation_cells
+<natural_cell_id_0>
+<natural_cell_id_1>
+<natural_cell_id_2>
+...
+<natural_cell_id_N>
+```
 
 ## `physics`
 

--- a/driver/main.c
+++ b/driver/main.c
@@ -1659,11 +1659,6 @@ PetscErrorCode DestroyBoundaryConditionDataset(BoundaryCondition *bc_dataset) {
 }
 
 int main(int argc, char *argv[]) {
-  // print out our version information
-  const char *rdy_build_config;
-  PetscCall(RDyGetBuildConfiguration(&rdy_build_config));
-  fprintf(stderr, "%s", rdy_build_config);
-
   // print usage info if no arguments given
   if (argc < 2) {
     usage(argv[0]);
@@ -1672,6 +1667,11 @@ int main(int argc, char *argv[]) {
 
   // initialize subsystems
   PetscCall(RDyInit(argc, argv, help_str));
+
+  // print out our version information
+  const char *rdy_build_config;
+  PetscCall(RDyGetBuildConfiguration(&rdy_build_config));
+  PetscFPrintf(PETSC_COMM_WORLD, stderr, "%s", rdy_build_config);
 
   if (strcmp(argv[1], "-help")) {  // if given a config file
     // create rdycore and set it up with the given file

--- a/driver/tests/swe_roe/ex2b.yaml
+++ b/driver/tests/swe_roe/ex2b.yaml
@@ -29,6 +29,12 @@ output:
   batch_size: 20
   time_series:
     boundary_fluxes: 10
+    observations:
+      interval: 10
+      sites:
+        cells: [0, 1, 2]
+      time_sampling:
+        instantaneous: true
 
 grid:
   file: planar_dam_10x5.msh

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -27,8 +27,7 @@
 // the maximum number of materials that can be defined for a simulation
 #define MAX_NUM_MATERIALS 32
 
-// the maximum number of flow/sediment/salinity conditions that can be defined for a
-// simulation
+// the maximum number of flow/sediment/salinity conditions that can be defined for a simulation
 #define MAX_NUM_CONDITIONS 32
 
 // The data structures below are intermediate representations of the sections
@@ -158,9 +157,29 @@ typedef struct {
   PetscBool reinitialize;              // PETSC_TRUE resets simulation time to 0
 } RDyRestartSection;
 
-// ---------------
+// --------------------
+// observations section
+// --------------------
+
+typedef struct {
+  int     *cells;
+  PetscInt cells_count;
+} RDyObservationSites;
+
+typedef struct {
+  PetscBool instantaneous;
+} RDyObservationTimeSampling;
+
+typedef struct {
+  RDyObservationSites        sites;
+  const char               **quantities;
+  PetscInt                   quantities_count;
+  RDyObservationTimeSampling time_sampling;
+} RDyObservationsSection;
+
+// --------------
 // output section
-// ---------------
+// --------------
 
 // output file formats
 typedef enum { OUTPUT_NONE = 0, OUTPUT_BINARY, OUTPUT_XDMF, OUTPUT_CGNS } RDyOutputFormat;
@@ -356,10 +375,11 @@ typedef struct {
   RDyNumericsSection numerics;
   RDyTimeSection     time;
 
-  RDyLoggingSection    logging;
-  RDyCheckpointSection checkpoint;
-  RDyRestartSection    restart;
-  RDyOutputSection     output;
+  RDyLoggingSection      logging;
+  RDyCheckpointSection   checkpoint;
+  RDyRestartSection      restart;
+  RDyObservationsSection observations;
+  RDyOutputSection       output;
 
   RDyGridSection grid;
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -177,8 +177,6 @@ typedef struct {
 typedef struct {
   PetscInt                   interval;
   RDyObservationSites        sites;
-  const char               **quantities;
-  PetscInt                   quantities_count;
   RDyObservationTimeSampling time_sampling;
 } RDyObservationsSection;
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -157,10 +157,14 @@ typedef struct {
   PetscBool reinitialize;              // PETSC_TRUE resets simulation time to 0
 } RDyRestartSection;
 
-// --------------------
-// observations section
-// --------------------
+// --------------
+// output section
+// --------------
 
+// output file formats
+typedef enum { OUTPUT_NONE = 0, OUTPUT_BINARY, OUTPUT_XDMF, OUTPUT_CGNS } RDyOutputFormat;
+
+// observations
 typedef struct {
   int     *cells;
   PetscInt cells_count;
@@ -171,22 +175,17 @@ typedef struct {
 } RDyObservationTimeSampling;
 
 typedef struct {
+  PetscInt                   interval;
   RDyObservationSites        sites;
   const char               **quantities;
   PetscInt                   quantities_count;
   RDyObservationTimeSampling time_sampling;
 } RDyObservationsSection;
 
-// --------------
-// output section
-// --------------
-
-// output file formats
-typedef enum { OUTPUT_NONE = 0, OUTPUT_BINARY, OUTPUT_XDMF, OUTPUT_CGNS } RDyOutputFormat;
-
 // time series output interval parameters appended to files
 typedef struct {
-  PetscInt boundary_fluxes;  // written to "boundary_fluxes.dat" [steps between outputs]
+  PetscInt               boundary_fluxes;  // written to "boundary_fluxes.dat" [steps between outputs]
+  RDyObservationsSection observations;
 } RDyTimeSeries;
 
 // all output parameters
@@ -375,11 +374,10 @@ typedef struct {
   RDyNumericsSection numerics;
   RDyTimeSection     time;
 
-  RDyLoggingSection      logging;
-  RDyCheckpointSection   checkpoint;
-  RDyRestartSection      restart;
-  RDyObservationsSection observations;
-  RDyOutputSection       output;
+  RDyLoggingSection    logging;
+  RDyCheckpointSection checkpoint;
+  RDyRestartSection    restart;
+  RDyOutputSection     output;
 
   RDyGridSection grid;
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -166,8 +166,8 @@ typedef enum { OUTPUT_NONE = 0, OUTPUT_BINARY, OUTPUT_XDMF, OUTPUT_CGNS } RDyOut
 
 // observations
 typedef struct {
-  int     *cells;
-  PetscInt cells_count;
+  PetscInt *cells;
+  PetscInt  cells_count;
 } RDyObservationSites;
 
 typedef struct {

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -45,10 +45,14 @@ typedef struct {
 
   // observations recorded at specific sites
   struct {
-    // serial vector containing observation sites on local process
-    Vec u_sites;
-    // VecScatter governing observation site vector scatters
-    VecScatter scatter_sites;
+    struct {
+      // fixed x, y, z coordinates of observation sites
+      PetscReal *x, *y, *z;
+      // serial vector containing observation sites on local process
+      Vec u;
+    } sites;
+    // VecScatter governing observation site vector scatter
+    VecScatter scatter_u;
     // last step for which observations data was written
     PetscInt last_step;
   } observations;

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -46,9 +46,11 @@ typedef struct {
   // observations recorded at specific sites
   struct {
     struct {
+      // global indices corresponding to observation site natural cell indices in input
+      PetscInt *global_indices;
       // fixed x, y, z coordinates of observation sites
       PetscReal *x, *y, *z;
-      // serial vector containing observation sites on local process
+      // serial vector containing data for all observation sites on process 0
       Vec u;
     } sites;
     // VecScatter governing observation site vector scatter

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -22,8 +22,6 @@ PETSC_INTERN PetscErrorCode GetCeedVecType(VecType *);
 // This type keeps track of accumulated time series data appended periodically
 // to files.
 typedef struct {
-  // last step for which time series data was written
-  PetscInt last_step;
   // fluxes on boundary edges
   struct {
     // per-process numbers of local boundary edges on which fluxes are accumulated
@@ -40,7 +38,20 @@ typedef struct {
       PetscReal x_momentum;
       PetscReal y_momentum;
     } * fluxes;
+
+    // last step for which boundary flux time series data was written
+    PetscInt last_step;
   } boundary_fluxes;
+
+  // observations recorded at specific sites
+  struct {
+    // serial vector containing observation sites on local process
+    Vec u_sites;
+    // VecScatter governing observation site vector scatters
+    VecScatter scatter_sites;
+    // last step for which observations data was written
+    PetscInt last_step;
+  } observations;
 } RDyTimeSeriesData;
 
 // This type serves as a "virtual table" containing function pointers that

--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -55,6 +55,8 @@ typedef struct {
     } sites;
     // VecScatter governing observation site vector scatter
     VecScatter scatter_u;
+    // accumulation vector for averaged observations or for instantaneous values
+    Vec accum_u;
     // last step for which observations data was written
     PetscInt last_step;
   } observations;

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -1177,9 +1177,9 @@ PetscErrorCode PauseIfRequested(RDy rdy) {
     PetscBool pause = PETSC_FALSE;
     PetscCall(PetscOptionsGetBool(NULL, NULL, "-pause", &pause, NULL));
     if (pause) {
-      pid_t pid          = getpid();  // local process ID
-      char  hostname[65] = {0};       // local hostname (64 characters + null terminator)
-      gethostname(hostname, 64);
+      pid_t pid                        = getpid();  // local process ID
+      char  hostname[MAX_NAME_LEN + 1] = {0};       // local hostname
+      gethostname(hostname, MAX_NAME_LEN);
       PetscFPrintf(rdy->comm, stderr, "Pausing... press Enter to resume.\n");
       if (rdy->nproc > 1) {
         pid_t *pids;

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -230,6 +230,47 @@ static const cyaml_schema_field_t restart_fields_schema[] = {
     CYAML_FIELD_END
 };
 
+// --------------------
+// observations section
+// --------------------
+// observations:
+//   sites:
+//     cells: [0, 1, 2, 3, 4, 5, 6]
+//   quantities:
+//     - Height
+//     - MomentumX
+//     - MomentumY
+//   time_sampling:
+//     instantaneous: true
+
+static const cyaml_schema_value_t observations_sites_cell_entry = {
+	CYAML_VALUE_INT(CYAML_FLAG_DEFAULT, int),
+};
+
+// mapping of sites fields to members of RDyObservationSites
+static const cyaml_schema_field_t observations_sites_fields_schema[] = {
+    CYAML_FIELD_SEQUENCE("cells", CYAML_FLAG_OPTIONAL | CYAML_FLAG_POINTER, RDyObservationSites, cells, &observations_sites_cell_entry, 0, CYAML_UNLIMITED),
+    CYAML_FIELD_END
+};
+
+static const cyaml_schema_value_t observations_quantity_entry = {
+	CYAML_VALUE_INT(CYAML_FLAG_DEFAULT, int),
+};
+
+// mapping of sites fields to members of RDyObservationSites
+static const cyaml_schema_field_t observations_time_sampling_fields_schema[] = {
+    CYAML_FIELD_BOOL("instantaneous", CYAML_FLAG_OPTIONAL, RDyObservationTimeSampling, instantaneous),
+    CYAML_FIELD_END
+};
+
+// mapping of observation fields to members of RDyObservationsSection
+static const cyaml_schema_field_t observations_fields_schema[] = {
+    CYAML_FIELD_MAPPING("sites", CYAML_FLAG_DEFAULT, RDyObservationsSection, sites, observations_sites_fields_schema),
+    CYAML_FIELD_SEQUENCE("quantities", CYAML_FLAG_DEFAULT, RDyObservationsSection, quantities, &observations_quantity_entry, 0, CYAML_UNLIMITED),
+    CYAML_FIELD_MAPPING("time_sampling", CYAML_FLAG_DEFAULT, RDyObservationsSection, time_sampling, observations_time_sampling_fields_schema),
+    CYAML_FIELD_END
+};
+
 // ---------------
 // output section
 // ---------------
@@ -683,6 +724,7 @@ static const cyaml_schema_field_t config_fields_schema[] = {
     CYAML_FIELD_MAPPING("logging", CYAML_FLAG_OPTIONAL, RDyConfig, logging, logging_fields_schema),
     CYAML_FIELD_MAPPING("checkpoint", CYAML_FLAG_OPTIONAL, RDyConfig, checkpoint, checkpoint_fields_schema),
     CYAML_FIELD_MAPPING("restart", CYAML_FLAG_OPTIONAL, RDyConfig, restart, restart_fields_schema),
+    CYAML_FIELD_MAPPING("observations", CYAML_FLAG_OPTIONAL, RDyConfig, observations, observations_fields_schema),
     CYAML_FIELD_MAPPING("output", CYAML_FLAG_OPTIONAL, RDyConfig, output, output_fields_schema),
     CYAML_FIELD_MAPPING("grid", CYAML_FLAG_DEFAULT, RDyConfig, grid, grid_fields_schema),
     CYAML_FIELD_SEQUENCE_COUNT("surface_composition", CYAML_FLAG_DEFAULT, RDyConfig, surface_composition, num_material_assignments, &surface_composition_entry, 0, MAX_NUM_REGIONS),

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -264,10 +264,6 @@ static const cyaml_schema_field_t observations_sites_fields_schema[] = {
     CYAML_FIELD_END
 };
 
-static const cyaml_schema_value_t observations_quantity_entry = {
-	CYAML_VALUE_INT(CYAML_FLAG_DEFAULT, int),
-};
-
 // mapping of sites fields to members of RDyObservationSites
 static const cyaml_schema_field_t observations_time_sampling_fields_schema[] = {
     CYAML_FIELD_BOOL("instantaneous", CYAML_FLAG_OPTIONAL, RDyObservationTimeSampling, instantaneous),
@@ -278,7 +274,6 @@ static const cyaml_schema_field_t observations_time_sampling_fields_schema[] = {
 static const cyaml_schema_field_t observations_fields_schema[] = {
     CYAML_FIELD_INT("interval", CYAML_FLAG_DEFAULT, RDyObservationsSection, interval),
     CYAML_FIELD_MAPPING("sites", CYAML_FLAG_DEFAULT, RDyObservationsSection, sites, observations_sites_fields_schema),
-    CYAML_FIELD_SEQUENCE("quantities", CYAML_FLAG_DEFAULT, RDyObservationsSection, quantities, &observations_quantity_entry, 0, CYAML_UNLIMITED),
     CYAML_FIELD_MAPPING("time_sampling", CYAML_FLAG_DEFAULT, RDyObservationsSection, time_sampling, observations_time_sampling_fields_schema),
     CYAML_FIELD_END
 };

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -243,6 +243,7 @@ static const cyaml_schema_field_t restart_fields_schema[] = {
 //   time_series:
 //     boundary_fluxes: <number-of-steps-between-flux-dumps>
 //     observations:
+//       interval: 10
 //       sites:
 //         cells: [0, 1, 2, 3, 4, 5, 6]
 //       quantities:
@@ -275,6 +276,7 @@ static const cyaml_schema_field_t observations_time_sampling_fields_schema[] = {
 
 // mapping of observation fields to members of RDyObservationsSection
 static const cyaml_schema_field_t observations_fields_schema[] = {
+    CYAML_FIELD_INT("interval", CYAML_FLAG_DEFAULT, RDyObservationsSection, interval),
     CYAML_FIELD_MAPPING("sites", CYAML_FLAG_DEFAULT, RDyObservationsSection, sites, observations_sites_fields_schema),
     CYAML_FIELD_SEQUENCE("quantities", CYAML_FLAG_DEFAULT, RDyObservationsSection, quantities, &observations_quantity_entry, 0, CYAML_UNLIMITED),
     CYAML_FIELD_MAPPING("time_sampling", CYAML_FLAG_DEFAULT, RDyObservationsSection, time_sampling, observations_time_sampling_fields_schema),

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -230,18 +230,28 @@ static const cyaml_schema_field_t restart_fields_schema[] = {
     CYAML_FIELD_END
 };
 
-// --------------------
-// observations section
-// --------------------
-// observations:
-//   sites:
-//     cells: [0, 1, 2, 3, 4, 5, 6]
-//   quantities:
-//     - Height
-//     - MomentumX
-//     - MomentumY
-//   time_sampling:
-//     instantaneous: true
+// ---------------
+// output section
+// ---------------
+// output:
+//   directory: <output-directory>
+//   fields: <list-of-output-fields>
+//   format: <binary|xdmf|cgns>
+//   output_interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
+//   batch_size: <number-of-steps-stored-in-each-output-file> # default: 1
+//   separate_grid_file: <true|false>
+//   time_series:
+//     boundary_fluxes: <number-of-steps-between-flux-dumps>
+//     observations:
+//       sites:
+//         cells: [0, 1, 2, 3, 4, 5, 6]
+//       quantities:
+//         - Height
+//         - MomentumX
+//         - MomentumY
+//       time_sampling:
+//         instantaneous: true
+
 
 static const cyaml_schema_value_t observations_sites_cell_entry = {
 	CYAML_VALUE_INT(CYAML_FLAG_DEFAULT, int),
@@ -271,19 +281,6 @@ static const cyaml_schema_field_t observations_fields_schema[] = {
     CYAML_FIELD_END
 };
 
-// ---------------
-// output section
-// ---------------
-// output:
-//   directory: <output-directory>
-//   fields: <list-of-output-fields>
-//   format: <binary|xdmf|cgns>
-//   output_interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
-//   batch_size: <number-of-steps-stored-in-each-output-file> # default: 1
-//   time_series:
-//     boundary_fluxes: <number-of-steps-between-flux-dumps>
-//   separate_grid_file: <true|false>
-
 // mapping of strings to file formats
 static const cyaml_strval_t output_file_formats[] = {
     {"none",   OUTPUT_NONE},
@@ -300,6 +297,7 @@ static const cyaml_schema_value_t output_field_schema = {
 // mapping of time_series fields to members of RDyTimeSeries
 static const cyaml_schema_field_t output_time_series_fields_schema[] = {
     CYAML_FIELD_INT("boundary_fluxes", CYAML_FLAG_DEFAULT, RDyTimeSeries, boundary_fluxes),
+    CYAML_FIELD_MAPPING("observations", CYAML_FLAG_OPTIONAL, RDyTimeSeries, observations, observations_fields_schema),
     CYAML_FIELD_END
 };
 
@@ -313,8 +311,8 @@ static const cyaml_schema_field_t output_fields_schema[] = {
     CYAML_FIELD_INT("time_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_interval),
     CYAML_FIELD_ENUM("time_unit", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_unit, time_units, CYAML_ARRAY_LEN(time_units)),
     CYAML_FIELD_INT("batch_size", CYAML_FLAG_OPTIONAL, RDyOutputSection, batch_size),
-    CYAML_FIELD_MAPPING("time_series", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_series, output_time_series_fields_schema),
     CYAML_FIELD_BOOL("separate_grid_file", CYAML_FLAG_OPTIONAL, RDyOutputSection, separate_grid_file),
+    CYAML_FIELD_MAPPING("time_series", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_series, output_time_series_fields_schema),
     CYAML_FIELD_END
 };
 
@@ -724,7 +722,6 @@ static const cyaml_schema_field_t config_fields_schema[] = {
     CYAML_FIELD_MAPPING("logging", CYAML_FLAG_OPTIONAL, RDyConfig, logging, logging_fields_schema),
     CYAML_FIELD_MAPPING("checkpoint", CYAML_FLAG_OPTIONAL, RDyConfig, checkpoint, checkpoint_fields_schema),
     CYAML_FIELD_MAPPING("restart", CYAML_FLAG_OPTIONAL, RDyConfig, restart, restart_fields_schema),
-    CYAML_FIELD_MAPPING("observations", CYAML_FLAG_OPTIONAL, RDyConfig, observations, observations_fields_schema),
     CYAML_FIELD_MAPPING("output", CYAML_FLAG_OPTIONAL, RDyConfig, output, output_fields_schema),
     CYAML_FIELD_MAPPING("grid", CYAML_FLAG_DEFAULT, RDyConfig, grid, grid_fields_schema),
     CYAML_FIELD_SEQUENCE_COUNT("surface_composition", CYAML_FLAG_DEFAULT, RDyConfig, surface_composition, num_material_assignments, &surface_composition_entry, 0, MAX_NUM_REGIONS),


### PR DESCRIPTION
This PR adds basic support for (instantaneous) observations at cells. These observations record all components of the solution vector at observation "sites". These records can be used to construct diagnostics.

At length, we'll add support for time-averaged observations, and records of any secondary variables needed to reconstruct more involved diagnostics.

Closes #295 