### PR TITLE
This PR removes the `separate_grid_file` parameter.

### DIFF
--- a/docs/common/input.md
+++ b/docs/common/input.md
@@ -409,7 +409,6 @@ output:
   format: xdmf
   output_interval: 100
   batch_size: 1
-  separate_grid_file: true
   time_series:
     boundary_fluxes: 10
     observations:
@@ -443,17 +442,14 @@ time series data (**but excluding checkpoint data**). Relevant parameters are
 * `format`: the format of the output written. Available options are
     * `none`: no output is written. This is the default value.
     * `binary`: output is written using PETSc's binary data format
-    * `xdmf`: output is written to the [XDMF](https://xdmf.org/index.php/XDMF_Model_and_Format) format
-    * `cgns`: output is written to the [CFD General Notation System (CGNS)](https://cgns.github.io/) format
+    * `xdmf`: output is written in the [XDMF](https://xdmf.org/index.php/XDMF_Model_and_Format) format
+    * `cgns`: output is written in the [CFD General Notation System (CGNS)](https://cgns.github.io/) format
 * `output_interval`: the number of time steps between output dumps. Default value: 0 (no output)
 * `time_interval`: the temporal frequency between output dumps. The is an integer with a minimum value of 1 second. Default value: 0 (no output)
 * `time_unit`: units of temporal frequency output.
 * `batch_size`: the number of time steps for which output data is stored in a
   single file. For example, a batch size of 10 specifies that each individual
   output file stores data for 10 time steps. Default value: 1
-* `separate_grid_file`: this optional parameter specifies whether the grid is
-  written to its own file, which saves space in very large simulations. Currently,
-  this option is only supported for `xdmf` output.
 * `time_series`: this subsection controls time series simulation output, which
   is useful for inspection and possibly even coupling. Parameters:
     * `boundary_fluxes`: the interval (number of timesteps) at which boundary

--- a/driver/tests/swe_roe/Simons.OceanDirichletBC.yaml
+++ b/driver/tests/swe_roe/Simons.OceanDirichletBC.yaml
@@ -22,7 +22,6 @@ output:
   batch_size: 20
   time_series:
     boundary_fluxes: 1
-  separate_grid_file: true
 
 grid:
   file: simons.exo

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -199,7 +199,6 @@ typedef struct {
   PetscInt        batch_size;                     // number of timesteps per output file (if available)
   RDyTimeSeries   time_series;                    // time series appended to text (.dat) files
   PetscReal       prev_output_time;               // previous time at which output was written
-  PetscBool       separate_grid_file;             // whether grid is written to a separate file
 } RDyOutputSection;
 
 // ------------

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -239,7 +239,6 @@ static const cyaml_schema_field_t restart_fields_schema[] = {
 //   format: <binary|xdmf|cgns>
 //   output_interval: <number-of-steps-between-output-dumps> # default: 0 (no output)
 //   batch_size: <number-of-steps-stored-in-each-output-file> # default: 1
-//   separate_grid_file: <true|false>
 //   time_series:
 //     boundary_fluxes: <number-of-steps-between-flux-dumps>
 //     observations:
@@ -308,7 +307,6 @@ static const cyaml_schema_field_t output_fields_schema[] = {
     CYAML_FIELD_INT("time_interval", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_interval),
     CYAML_FIELD_ENUM("time_unit", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_unit, time_units, CYAML_ARRAY_LEN(time_units)),
     CYAML_FIELD_INT("batch_size", CYAML_FLAG_OPTIONAL, RDyOutputSection, batch_size),
-    CYAML_FIELD_BOOL("separate_grid_file", CYAML_FLAG_OPTIONAL, RDyOutputSection, separate_grid_file),
     CYAML_FIELD_MAPPING("time_series", CYAML_FLAG_OPTIONAL, RDyOutputSection, time_series, output_time_series_fields_schema),
     CYAML_FIELD_END
 };
@@ -1040,8 +1038,6 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
     if ((config->output.batch_size == 0) && (config->output.format != OUTPUT_NONE) && config->output.format != OUTPUT_BINARY) {
       config->output.batch_size = 1;
     }
-    PetscCheck(!config->output.separate_grid_file || (config->output.format == OUTPUT_XDMF), comm, PETSC_ERR_USER,
-               "separate_grid_file option is only supported for XDMF output");
 
     if (config->output.time_interval) {
       if (!coupling_interval_was_specified) config->time.coupling_interval = config->output.time_interval * 1.0;


### PR DESCRIPTION
We've been using this parameter to request that the computational grid be written to its own file, separate separate from field data. After this change, RDycore will always write this separate XDMF file, since there's no reason to do otherwise.