### PR TITLE
Creating an interface for setting up operators with greater flexibility for time integration

### DIFF
--- a/include/private/rdyoperatorimpl.h
+++ b/include/private/rdyoperatorimpl.h
@@ -63,13 +63,9 @@ PETSC_INTERN PetscErrorCode PetscOperatorFieldsGet(PetscOperatorFields, const ch
 // This operator type has a context that stores physics-specific data and two
 // operations:
 //
-// 1. F(context, dt, u, udot, F), which computes the function F representing the the left-hand side
-//    of the equation F(t, u, udot) = G(t, u)
-// 2. G(context, dt, u, G), which computes the global right-hand-side vector
-//    G by applying the operator to the local vector u over the timestep dt
-// 3. dF(context, dt, u, dF), which computes the Jacobian of F
-// 4. dG(context, dt, u, dF), which computes the Jacobian of G
-// 5. destroy(context), which deallocates all resources related to the context
+// 1. apply(context, dt, u, F), which updates the global right-hand-side vector
+//    F by applying the operator to the local vector u over the timestep dt
+// 2. destroy(context), which deallocates all resources related to the context
 //
 // The PetscOperator resembles the CeedOperator type, which allows us to
 // structure our PETSc-backed physics similarly to CEED-backed physics. Because
@@ -81,7 +77,7 @@ struct _p_PetscOperator {
   void               *context;
   PetscOperatorFields fields;
   PetscBool           is_composite;
-  PetscErrorCode (*rhs)(void *, PetscOperatorFields, PetscReal, Vec, Vec);
+  PetscErrorCode (*apply)(void *, PetscOperatorFields, PetscReal, Vec, Vec);
   PetscErrorCode (*destroy)(void *);
 };
 
@@ -143,9 +139,14 @@ typedef struct Operator {
   // CEED/PETSc backends
   union {
     struct {
-      // CEED flux and source operators (each composed of sub-operators, see
-      // CreateOperator in src/operator.c)
-      CeedOperator flux, source;
+      // CEED operator for F(t, u, du/dt) -- reduces to du/dt for explicit time integration
+      CeedOperator F;
+
+      // CEED flux and source operators for the function G(t, u), each composed of sub-operators.
+      // See CreateOperator in src/operator.c.
+      struct {
+        CeedOperator flux, source;
+      } G;
 
       // timestep last set on operators
       PetscReal dt;
@@ -159,9 +160,14 @@ typedef struct Operator {
 
     // PETSc operator data
     struct {
-      // PETSc composite operators with sub-operators identical in structure to
-      // the CEED composite operators above
-      PetscOperator flux, source;
+      // PETsc operator for F(t, u, du/dt) -- reduces to du/dt for explicit time integration
+      PetscOperator F;
+
+      // PETsc flux and source operators for the function G(t, u), each composed of sub-operators.
+      // See CreateOperator in src/operator.c.
+      struct {
+        PetscOperator flux, source;
+      } G;
 
       // array of Dirichlet boundary value vectors, indexed by boundary
       Vec *boundary_values;
@@ -192,9 +198,10 @@ PETSC_INTERN PetscErrorCode CreateOperator(RDyConfig *, DM, RDyMesh *, PetscInt,
 PETSC_INTERN PetscErrorCode DestroyOperator(Operator **);
 
 // operator functions for interacting with PETSc's TS solver (RDy passed as context)
-PETSC_INTERN PetscErrorCode OperatorIFunction(TS, PetscReal, Vec, Vec, Vec, void*);
-PETSC_INTERN PetscErrorCode OperatorRHSFunction(TS, PetscReal, Vec, Vec, void*);
-PETSC_INTERN PetscErrorCode OperatorIJacobian(TS, PetscReal, Vec, Vec, PetscReal, Mat, Mat, void*);
+PETSC_INTERN PetscErrorCode OperatorIFunction(TS, PetscReal, Vec, Vec, Vec, void *);
+PETSC_INTERN PetscErrorCode OperatorIJacobian(TS, PetscReal, Vec, Vec, PetscReal, Mat, Mat, void *);
+PETSC_INTERN PetscErrorCode OperatorRHSFunction(TS, PetscReal, Vec, Vec, void *);
+PETSC_INTERN PetscErrorCode OperatorRHSJacobian(TS, PetscReal, Vec, Mat, Mat, void *);
 
 //--------------------------------------------------
 // CEED/PETSc Flux and Source Operator Constructors

--- a/include/private/rdyoperatorimpl.h
+++ b/include/private/rdyoperatorimpl.h
@@ -63,9 +63,13 @@ PETSC_INTERN PetscErrorCode PetscOperatorFieldsGet(PetscOperatorFields, const ch
 // This operator type has a context that stores physics-specific data and two
 // operations:
 //
-// 1. apply(context, dt, u, F), which updates the global right-hand-side vector
-//    F by applying the operator to the local vector u over the timestep dt
-// 2. destroy(context), which deallocates all resources related to the context
+// 1. F(context, dt, u, udot, F), which computes the function F representing the the left-hand side
+//    of the equation F(t, u, udot) = G(t, u)
+// 2. G(context, dt, u, G), which computes the global right-hand-side vector
+//    G by applying the operator to the local vector u over the timestep dt
+// 3. dF(context, dt, u, dF), which computes the Jacobian of F
+// 4. dG(context, dt, u, dF), which computes the Jacobian of G
+// 5. destroy(context), which deallocates all resources related to the context
 //
 // The PetscOperator resembles the CeedOperator type, which allows us to
 // structure our PETSc-backed physics similarly to CEED-backed physics. Because
@@ -77,7 +81,7 @@ struct _p_PetscOperator {
   void               *context;
   PetscOperatorFields fields;
   PetscBool           is_composite;
-  PetscErrorCode (*apply)(void *, PetscOperatorFields, PetscReal, Vec, Vec);
+  PetscErrorCode (*rhs)(void *, PetscOperatorFields, PetscReal, Vec, Vec);
   PetscErrorCode (*destroy)(void *);
 };
 
@@ -93,11 +97,22 @@ PETSC_INTERN PetscErrorCode PetscCompositeOperatorAddSub(PetscOperator, PetscOpe
 // Operator
 //----------
 
-// This type and its related functions define an interface for creating a
-// nonlinear operator F that computes the time derivative du/dt of a local
-// solution vector u at time t:
+// This type and its related functions define an interface for solving a nonlinear equation for a
+// time-dependent solution u(t) for which the equation
 //
-// F(u, t) -> du/dt
+// F(t, u, du/dt) = G(t, u)
+//
+// holds, where F is in general a differential-algebraic expression involving u and its time
+// derivative, and G is a "right-hand side function".
+//
+// In the case of explicit time integration, F(t, u, du/dt) reduces to du/dt itself, and the
+// nonlinear system becomes a system of ordinary differential equations:
+//
+// du/dt = G(t, u),
+//
+// evaluated at appropriate quadrature points.
+//
+// These two parts are then evaluated according to the selected time integration method.
 //
 // There are two families of operator implementations:
 // 1. CEED implementation: a composite CeedOperator with interior and boundary
@@ -176,8 +191,10 @@ PETSC_INTERN PetscErrorCode CreateOperator(RDyConfig *, DM, RDyMesh *, PetscInt,
                                            Operator **);
 PETSC_INTERN PetscErrorCode DestroyOperator(Operator **);
 
-// operator timestepping function
-PETSC_INTERN PetscErrorCode ApplyOperator(Operator *, PetscReal, Vec, Vec);
+// operator functions for interacting with PETSc's TS solver (RDy passed as context)
+PETSC_INTERN PetscErrorCode OperatorIFunction(TS, PetscReal, Vec, Vec, Vec, void*);
+PETSC_INTERN PetscErrorCode OperatorRHSFunction(TS, PetscReal, Vec, Vec, void*);
+PETSC_INTERN PetscErrorCode OperatorIJacobian(TS, PetscReal, Vec, Vec, PetscReal, Mat, Mat, void*);
 
 //--------------------------------------------------
 // CEED/PETSc Flux and Source Operator Constructors

--- a/include/private/rdyoperatorimpl.h
+++ b/include/private/rdyoperatorimpl.h
@@ -138,15 +138,18 @@ typedef struct Operator {
 
   // CEED/PETSc backends
   union {
+    // CEED
     struct {
-      // CEED operator for F(t, u, du/dt) -- reduces to du/dt for explicit time integration
-      CeedOperator F;
+      // Operators for F(t, u, du/dt) and its Jacobian dF. F reduces to du/dt for explicit time
+      // integration.
+      CeedOperator F, dF;
 
-      // CEED flux and source operators for the function G(t, u), each composed of sub-operators.
-      // See CreateOperator in src/operator.c.
+      // Flux and source operators for the function G(t, u) and its Jacobian dG. Each is composed of
+      // sub-operators.
       struct {
         CeedOperator flux, source;
       } G;
+      CeedOperator dG;
 
       // timestep last set on operators
       PetscReal dt;
@@ -160,14 +163,16 @@ typedef struct Operator {
 
     // PETSc operator data
     struct {
-      // PETsc operator for F(t, u, du/dt) -- reduces to du/dt for explicit time integration
-      PetscOperator F;
+      // Operators for F(t, u, du/dt) and its Jacobian dF. F reduces to du/dt for explicit time
+      // integration.
+      PetscOperator F, dF;
 
-      // PETsc flux and source operators for the function G(t, u), each composed of sub-operators.
-      // See CreateOperator in src/operator.c.
+      // Flux and source operators for the function G(t, u) and its Jacobian dG. Each is composed of
+      // sub-operators.
       struct {
         PetscOperator flux, source;
       } G;
+      PetscOperator dG;
 
       // array of Dirichlet boundary value vectors, indexed by boundary
       Vec *boundary_values;
@@ -201,7 +206,6 @@ PETSC_INTERN PetscErrorCode DestroyOperator(Operator **);
 PETSC_INTERN PetscErrorCode OperatorIFunction(TS, PetscReal, Vec, Vec, Vec, void *);
 PETSC_INTERN PetscErrorCode OperatorIJacobian(TS, PetscReal, Vec, Vec, PetscReal, Mat, Mat, void *);
 PETSC_INTERN PetscErrorCode OperatorRHSFunction(TS, PetscReal, Vec, Vec, void *);
-PETSC_INTERN PetscErrorCode OperatorRHSJacobian(TS, PetscReal, Vec, Mat, Mat, void *);
 
 //--------------------------------------------------
 // CEED/PETSc Flux and Source Operator Constructors
@@ -209,9 +213,14 @@ PETSC_INTERN PetscErrorCode OperatorRHSJacobian(TS, PetscReal, Vec, Mat, Mat, vo
 
 PETSC_INTERN PetscErrorCode CreateCeedFluxOperator(RDyConfig *, RDyMesh *, PetscInt, RDyBoundary *, RDyCondition *, CeedOperator *);
 PETSC_INTERN PetscErrorCode CreateCeedSourceOperator(RDyConfig *, RDyMesh *, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateCeedIOperator(RDyConfig *, RDyMesh *, PetscInt, RDyBoundary *, RDyCondition *, CeedOperator *);
+PETSC_INTERN PetscErrorCode CreateCeedIJacobian(RDyConfig *, RDyMesh *, PetscInt, RDyBoundary *, RDyCondition *, CeedOperator *);
+
 PETSC_INTERN PetscErrorCode CreatePetscFluxOperator(RDyConfig *, RDyMesh *, PetscInt, RDyBoundary *, RDyCondition *, Vec *, Vec *,
                                                     OperatorDiagnostics *, PetscOperator *);
 PETSC_INTERN PetscErrorCode CreatePetscSourceOperator(RDyConfig *, RDyMesh *, Vec, Vec, PetscOperator *);
+PETSC_INTERN PetscErrorCode CreatePetscIOperator(RDyConfig *, RDyMesh *, PetscInt, RDyBoundary *, RDyCondition *, PetscOperator *);
+PETSC_INTERN PetscErrorCode CreatePetscIJacobian(RDyConfig *, RDyMesh *, PetscInt, RDyBoundary *, RDyCondition *, PetscOperator *);
 
 //----------------------
 // Operator Data Access

--- a/src/operator.c
+++ b/src/operator.c
@@ -152,9 +152,9 @@ static PetscErrorCode AddOperatorFluxDivergence(Operator *op) {
 
     // add this vector to all source sub-operators
     CeedInt num_source_suboperators;
-    PetscCallCEED(CeedCompositeOperatorGetNumSub(op->ceed.source, &num_source_suboperators));
+    PetscCallCEED(CeedCompositeOperatorGetNumSub(op->ceed.G.source, &num_source_suboperators));
     CeedOperator *source_suboperators;
-    PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.source, &source_suboperators));
+    PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.G.source, &source_suboperators));
     for (CeedInt i = 0; i < num_source_suboperators; ++i) {
       PetscCallCEED(CeedOperatorSetField(source_suboperators[i], "riemannf", flux_div_restriction, CEED_BASIS_NONE, op->ceed.flux_divergence));
     }
@@ -162,7 +162,7 @@ static PetscErrorCode AddOperatorFluxDivergence(Operator *op) {
     // clean up (the suboperators keep references to restrictions and vectors)
     PetscCallCEED(CeedElemRestrictionDestroy(&flux_div_restriction));
   } else {
-    PetscCall(PetscOperatorSetField(op->petsc.source, "riemannf", op->flux_divergence));
+    PetscCall(PetscOperatorSetField(op->petsc.G.source, "riemannf", op->flux_divergence));
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);
@@ -218,14 +218,14 @@ PetscErrorCode CreateOperator(RDyConfig *config, DM domain_dm, RDyMesh *domain_m
     }
 
     PetscCall(CreateCeedFluxOperator((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
-                                     (*operator)->boundary_conditions, &(*operator)->ceed.flux));
-    PetscCall(CreateCeedSourceOperator((*operator)->config, (*operator)->mesh, &(*operator)->ceed.source));
+                                     (*operator)->boundary_conditions, &(*operator)->ceed.G.flux));
+    PetscCall(CreateCeedSourceOperator((*operator)->config, (*operator)->mesh, &(*operator)->ceed.G.source));
   } else {
     PetscCall(CreatePetscFluxOperator((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
                                       (*operator)->boundary_conditions, (*operator)->petsc.boundary_values, (*operator)->petsc.boundary_fluxes,
-                                      &(*operator)->diagnostics, &(*operator)->petsc.flux));
+                                      &(*operator)->diagnostics, &(*operator)->petsc.G.flux));
     PetscCall(CreatePetscSourceOperator((*operator)->config, (*operator)->mesh, (*operator)->petsc.external_sources,
-                                        (*operator)->petsc.material_properties, &(*operator)->petsc.source));
+                                        (*operator)->petsc.material_properties, &(*operator)->petsc.G.source));
   }
 
   // set up our flux divergence vector(s)
@@ -248,8 +248,8 @@ PetscErrorCode DestroyOperator(Operator **op) {
   PetscBool ceed_enabled = CeedEnabled();
 
   if (ceed_enabled) {
-    PetscCallCEED(CeedOperatorDestroy(&((*op)->ceed.flux)));
-    PetscCallCEED(CeedOperatorDestroy(&((*op)->ceed.source)));
+    PetscCallCEED(CeedOperatorDestroy(&((*op)->ceed.G.flux)));
+    PetscCallCEED(CeedOperatorDestroy(&((*op)->ceed.G.source)));
     PetscCallCEED(CeedVectorDestroy(&((*op)->ceed.u_local)));
     PetscCallCEED(CeedVectorDestroy(&((*op)->ceed.rhs)));
     PetscCallCEED(CeedVectorDestroy(&((*op)->ceed.sources)));
@@ -265,8 +265,8 @@ PetscErrorCode DestroyOperator(Operator **op) {
     PetscFree((*op)->petsc.boundary_fluxes);
     PetscCall(VecDestroy(&(*op)->petsc.external_sources));
     PetscCall(VecDestroy(&(*op)->petsc.material_properties));
-    PetscCall(PetscOperatorDestroy(&(*op)->petsc.flux));
-    PetscCall(PetscOperatorDestroy(&(*op)->petsc.source));
+    PetscCall(PetscOperatorDestroy(&(*op)->petsc.G.flux));
+    PetscCall(PetscOperatorDestroy(&(*op)->petsc.G.source));
   }
   if ((*op)->flux_divergence) {
     PetscCall(VecDestroy(&(*op)->flux_divergence));
@@ -292,10 +292,10 @@ static PetscErrorCode ApplyCeedOperator(Operator *op, PetscReal dt, Vec u_local,
     op->ceed.dt = dt;
 
     CeedContextFieldLabel label;
-    PetscCallCEED(CeedOperatorGetContextFieldLabel(op->ceed.flux, "time step", &label));
-    PetscCallCEED(CeedOperatorSetContextDouble(op->ceed.flux, label, &op->ceed.dt));
-    PetscCallCEED(CeedOperatorGetContextFieldLabel(op->ceed.source, "time step", &label));
-    PetscCallCEED(CeedOperatorSetContextDouble(op->ceed.source, label, &op->ceed.dt));
+    PetscCallCEED(CeedOperatorGetContextFieldLabel(op->ceed.G.flux, "time step", &label));
+    PetscCallCEED(CeedOperatorSetContextDouble(op->ceed.G.flux, label, &op->ceed.dt));
+    PetscCallCEED(CeedOperatorGetContextFieldLabel(op->ceed.G.source, "time step", &label));
+    PetscCallCEED(CeedOperatorSetContextDouble(op->ceed.G.source, label, &op->ceed.dt));
   }
 
   //------------------
@@ -319,7 +319,7 @@ static PetscErrorCode ApplyCeedOperator(Operator *op, PetscReal dt, Vec u_local,
     // apply the flux operator, computing flux divergences
     PetscCall(PetscLogEventBegin(RDY_CeedOperatorApply_, u_local, f_global, 0, 0));
     PetscCall(PetscLogGpuTimeBegin());
-    PetscCallCEED(CeedOperatorApply(op->ceed.flux, op->ceed.u_local, op->ceed.rhs, CEED_REQUEST_IMMEDIATE));
+    PetscCallCEED(CeedOperatorApply(op->ceed.G.flux, op->ceed.u_local, op->ceed.rhs, CEED_REQUEST_IMMEDIATE));
     PetscCall(PetscLogGpuTimeEnd());
     PetscCall(PetscLogEventEnd(RDY_CeedOperatorApply_, u_local, f_global, 0, 0));
 
@@ -364,7 +364,7 @@ static PetscErrorCode ApplyCeedOperator(Operator *op, PetscReal dt, Vec u_local,
     // apply the source operator(s)
     PetscCall(PetscLogEventBegin(RDY_CeedOperatorApply_, u_local, f_global, 0, 0));
     PetscCall(PetscLogGpuTimeBegin());
-    PetscCallCEED(CeedOperatorApply(op->ceed.source, op->ceed.u_local, op->ceed.sources, CEED_REQUEST_IMMEDIATE));
+    PetscCallCEED(CeedOperatorApply(op->ceed.G.source, op->ceed.u_local, op->ceed.sources, CEED_REQUEST_IMMEDIATE));
     PetscCall(PetscLogGpuTimeEnd());
     PetscCall(PetscLogEventEnd(RDY_CeedOperatorApply_, u_local, f_global, 0, 0));
 
@@ -392,24 +392,57 @@ static PetscErrorCode ApplyPetscOperator(Operator *op, PetscReal dt, Vec u_local
   PetscFunctionBegin;
 
   // apply the composite PETSc flux operators
-  PetscCall(PetscOperatorApply(op->petsc.flux, dt, u_local, f_global));
+  PetscCall(PetscOperatorApply(op->petsc.G.flux, dt, u_local, f_global));
 
   // copy the flux divergences out of f_global for use with the source operator
   PetscCall(VecCopy(f_global, op->flux_divergence));
 
   // apply the composite PETSc source operators
-  PetscCall(PetscOperatorApply(op->petsc.source, dt, u_local, f_global));
+  PetscCall(PetscOperatorApply(op->petsc.G.source, dt, u_local, f_global));
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// Evaluates the right-hand-side of the operator, usable with TS via TSSetRHSFunction.
+/// Evaluates the left hand side of the operator F(t, u, du/dt). Use with TS via TSSetIFunction.
+/// @param [in]    ts   the solver
+/// @param [in]    t    the simulation time [seconds]
+/// @param [in]    u    the global solution vector at time t
+/// @param [in]    dudt the time derivative of the global solution vector at time t
+/// @param [out]   F    the global right hand side vector to be evaluated at time t
+/// @param [inout] ctx the RDy instance for the operator
+PetscErrorCode OperatorIFunction(TS ts, PetscReal t, Vec u, Vec dudt, Vec F, void *ctx) {
+  PetscFunctionBegin;
+
+  RDy rdy = ctx;
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Evaluates the jacobian of the left hand side of the operator, dF(t, u, du/dt). Use with TS via
+/// TSSetIJacobian.
+/// @param [in]    ts    the solver
+/// @param [in]    t     the simulation time [seconds]
+/// @param [in]    u     the global solution vector at time t
+/// @param [in]    dudt  the time derivative of the global solution vector at time t
+/// @param [in]    sigma the "shift" coefficient preceding the time derivative term of the jacobian
+/// @param [out]   dF  the matrix that stores the jacobian of the left hand side
+/// @param [out]   P   the matrix from which to construct the preconditioner (usually same as dF)
+/// @param [inout] ctx the RDy instance for the operator
+PetscErrorCode OperatorIJacobian(TS ts, PetscReal dt, Vec u, Vec dudt, PetscReal sigma, Mat dG, Mat P, void *ctx) {
+  PetscFunctionBegin;
+
+  RDy rdy = ctx;
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Evaluates the right hand side of the operator G(t, u). Use with TS via TSSetRHSFunction.
 /// @param [in]    ts  the solver
 /// @param [in]    t   the simulation time [seconds]
-/// @param [in]    U   the global solution vector at time t
-/// @param [out]   F   the global right hand side vector to be evaluated at time t
-/// @param [inout] ctx a pointer to the operator representing the system being solved
-PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec U, Vec F, void *ctx) {
+/// @param [in]    u   the global solution vector at time t
+/// @param [out]   G   the global right hand side vector to be evaluated at time t
+/// @param [inout] ctx the RDy instance for the operator
+PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec u, Vec G, void *ctx) {
   PetscFunctionBegin;
 
   RDy       rdy = ctx;
@@ -419,105 +452,32 @@ PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec U, Vec F, void *ctx) 
   PetscScalar dt;
   PetscCall(TSGetTimeStep(ts, &dt));
 
-  PetscCall(VecZeroEntries(F));
+  PetscCall(VecZeroEntries(G));
 
-  // populate the local U vector
-  PetscCall(DMGlobalToLocalBegin(dm, U, INSERT_VALUES, rdy->u_local));
-  PetscCall(DMGlobalToLocalEnd(dm, U, INSERT_VALUES, rdy->u_local));
+  // populate the local u vector
+  PetscCall(DMGlobalToLocalBegin(dm, u, INSERT_VALUES, rdy->u_local));
+  PetscCall(DMGlobalToLocalEnd(dm, u, INSERT_VALUES, rdy->u_local));
 
   PetscCall(ResetOperatorDiagnostics(op));
 
   // compute the right hand side
-  PetscCall(ApplyOperator(op, dt, rdy->u_local, F));
-  if (0) {
-    PetscInt nstep;
-    PetscCall(TSGetStepNumber(ts, &nstep));
-
-    const char *backend = (CeedEnabled()) ? "ceed" : "petsc";
-    char        file[PETSC_MAX_PATH_LEN];
-    snprintf(file, PETSC_MAX_PATH_LEN, "F_%s_nstep%" PetscInt_FMT "_N%d.dat", backend, nstep, rdy->nproc);
-
-    PetscViewer viewer;
-    PetscCall(PetscViewerASCIIOpen(PETSC_COMM_WORLD, file, &viewer));
-    PetscCall(VecView(F, viewer));
-    PetscCall(PetscViewerDestroy(&viewer));
-  }
-
-  // if debug-level logging is enabled, find the latest global maximum Courant number
-  // and log it.
-  if (rdy->config.logging.level >= LOG_DEBUG) {
-    PetscCall(UpdateOperatorDiagnostics(op));
-    OperatorDiagnostics diagnostics;
-    PetscCall(GetOperatorDiagnostics(op, &diagnostics));
-
-    PetscReal time;
-    PetscInt  stepnum;
-    PetscCall(TSGetTime(ts, &time));
-    PetscCall(TSGetStepNumber(ts, &stepnum));
-    const char *units = TimeUnitAsString(rdy->config.time.unit);
-
-    RDyLogDebug(rdy, "[%" PetscInt_FMT "] Time = %f [%s] Max courant number %g", stepnum, ConvertTimeFromSeconds(time, rdy->config.time.unit), units,
-                diagnostics.courant_number.max_courant_num);
-  }
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Applies the operator to a local solution vector, storing the result in the
-/// given global vector.
-/// @param [inout] op       the operator to be applied to the solution vector
-/// @param [dt]    dt       the time step over which the operator is applied
-/// @param [in]    u_local  the local solution vector to which the operator is applied
-/// @param [inout] f_global the global vector storing the result of the application
-static PetscErrorCode ApplyOperator(Operator *op, PetscReal dt, Vec u_local, Vec f_global) {
-  PetscFunctionBegin;
-
   if (CeedEnabled()) {
-    PetscCall(ApplyCeedOperator(op, dt, u_local, f_global));
+    PetscCall(ApplyCeedOperator(op, dt, rdy->u_local, G));
   } else {
-    PetscCall(ApplyPetscOperator(op, dt, u_local, f_global));
+    PetscCall(ApplyPetscOperator(op, dt, rdy->u_local, G));
   }
 
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
-/// Evaluates the right-hand-side of the operator, usable with TS via TSSetRHSFunction.
-/// @param [in]    ts  the solver
-/// @param [in]    t   the simulation time [seconds]
-/// @param [in]    U   the global solution vector at time t
-/// @param [out]   F   the global right hand side vector to be evaluated at time t
-/// @param [inout] ctx a pointer to the operator representing the system being solved
-PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec U, Vec F, void *ctx) {
-  PetscFunctionBegin;
-
-  RDy       rdy = ctx;
-  DM        dm  = rdy->dm;
-  Operator *op  = rdy->operator;
-
-  PetscScalar dt;
-  PetscCall(TSGetTimeStep(ts, &dt));
-
-  PetscCall(VecZeroEntries(F));
-
-  // populate the local U vector
-  PetscCall(DMGlobalToLocalBegin(dm, U, INSERT_VALUES, rdy->u_local));
-  PetscCall(DMGlobalToLocalEnd(dm, U, INSERT_VALUES, rdy->u_local));
-
-  PetscCall(ResetOperatorDiagnostics(op));
-
-  // compute the right hand side
-  PetscCall(ApplyOperator(op, dt, rdy->u_local, F));
   if (0) {
     PetscInt nstep;
     PetscCall(TSGetStepNumber(ts, &nstep));
 
     const char *backend = (CeedEnabled()) ? "ceed" : "petsc";
     char        file[PETSC_MAX_PATH_LEN];
-    snprintf(file, PETSC_MAX_PATH_LEN, "F_%s_nstep%" PetscInt_FMT "_N%d.dat", backend, nstep, rdy->nproc);
+    snprintf(file, PETSC_MAX_PATH_LEN, "G_%s_nstep%" PetscInt_FMT "_N%d.dat", backend, nstep, rdy->nproc);
 
     PetscViewer viewer;
     PetscCall(PetscViewerASCIIOpen(PETSC_COMM_WORLD, file, &viewer));
-    PetscCall(VecView(F, viewer));
+    PetscCall(VecView(G, viewer));
     PetscCall(PetscViewerDestroy(&viewer));
   }
 
@@ -537,6 +497,22 @@ PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec U, Vec F, void *ctx) 
     RDyLogDebug(rdy, "[%" PetscInt_FMT "] Time = %f [%s] Max courant number %g", stepnum, ConvertTimeFromSeconds(time, rdy->config.time.unit), units,
                 diagnostics.courant_number.max_courant_num);
   }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Evaluates the jacobian of the right hand side of the operator, dG(t, u). Use with TS via
+/// TSSetRHSJacobian.
+/// @param [in]    ts  the solver
+/// @param [in]    t   the simulation time [seconds]
+/// @param [in]    u   the global solution vector at time t
+/// @param [out]   dG  the matrix that stores the jacobian of the right hand side
+/// @param [out]   P   the matrix from which to construct the preconditioner (usually same as dG)
+/// @param [inout] ctx the RDy instance for the operator
+PetscErrorCode OperatorRHSJacobian(TS ts, PetscReal dt, Vec u, Mat dG, Mat P, void *ctx) {
+  PetscFunctionBegin;
+
+  RDy rdy = ctx;
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -724,7 +700,7 @@ static PetscErrorCode UpdateCeedCourantNumberDiagnostics(Operator *op) {
   if (CeedEnabled()) {
     // we need to extract the maximum courant number from the operator in the
     // CEED case; in the PETSc case it's already set for this process
-    PetscCall(CeedFindMaxCourantNumber(op->ceed.flux, op->mesh, op->num_boundaries, op->boundaries, comm, courant_num_diags));
+    PetscCall(CeedFindMaxCourantNumber(op->ceed.G.flux, op->mesh, op->num_boundaries, op->boundaries, comm, courant_num_diags));
   }
 
   // reduce the courant diagnostics across all processes
@@ -799,7 +775,7 @@ static PetscErrorCode GetCeedOperatorBoundaryData(Operator *op, RDyBoundary boun
 
   // get the relevant boundary sub-operator
   CeedOperator *sub_ops;
-  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.flux, &sub_ops));
+  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.G.flux, &sub_ops));
   CeedOperator sub_op = sub_ops[1 + boundary.index];
 
   // fetch the relevant vector
@@ -826,7 +802,7 @@ static PetscErrorCode RestoreCeedOperatorBoundaryData(Operator *op, RDyBoundary 
 
   // get the relevant boundary sub-operator
   CeedOperator *sub_ops;
-  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.flux, &sub_ops));
+  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.G.flux, &sub_ops));
   CeedOperator sub_op = sub_ops[1 + boundary.index];
 
   // copy the data in
@@ -991,7 +967,7 @@ static PetscErrorCode GetCeedSourceOperatorRegionData(Operator *op, RDyRegion re
   PetscFunctionBegin;
 
   CeedOperator *sub_ops;
-  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.source, &sub_ops));
+  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.G.source, &sub_ops));
   CeedOperator source_op = sub_ops[0];
 
   // fetch the relevant vector
@@ -1018,7 +994,7 @@ static PetscErrorCode RestoreCeedSourceOperatorRegionData(Operator *op, RDyRegio
   PetscFunctionBegin;
 
   CeedOperator *sub_ops;
-  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.source, &sub_ops));
+  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.G.source, &sub_ops));
   CeedOperator source_op = sub_ops[0];
 
   // copy the data into place
@@ -1187,7 +1163,7 @@ static PetscErrorCode GetCeedSourceOperatorDomainData(Operator *op, const char *
   PetscFunctionBegin;
 
   CeedOperator *sub_ops;
-  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.source, &sub_ops));
+  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.G.source, &sub_ops));
   CeedOperator source_op = sub_ops[0];
 
   // fetch the relevant vector
@@ -1213,7 +1189,7 @@ static PetscErrorCode RestoreCeedSourceOperatorDomainData(Operator *op, const ch
   PetscFunctionBegin;
 
   CeedOperator *sub_ops;
-  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.source, &sub_ops));
+  PetscCallCEED(CeedCompositeOperatorGetSubList(op->ceed.G.source, &sub_ops));
   CeedOperator source_op = sub_ops[0];
 
   // copy the data into place

