### PR TITLE
CMAKE_MODULE_PATH is now set in an E3SM-compatible way.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(NUM_MATERIAL_PROPERTIES    1)
 math(EXPR MAX_NUM_FIELD_COMPONENTS "3 + ${MAX_NUM_SEDIMENT_CLASSES}")
 
 # CMake files live in the cmake/ directory.
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 # Use a specific version of clang-format.
 set(CLANG_FORMAT_VERSION 14)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,11 +23,11 @@ set(RDYCORE_C_SOURCE_FILES
 )
 
 # generate <physics>_ceed.h headers inside each CEED operator implementation
-# directory so the JIT compilers have everything they need 
+# directory so the JIT compilers have everything they need
 foreach(physics swe;sediment)
   string(TOUPPER ${physics} PHYSICS)
   configure_file(
-    ${CMAKE_SOURCE_DIR}/include/private/physics_ceed.h.in
+    ${CMAKE_CURRENT_SOURCE_DIR}/../include/private/physics_ceed.h.in
     ${CMAKE_CURRENT_SOURCE_DIR}/${physics}/${physics}_ceed.h
     @ONLY
   )


### PR DESCRIPTION
This is an easy one! :-)

With this change, E3SM is able to find and use RDycore-supplied CMake functions and macros.