### PR TITLE
Updates modules for Perlmutter and Frontier

### DIFF
--- a/config/modules.frontier.craygnu-mphipcc
+++ b/config/modules.frontier.craygnu-mphipcc
@@ -1,31 +1,6 @@
-module purge
-module load  craype-x86-trento                
-module load  libfabric/1.22.0                 
-module load  craype-network-ofi               
-module load  xpmem/2.10.6-1.2_gfaa90a94be64   
-module load  Core/24.07         
-module load  tmux/3.4           
-module load  hsi/default        
-module load  lfs-wrapper/0.0.1  
-module load  DefApps              
-module load  PrgEnv-gnu/8.6.0     
-module load  cray-dsmml/0.3.0     
-module load  cray-libsci/24.11.0  
-module load  cray-mpich/8.1.31  
-module load  cray-pmi/6.1.15    
-module load  craype/2.7.33      
-module load  gcc-native/13.2    
-module load  perftools-base/24.11.0  
-module load  cpe/24.11               
-module load  libunwind/1.8.1         
-module load  cray-python/3.11.7      
-module load  subversion/1.14.2            
-module load  git/2.47.0
-module load  cmake/3.30.5
-module load  cray-hdf5-parallel/1.14.3.3  
-module load  cray-netcdf-hdf5parallel/4.9.0.15
-module load  cray-parallel-netcdf/1.12.3.15
-module load  craype-accel-amd-gfx90a
-module load  rocm/6.2.4
+module reset
+module load Core/25.03 PrgEnv-gnu cpe/24.11 libunwind/1.8.1 cray-python/3.11.7 subversion git cmake cray-hdf5-parallel/1.14.3.3 cray-netcdf-hdf5parallel/4.9.0.15 cray-parallel-netcdf/1.12.3.15
+module unload darshan-runtime
+module load craype-accel-amd-gfx90a rocm/6.2.4
 module load  ninja/1.12.1
 

--- a/config/modules.pm-cpu.gnu
+++ b/config/modules.pm-cpu.gnu
@@ -1,18 +1,3 @@
-module purge
-module load  craype-x86-milan                                
-module load  libfabric/1.20.1                                
-module load  craype-network-ofi                              
-module load  sqs/2.0                    
-module load  conda/Miniforge3-24.7.1-0  
-module load  python/3.11                
-module load  cray-dsmml/0.3.0              
-module load  PrgEnv-gnu/8.5.0
-module load  gcc-native/12.3
-module load  cray-libsci/23.12.5           
-module load  craype-accel-host                  
-module load  craype/2.7.30
-module load  cray-mpich/8.1.28
-module load  cray-hdf5-parallel/1.12.2.9        
-module load  cray-netcdf-hdf5parallel/4.9.0.9
-module load  cray-parallel-netcdf/1.12.3.9
-module load  cmake/3.24.3
+module -q unload cpe cray-hdf5-parallel cray-netcdf-hdf5parallel cray-parallel-netcdf cray-netcdf cray-hdf5 PrgEnv-gnu PrgEnv-intel PrgEnv-nvidia PrgEnv-cray PrgEnv-aocc gcc-native intel intel-oneapi nvidia aocc cudatoolkit climate-utils cray-libsci matlab craype-accel-nvidia80 craype-accel-host perftools-base perftools darshan 
+module load PrgEnv-gnu/8.5.0 gcc-native/12.3 cray-libsci/23.12.5 craype-accel-host craype/2.7.30 cray-mpich/8.1.28 cray-hdf5-parallel/1.12.2.9 cray-netcdf-hdf5parallel/4.9.0.9 cray-parallel-netcdf/1.12.3.9 cmake/3.24.3 
+

--- a/config/modules.pm-gpu.gnugpu
+++ b/config/modules.pm-gpu.gnugpu
@@ -1,21 +1,3 @@
-module purge
-module load  craype-x86-milan                                
-module load  libfabric/1.20.1                                
-module load  craype-network-ofi                              
-module load  gpu/1.0                    
-module load  sqs/2.0                    
-module load  conda/Miniforge3-24.7.1-0  
-module load  python/3.11                
-module load  cray-dsmml/0.3.0              
-module load  PrgEnv-gnu/8.5.0
-module load  gcc-native/12.3
-module load  cudatoolkit/12.4
-module load  craype-accel-nvidia80
-module load  cray-libsci/23.12.5           
-module load  craype/2.7.30
-module load  cray-mpich/8.1.28
-module load  cray-hdf5-parallel/1.12.2.9        
-module load  cray-netcdf-hdf5parallel/4.9.0.9
-module load  cray-parallel-netcdf/1.12.3.9
-module load  cmake/3.24.3
+module -q unload cpe cray-hdf5-parallel cray-netcdf-hdf5parallel cray-parallel-netcdf cray-netcdf cray-hdf5 PrgEnv-gnu PrgEnv-intel PrgEnv-nvidia PrgEnv-cray PrgEnv-aocc gcc-native intel intel-oneapi nvidia aocc cudatoolkit climate-utils cray-libsci matlab craype-accel-nvidia80 craype-accel-host perftools-base perftools darshan 
+module load PrgEnv-gnu/8.5.0 gcc-native/12.3 cudatoolkit/12.4 craype-accel-nvidia80 cray-libsci/23.12.5 craype/2.7.30 cray-mpich/8.1.28 cray-hdf5-parallel/1.12.2.9 cray-netcdf-hdf5parallel/4.9.0.9 cray-parallel-netcdf/1.12.3.9 cmake/3.24.3 
 


### PR DESCRIPTION
Updates the modules for Perlmutter (CPU and GPU nodes) and Frontier.

Since we used the same modules as E3SM, the appropriate modules are determined via the following commands:

- Modules for Perlmutter CPU nodes:
```
cd <e3sm-dir>
./cime/CIME/Tools/get_case_env -c ERS.f09_f09.IELM.pm-cpu_gnu
```

- Modules for Perlmutter GPU nodes:
```
cd <e3sm-dir>
./cime/CIME/Tools/get_case_env -c ERS.f09_f09.IELM.pm-gpu_gnugpu
```
- Modules for Frontier nodes:
```
cd <e3sm-dir>
./cime/CIME/Tools/get_case_env -c ERS.f09_f09.IELM.frontier_craygnu-mphipcc
```