--- a/src/operator.c
+++ b/src/operator.c
@@ -403,19 +403,139 @@ static PetscErrorCode ApplyPetscOperator(Operator *op, PetscReal dt, Vec u_local
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
+/// Evaluates the right-hand-side of the operator, usable with TS via TSSetRHSFunction.
+/// @param [in]    ts  the solver
+/// @param [in]    t   the simulation time [seconds]
+/// @param [in]    U   the global solution vector at time t
+/// @param [out]   F   the global right hand side vector to be evaluated at time t
+/// @param [inout] ctx a pointer to the operator representing the system being solved
+PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec U, Vec F, void *ctx) {
+  PetscFunctionBegin;
+
+  RDy       rdy = ctx;
+  DM        dm  = rdy->dm;
+  Operator *op  = rdy->operator;
+
+  PetscScalar dt;
+  PetscCall(TSGetTimeStep(ts, &dt));
+
+  PetscCall(VecZeroEntries(F));
+
+  // populate the local U vector
+  PetscCall(DMGlobalToLocalBegin(dm, U, INSERT_VALUES, rdy->u_local));
+  PetscCall(DMGlobalToLocalEnd(dm, U, INSERT_VALUES, rdy->u_local));
+
+  PetscCall(ResetOperatorDiagnostics(op));
+
+  // compute the right hand side
+  PetscCall(ApplyOperator(op, dt, rdy->u_local, F));
+  if (0) {
+    PetscInt nstep;
+    PetscCall(TSGetStepNumber(ts, &nstep));
+
+    const char *backend = (CeedEnabled()) ? "ceed" : "petsc";
+    char        file[PETSC_MAX_PATH_LEN];
+    snprintf(file, PETSC_MAX_PATH_LEN, "F_%s_nstep%" PetscInt_FMT "_N%d.dat", backend, nstep, rdy->nproc);
+
+    PetscViewer viewer;
+    PetscCall(PetscViewerASCIIOpen(PETSC_COMM_WORLD, file, &viewer));
+    PetscCall(VecView(F, viewer));
+    PetscCall(PetscViewerDestroy(&viewer));
+  }
+
+  // if debug-level logging is enabled, find the latest global maximum Courant number
+  // and log it.
+  if (rdy->config.logging.level >= LOG_DEBUG) {
+    PetscCall(UpdateOperatorDiagnostics(op));
+    OperatorDiagnostics diagnostics;
+    PetscCall(GetOperatorDiagnostics(op, &diagnostics));
+
+    PetscReal time;
+    PetscInt  stepnum;
+    PetscCall(TSGetTime(ts, &time));
+    PetscCall(TSGetStepNumber(ts, &stepnum));
+    const char *units = TimeUnitAsString(rdy->config.time.unit);
+
+    RDyLogDebug(rdy, "[%" PetscInt_FMT "] Time = %f [%s] Max courant number %g", stepnum, ConvertTimeFromSeconds(time, rdy->config.time.unit), units,
+                diagnostics.courant_number.max_courant_num);
+  }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 /// Applies the operator to a local solution vector, storing the result in the
 /// given global vector.
 /// @param [inout] op       the operator to be applied to the solution vector
 /// @param [dt]    dt       the time step over which the operator is applied
 /// @param [in]    u_local  the local solution vector to which the operator is applied
 /// @param [inout] f_global the global vector storing the result of the application
-PetscErrorCode ApplyOperator(Operator *op, PetscReal dt, Vec u_local, Vec f_global) {
+static PetscErrorCode ApplyOperator(Operator *op, PetscReal dt, Vec u_local, Vec f_global) {
   PetscFunctionBegin;
 
   if (CeedEnabled()) {
     PetscCall(ApplyCeedOperator(op, dt, u_local, f_global));
   } else {
     PetscCall(ApplyPetscOperator(op, dt, u_local, f_global));
+  }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Evaluates the right-hand-side of the operator, usable with TS via TSSetRHSFunction.
+/// @param [in]    ts  the solver
+/// @param [in]    t   the simulation time [seconds]
+/// @param [in]    U   the global solution vector at time t
+/// @param [out]   F   the global right hand side vector to be evaluated at time t
+/// @param [inout] ctx a pointer to the operator representing the system being solved
+PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec U, Vec F, void *ctx) {
+  PetscFunctionBegin;
+
+  RDy       rdy = ctx;
+  DM        dm  = rdy->dm;
+  Operator *op  = rdy->operator;
+
+  PetscScalar dt;
+  PetscCall(TSGetTimeStep(ts, &dt));
+
+  PetscCall(VecZeroEntries(F));
+
+  // populate the local U vector
+  PetscCall(DMGlobalToLocalBegin(dm, U, INSERT_VALUES, rdy->u_local));
+  PetscCall(DMGlobalToLocalEnd(dm, U, INSERT_VALUES, rdy->u_local));
+
+  PetscCall(ResetOperatorDiagnostics(op));
+
+  // compute the right hand side
+  PetscCall(ApplyOperator(op, dt, rdy->u_local, F));
+  if (0) {
+    PetscInt nstep;
+    PetscCall(TSGetStepNumber(ts, &nstep));
+
+    const char *backend = (CeedEnabled()) ? "ceed" : "petsc";
+    char        file[PETSC_MAX_PATH_LEN];
+    snprintf(file, PETSC_MAX_PATH_LEN, "F_%s_nstep%" PetscInt_FMT "_N%d.dat", backend, nstep, rdy->nproc);
+
+    PetscViewer viewer;
+    PetscCall(PetscViewerASCIIOpen(PETSC_COMM_WORLD, file, &viewer));
+    PetscCall(VecView(F, viewer));
+    PetscCall(PetscViewerDestroy(&viewer));
+  }
+
+  // if debug-level logging is enabled, find the latest global maximum Courant number
+  // and log it.
+  if (rdy->config.logging.level >= LOG_DEBUG) {
+    PetscCall(UpdateOperatorDiagnostics(op));
+    OperatorDiagnostics diagnostics;
+    PetscCall(GetOperatorDiagnostics(op, &diagnostics));
+
+    PetscReal time;
+    PetscInt  stepnum;
+    PetscCall(TSGetTime(ts, &time));
+    PetscCall(TSGetStepNumber(ts, &stepnum));
+    const char *units = TimeUnitAsString(rdy->config.time.unit);
+
+    RDyLogDebug(rdy, "[%" PetscInt_FMT "] Time = %f [%s] Max courant number %g", stepnum, ConvertTimeFromSeconds(time, rdy->config.time.unit), units,
+                diagnostics.courant_number.max_courant_num);
   }
 
   PetscFunctionReturn(PETSC_SUCCESS);

--- a/src/operator.c
+++ b/src/operator.c
@@ -220,12 +220,20 @@ PetscErrorCode CreateOperator(RDyConfig *config, DM domain_dm, RDyMesh *domain_m
     PetscCall(CreateCeedFluxOperator((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
                                      (*operator)->boundary_conditions, &(*operator)->ceed.G.flux));
     PetscCall(CreateCeedSourceOperator((*operator)->config, (*operator)->mesh, &(*operator)->ceed.G.source));
+    PetscCall(CreateCeedIOperator((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
+                                  (*operator)->boundary_conditions, &(*operator)->ceed.F));
+    PetscCall(CreateCeedIJacobian((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
+                                  (*operator)->boundary_conditions, &(*operator)->ceed.dF));
   } else {
     PetscCall(CreatePetscFluxOperator((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
                                       (*operator)->boundary_conditions, (*operator)->petsc.boundary_values, (*operator)->petsc.boundary_fluxes,
                                       &(*operator)->diagnostics, &(*operator)->petsc.G.flux));
     PetscCall(CreatePetscSourceOperator((*operator)->config, (*operator)->mesh, (*operator)->petsc.external_sources,
                                         (*operator)->petsc.material_properties, &(*operator)->petsc.G.source));
+    PetscCall(CreatePetscIOperator((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
+                                   (*operator)->boundary_conditions, &(*operator)->petsc.F));
+    PetscCall(CreatePetscIJacobian((*operator)->config, (*operator)->mesh, (*operator)->num_boundaries, (*operator)->boundaries,
+                                   (*operator)->boundary_conditions, &(*operator)->petsc.dF));
   }
 
   // set up our flux divergence vector(s)
@@ -413,7 +421,41 @@ static PetscErrorCode ApplyPetscOperator(Operator *op, PetscReal dt, Vec u_local
 PetscErrorCode OperatorIFunction(TS ts, PetscReal t, Vec u, Vec dudt, Vec F, void *ctx) {
   PetscFunctionBegin;
 
-  RDy rdy = ctx;
+  RDy       rdy = ctx;
+  DM        dm  = rdy->dm;
+  Operator *op  = rdy->operator;
+
+  PetscScalar dt;
+  PetscCall(TSGetTimeStep(ts, &dt));
+
+  PetscCall(VecZeroEntries(F));
+
+  // populate the local u vector
+  PetscCall(DMGlobalToLocalBegin(dm, u, INSERT_VALUES, rdy->u_local));
+  PetscCall(DMGlobalToLocalEnd(dm, u, INSERT_VALUES, rdy->u_local));
+
+  // populate the du/dt vector field on the operator and compute the left hand side
+  if (CeedEnabled()) {
+    // TODO: set du/dt field on operator
+    PetscCall(ApplyCeedOperator(op, dt, rdy->u_local, F));
+  } else {
+    // TODO: set du/dt field on operator
+    PetscCall(ApplyPetscOperator(op, dt, rdy->u_local, F));
+  }
+
+  if (0) {
+    PetscInt nstep;
+    PetscCall(TSGetStepNumber(ts, &nstep));
+
+    const char *backend = (CeedEnabled()) ? "ceed" : "petsc";
+    char        file[PETSC_MAX_PATH_LEN];
+    snprintf(file, PETSC_MAX_PATH_LEN, "F_%s_nstep%" PetscInt_FMT "_N%d.dat", backend, nstep, rdy->nproc);
+
+    PetscViewer viewer;
+    PetscCall(PetscViewerASCIIOpen(PETSC_COMM_WORLD, file, &viewer));
+    PetscCall(VecView(F, viewer));
+    PetscCall(PetscViewerDestroy(&viewer));
+  }
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -425,13 +467,40 @@ PetscErrorCode OperatorIFunction(TS ts, PetscReal t, Vec u, Vec dudt, Vec F, voi
 /// @param [in]    u     the global solution vector at time t
 /// @param [in]    dudt  the time derivative of the global solution vector at time t
 /// @param [in]    sigma the "shift" coefficient preceding the time derivative term of the jacobian
-/// @param [out]   dF  the matrix that stores the jacobian of the left hand side
-/// @param [out]   P   the matrix from which to construct the preconditioner (usually same as dF)
-/// @param [inout] ctx the RDy instance for the operator
-PetscErrorCode OperatorIJacobian(TS ts, PetscReal dt, Vec u, Vec dudt, PetscReal sigma, Mat dG, Mat P, void *ctx) {
+/// @param [out]   dF    the matrix that stores the jacobian of the left hand side
+/// @param [in]    P     the matrix from which to construct the preconditioner (usually same as dF)
+/// @param [inout] ctx   the RDy instance for the operator
+PetscErrorCode OperatorIJacobian(TS ts, PetscReal dt, Vec u, Vec dudt, PetscReal sigma, Mat dF, Mat P, void *ctx) {
   PetscFunctionBegin;
 
-  RDy rdy = ctx;
+  RDy       rdy = ctx;
+  Operator *op  = rdy->operator;
+
+  if (CeedEnabled()) {
+    // copy the nonzeros into the matrix dF in COO format
+    CeedOperatorField nonzeros_field;
+    PetscCallCEED(CeedOperatorGetFieldByName(op->ceed.dF, "nonzeros", &nonzeros_field));
+    CeedVector nonzeros;
+    PetscCallCEED(CeedOperatorFieldGetVector(nonzeros_field, &nonzeros));
+
+    const CeedScalar *nz;
+    PetscCall(CeedVectorGetArrayRead(nonzeros, CEED_MEM_DEVICE, &nz));
+    PetscCall(MatSetValuesCOO(dF, nz, INSERT_VALUES));
+    PetscCall(MatAssemblyBegin(dF, MAT_FLUSH_ASSEMBLY));
+    PetscCall(MatAssemblyEnd(dF, MAT_FLUSH_ASSEMBLY));
+    PetscCall(CeedVectorRestoreArrayRead(nonzeros, &nz));
+  } else {
+    // copy the nonzeros into the matrix dF in COO format
+    Vec nonzeros;
+    PetscCall(PetscOperatorFieldsGet(op->petsc.dF->fields, "nonzeros", &nonzeros));
+
+    const PetscReal *nz;
+    PetscCall(VecGetArrayRead(nonzeros, &nz));
+    PetscCall(MatSetValuesCOO(dF, nz, INSERT_VALUES));
+    PetscCall(MatAssemblyBegin(dF, MAT_FLUSH_ASSEMBLY));
+    PetscCall(MatAssemblyEnd(dF, MAT_FLUSH_ASSEMBLY));
+    PetscCall(VecRestoreArrayRead(nonzeros, &nz));
+  }
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
@@ -507,12 +576,39 @@ PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec u, Vec G, void *ctx) 
 /// @param [in]    t   the simulation time [seconds]
 /// @param [in]    u   the global solution vector at time t
 /// @param [out]   dG  the matrix that stores the jacobian of the right hand side
-/// @param [out]   P   the matrix from which to construct the preconditioner (usually same as dG)
+/// @param [in]    P   the matrix from which to construct the preconditioner (usually same as dG)
 /// @param [inout] ctx the RDy instance for the operator
 PetscErrorCode OperatorRHSJacobian(TS ts, PetscReal dt, Vec u, Mat dG, Mat P, void *ctx) {
   PetscFunctionBegin;
 
-  RDy rdy = ctx;
+  RDy       rdy = ctx;
+  Operator *op  = rdy->operator;
+
+  if (CeedEnabled()) {
+    // copy the nonzeros into the matrix dG in COO format
+    CeedOperatorField nonzeros_field;
+    PetscCallCEED(CeedOperatorGetFieldByName(op->ceed.dG, "nonzeros", &nonzeros_field));
+    CeedVector nonzeros;
+    PetscCallCEED(CeedOperatorFieldGetVector(nonzeros_field, &nonzeros));
+
+    const CeedScalar *nz;
+    PetscCall(CeedVectorGetArrayRead(nonzeros, CEED_MEM_DEVICE, &nz));
+    PetscCall(MatSetValuesCOO(dG, nz, INSERT_VALUES));
+    PetscCall(MatAssemblyBegin(dG, MAT_FLUSH_ASSEMBLY));
+    PetscCall(MatAssemblyEnd(dG, MAT_FLUSH_ASSEMBLY));
+    PetscCall(CeedVectorRestoreArrayRead(nonzeros, &nz));
+  } else {
+    // copy the nonzeros into the matrix dG in COO format
+    Vec nonzeros;
+    PetscCall(PetscOperatorFieldsGet(op->petsc.dF->fields, "nonzeros", &nonzeros));
+
+    const PetscReal *nz;
+    PetscCall(VecGetArrayRead(nonzeros, &nz));
+    PetscCall(MatSetValuesCOO(dG, nz, INSERT_VALUES));
+    PetscCall(MatAssemblyBegin(dG, MAT_FLUSH_ASSEMBLY));
+    PetscCall(MatAssemblyEnd(dG, MAT_FLUSH_ASSEMBLY));
+    PetscCall(VecRestoreArrayRead(nonzeros, &nz));
+  }
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }

--- a/src/operator_ceed.c
+++ b/src/operator_ceed.c
@@ -692,5 +692,49 @@ PetscErrorCode CreateCeedSourceOperator(RDyConfig *config, RDyMesh *mesh, CeedOp
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
+
+/// Creates a CEED "identity" operator appropriate for the given configuration.
+/// @param [in]    config              the configuration defining the physics and numerics for the new operator
+/// @param [in]    mesh                a mesh containing geometric and topological information for the domain
+/// @param [in]    num_boundaries      the number of distinct boundaries bounding the computational domain
+/// @param [in]    boundaries          an array of distinct boundaries bounding the computational domain
+/// @param [in]    boundary_conditions an array of boundary conditions corresponding to the domain boundaries
+/// @param [out]   identity_op         the newly created operator
+/// @return 0 on success, or a non-zero error code on failure
+PetscErrorCode CreateCeedIOperator(RDyConfig *config, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary *boundaries, RDyCondition *conditions,
+                                   CeedOperator *identity_op) {
+  PetscFunctionBegin;
+
+  // TODO: implement this! Create an input field large enought to store u and du/dt
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Creates a CEED "identity jacobian" operator appropriate for the given configuration.
+/// @param [in]    config              the configuration defining the physics and numerics for the new operator
+/// @param [in]    mesh                a mesh containing geometric and topological information for the domain
+/// @param [in]    num_boundaries      the number of distinct boundaries bounding the computational domain
+/// @param [in]    boundaries          an array of distinct boundaries bounding the computational domain
+/// @param [in]    boundary_conditions an array of boundary conditions corresponding to the domain boundaries
+/// @param [out]   jacobian_op         the newly created operator
+/// @return 0 on success, or a non-zero error code on failure
+PetscErrorCode CreateCeedIJacobian(RDyConfig *config, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary *boundaries, RDyCondition *conditions,
+                                   CeedOperator *jacobian_op) {
+  PetscFunctionBegin;
+
+  // TODO: implement this! Create an output field for nonzero values
+
+  /*
+  // ...
+
+  CeedInt *rows, *columns;
+  PetscCall(CeedOperatorLinearAssembleSymbolic(*jacobian_op, jacobian_nnz, &rows, &columns));
+  PetscFree(rows);
+  PetscFree(columns);
+  */
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 #pragma GCC diagnostic   pop
 #pragma clang diagnostic pop

--- a/src/operator_petsc.c
+++ b/src/operator_petsc.c
@@ -234,3 +234,37 @@ PetscErrorCode CreatePetscSourceOperator(RDyConfig *config, RDyMesh *mesh, Vec e
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
+
+/// Creates a PETSc "identity" operator appropriate for the given configuration.
+/// @param [in]    config              the configuration defining the physics and numerics for the new operator
+/// @param [in]    mesh                a mesh containing geometric and topological information for the domain
+/// @param [in]    num_boundaries      the number of distinct boundaries bounding the computational domain
+/// @param [in]    boundaries          an array of distinct boundaries bounding the computational domain
+/// @param [in]    boundary_conditions an array of boundary conditions corresponding to the domain boundaries
+/// @param [out]   identity_op         the newly created operator
+/// @return 0 on success, or a non-zero error code on failure
+PetscErrorCode CreatePetscIOperator(RDyConfig *config, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary *boundaries, RDyCondition *conditions,
+                                    PetscOperator *identity_op) {
+  PetscFunctionBegin;
+
+  // TODO: implement this! Create an input field for du/dt
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
+/// Creates a PETSc "identity jacobian" operator appropriate for the given configuration.
+/// @param [in]    config              the configuration defining the physics and numerics for the new operator
+/// @param [in]    mesh                a mesh containing geometric and topological information for the domain
+/// @param [in]    num_boundaries      the number of distinct boundaries bounding the computational domain
+/// @param [in]    boundaries          an array of distinct boundaries bounding the computational domain
+/// @param [in]    boundary_conditions an array of boundary conditions corresponding to the domain boundaries
+/// @param [out]   jacobian_op         the newly created operator
+/// @return 0 on success, or a non-zero error code on failure
+PetscErrorCode CreatePetscIJacobian(RDyConfig *config, RDyMesh *mesh, PetscInt num_boundaries, RDyBoundary *boundaries, RDyCondition *conditions,
+                                    PetscOperator *jacobian_op) {
+  PetscFunctionBegin;
+
+  // TODO: implement this! Create an output field for nonzero values
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -993,66 +993,6 @@ PetscErrorCode InitOperator(RDy rdy) {
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// This is the right-hand-side function used by our timestepping solver.
-/// @param [in]    ts  the solver
-/// @param [in]    t   the simulation time [seconds]
-/// @param [in]    U   the global solution vector at time t
-/// @param [out]   F   the global right hand side vector to be evaluated at time t
-/// @param [inout] ctx a pointer to the operator representing the system being solved
-static PetscErrorCode OperatorRHSFunction(TS ts, PetscReal t, Vec U, Vec F, void *ctx) {
-  PetscFunctionBegin;
-
-  RDy       rdy = ctx;
-  DM        dm  = rdy->dm;
-  Operator *op  = rdy->operator;
-
-  PetscScalar dt;
-  PetscCall(TSGetTimeStep(ts, &dt));
-
-  PetscCall(VecZeroEntries(F));
-
-  // populate the local U vector
-  PetscCall(DMGlobalToLocalBegin(dm, U, INSERT_VALUES, rdy->u_local));
-  PetscCall(DMGlobalToLocalEnd(dm, U, INSERT_VALUES, rdy->u_local));
-
-  PetscCall(ResetOperatorDiagnostics(op));
-
-  // compute the right hand side
-  PetscCall(ApplyOperator(op, dt, rdy->u_local, F));
-  if (0) {
-    PetscInt nstep;
-    PetscCall(TSGetStepNumber(ts, &nstep));
-
-    const char *backend = (CeedEnabled()) ? "ceed" : "petsc";
-    char        file[PETSC_MAX_PATH_LEN];
-    snprintf(file, PETSC_MAX_PATH_LEN, "F_%s_nstep%" PetscInt_FMT "_N%d.dat", backend, nstep, rdy->nproc);
-
-    PetscViewer viewer;
-    PetscCall(PetscViewerASCIIOpen(PETSC_COMM_WORLD, file, &viewer));
-    PetscCall(VecView(F, viewer));
-    PetscCall(PetscViewerDestroy(&viewer));
-  }
-
-  // if debug-level logging is enabled, find the latest global maximum Courant number
-  // and log it.
-  if (rdy->config.logging.level >= LOG_DEBUG) {
-    PetscCall(UpdateOperatorDiagnostics(op));
-    OperatorDiagnostics diagnostics;
-    PetscCall(GetOperatorDiagnostics(op, &diagnostics));
-
-    PetscReal time;
-    PetscInt  stepnum;
-    PetscCall(TSGetTime(ts, &time));
-    PetscCall(TSGetStepNumber(ts, &stepnum));
-    const char *units = TimeUnitAsString(rdy->config.time.unit);
-
-    RDyLogDebug(rdy, "[%" PetscInt_FMT "] Time = %f [%s] Max courant number %g", stepnum, ConvertTimeFromSeconds(time, rdy->config.time.unit), units,
-                diagnostics.courant_number.max_courant_num);
-  }
-
-  PetscFunctionReturn(PETSC_SUCCESS);
-}
-
 PetscErrorCode InitSolver(RDy rdy) {
   PetscFunctionBegin;
 


### PR DESCRIPTION
This PR creates some structure we'll use to implement semi-implicit (and perhaps even implicit) time integration schemes for RDycore.

## Summary

I am following [PETSc's TS-related discussion of time integration](https://petsc.org/release/manual/ts/#ts-scalable-ode-and-dae-solvers) in terms of notation. Specifically, we are solving a system of equations represented by

F(t, u, du/dt) = G(t, u)

where

* F represents an "I" (as in identity matrix") function representing the left hand side of a semi-discrete update expression, containing any implicitly integrated terms, and
* G representing the explicitly integrated terms in the evolution of the system.

Because we've been focusing exclusively on explicit time integration, our existing "flux and source operators" are terms in G, and F is just du/dt. If we start using IMEX methods (say) to treat stiff source terms implicitly, these stiff terms migrate to F, and we need to compute F's Jacobian, which I have written dF in code. 

In following with our approach to the aforementioned flux and source operators, I'm providing functions that can be called in `RDySetup` (see line 1021, for example). One can pass these functions directly to a TS solver provided a properly constructed operator. The forms of these functions depends on the configuration of RDycore, and I've stubbed out functions for passing the relevant configuration information to the operator.

None of this code is doing anything yet, so I'm just putting this up as a draft PR.