### PR TITLE
Renames `rdycore` CMake library target to `rdycore_c`.

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -3,21 +3,21 @@ add_executable(rdycore_exe
   main.c
 )
 set_target_properties(rdycore_exe PROPERTIES OUTPUT_NAME rdycore)
-target_link_libraries(rdycore_exe PRIVATE rdycore)
+target_link_libraries(rdycore_exe PRIVATE rdycore_c)
 
 # MMS C driver
 add_executable(rdycore_mms
   mms.c
 )
 set_target_properties(rdycore_mms PROPERTIES OUTPUT_NAME rdycore_mms)
-target_link_libraries(rdycore_mms PRIVATE rdycore)
+target_link_libraries(rdycore_mms PRIVATE rdycore_c)
 
 # AMR C driver
 add_executable(rdycore_amr
   amr.c
 )
 set_target_properties(rdycore_amr PROPERTIES OUTPUT_NAME rdycore_amr)
-target_link_libraries(rdycore_amr PRIVATE rdycore)
+target_link_libraries(rdycore_amr PRIVATE rdycore_c)
 
 install(
   TARGETS rdycore_exe rdycore_mms rdycore_amr

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,17 +33,17 @@ foreach(physics swe;sediment)
   )
 endforeach()
 
-add_library(rdycore ${RDYCORE_C_SOURCE_FILES})
-target_link_libraries(rdycore cyaml yaml muparser hdf5 ceed ${SYSTEM_LIBRARIES})
-add_dependencies(rdycore cyaml yaml)
+add_library(rdycore_c ${RDYCORE_C_SOURCE_FILES})
+target_link_libraries(rdycore_c cyaml yaml muparser hdf5 ceed ${SYSTEM_LIBRARIES})
+add_dependencies(rdycore_c cyaml yaml)
 
 install(
-  TARGETS rdycore
+  TARGETS rdycore_c
   DESTINATION lib
 )
 if (ENABLE_SANITIZERS)
-  target_compile_options(rdycore PUBLIC -fsanitize=${SANITIZERS})
-  target_link_options(rdycore PUBLIC -fsanitize=${SANITIZERS})
+  target_compile_options(rdycore_c PUBLIC -fsanitize=${SANITIZERS})
+  target_link_options(rdycore_c PUBLIC -fsanitize=${SANITIZERS})
 endif()
 
 # Unit tests for the main library

--- a/src/f90-mod/CMakeLists.txt
+++ b/src/f90-mod/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
   add_library(rdycore_f90
     ${RDYCORE_F90_SOURCE_FILES}
   )
-  target_link_libraries(rdycore_f90 rdycore cyaml yaml ceed ${SYSTEM_LIBRARIES})
+  target_link_libraries(rdycore_f90 rdycore_c cyaml yaml ceed ${SYSTEM_LIBRARIES})
 endif()
 target_include_directories(rdycore_f90 PUBLIC ${PROJECT_BINARY_DIR}/include/private)
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -11,7 +11,7 @@ foreach(exe_name
         test_yaml_input)
   set(exe_source ${exe_name}.c)
   add_executable(${exe_name} ${exe_source})
-  target_link_libraries(${exe_name} PRIVATE rdycore cmocka)
+  target_link_libraries(${exe_name} PRIVATE rdycore_c cmocka)
   foreach(np 1 2) # test on 1 and 2 processes
     set(test_name ${exe_name}_np_${np})
     add_test(${test_name} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${CMAKE_CURRENT_BINARY_DIR}/${exe_name})


### PR DESCRIPTION
This name change allows us to build the RDycore library within E3SM's CMake build system without interfering with the corresponding `rdycore` component.