### PR TITLE
fix dry cells conditions at boundary

### DIFF
--- a/src/sediment/sediment_ceed_impl.h
+++ b/src/sediment/sediment_ceed_impl.h
@@ -125,7 +125,7 @@ CEED_QFUNCTION_HELPER int SedimentBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, c
       qL.hci[j] = q_L[flow_ndof + j][i];
       qR.hci[j] = q_R[flow_ndof + j][i];
     }
-    if (qL.h > tiny_h) {
+    if (qL.h > tiny_h || qR.h > tiny_h) {
       CeedScalar flux[MAX_NUM_FIELD_COMPONENTS], amax;
       switch (flux_type) {
         case RIEMANN_FLUX_ROE:

--- a/src/swe/swe_ceed_impl.h
+++ b/src/swe/swe_ceed_impl.h
@@ -116,7 +116,7 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, const 
   for (CeedInt i = 0; i < Q; i++) {
     SWEState qL = {q_L[0][i], q_L[1][i], q_L[2][i]};
     SWEState qR = {q_R[0][i], q_R[1][i], q_R[2][i]};
-    if (qL.h > tiny_h) {
+    if (qL.h > tiny_h || qR.h > tiny_h) {
       CeedScalar flux[3], amax;
       switch (flux_type) {
         case RIEMANN_FLUX_ROE:


### PR DESCRIPTION
Fix bug for the dry cells at boundary cells. 
Run simulation with dry initial condition and ocean boundary condition, and the water can inundate from boundary condition into the domain. 