### PR TITLE
Fix CEED Qfunctions

### DIFF
--- a/src/sediment/sediment_ceed_impl.h
+++ b/src/sediment/sediment_ceed_impl.h
@@ -82,6 +82,14 @@ CEED_QFUNCTION_HELPER int SedimentFlux(void *ctx, CeedInt Q, const CeedScalar *c
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
       courant_num[1][i] = amax * geom[3][i] * dt;
+    } else {
+      for (CeedInt j = 0; j < tot_ndof; j++) {
+        cell_L[j][i]     = 0.0;
+        cell_R[j][i]     = 0.0;
+        accum_flux[j][i] = 0.0;
+      }
+      courant_num[0][i] = 0.0;
+      courant_num[1][i] = 0.0;
     }
   }
   return 0;
@@ -129,6 +137,13 @@ CEED_QFUNCTION_HELPER int SedimentBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, c
         accum_flux[j][i] = flux[j];
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
+    } else {
+      for (CeedInt j = 0; j < tot_ndof; j++) {
+        cell_L[j][i]     = 0.0;
+        accum_flux[j][i] = 0.0;
+      }
+      courant_num[0][i] = 0.0;
+      courant_num[1][i] = 0.0;
     }
   }
   return 0;
@@ -178,6 +193,11 @@ CEED_QFUNCTION_HELPER int SedimentBoundaryFlux_Reflecting(void *ctx, CeedInt Q, 
         cell_L[j][i] = flux[j] * geom[2][i];
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
+    } else {
+      for (CeedInt j = 0; j < tot_ndof; j++) {
+        cell_L[j][i] = 0.0;
+      }
+      courant_num[0][i] = 0.0;
     }
   }
   return 0;

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -80,6 +80,14 @@ CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const 
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
       courant_num[1][i] = amax * geom[3][i] * dt;
+    } else {
+      for (CeedInt j = 0; j < 3; j++) {
+        cell_L[j][i]     = 0.0;
+        cell_R[j][i]     = 0.0;
+        accum_flux[j][i] = 0.0;
+      }
+      courant_num[0][i] = 0.0;
+      courant_num[1][i] = 0.0;
     }
   }
   return 0;
@@ -120,6 +128,12 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, const 
         accum_flux[j][i] = flux[j];
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
+    } else {
+      for (CeedInt j = 0; j < 3; j++) {
+        cell_L[j][i]     = 0.0;
+        accum_flux[j][i] = 0.0;
+      }
+      courant_num[0][i] = 0.0;
     }
   }
   return 0;
@@ -160,6 +174,11 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Reflecting(void *ctx, CeedInt Q, const
         cell_L[j][i] = flux[j] * geom[2][i];
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
+    } else {
+      for (CeedInt j = 0; j < 3; j++) {
+        cell_L[j][i] = 0.0;
+      }
+      courant_num[0][i] = 0.0;
     }
   }
   return 0;
@@ -203,6 +222,12 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Outflow(void *ctx, CeedInt Q, const Ce
         accum_flux[j][i] = flux[j];
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
+    } else {
+      for (CeedInt j = 0; j < 3; j++) {
+        cell_L[j][i]     = 0.0;
+        accum_flux[j][i] = 0.0;
+      }
+      courant_num[0][i] = 0.0;
     }
   }
   return 0;


### PR DESCRIPTION
Instead of leaving the output CEED vectors uninitialized when the water height is
below a prescribed threshold, a zero set is assigned.