### PR TITLE
Removes a target-related conflict between EAMxx and RDycore in E3SM cases.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,8 +251,10 @@ endif()
 #--------------------
 
 # Add a "make memcheck" target that runs Valgrind on all tests (Linux only).
-include(add_memcheck_target)
-add_memcheck_target()
+if (NOT TARGET memcheck) # only add if not already present
+  include(add_memcheck_target)
+  add_memcheck_target()
+endif()
 
 # Create the following targets for checking code formatting:
 # make format-c       <-- reformats C code to conform to desired style


### PR DESCRIPTION
Specifically: we now check to see whether the `memcheck` CMake target exists before creating it.

@bishtgautam , I've verified that the case you mentioned now builds successfully when the RDycore submodule contains this change, so after this is merged we can fast-forward the RDycore submodule in the appropriate RDycore/E3SM branch.