### PR TITLE
Saves and uses previous accumulated boundary flux value

### DIFF
--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -22,6 +22,12 @@ PETSC_INTERN PetscErrorCode GetCeedVecType(VecType *);
 // This type keeps track of accumulated time series data appended periodically
 // to files.
 typedef struct {
+  PetscReal water_mass;
+  PetscReal x_momentum;
+  PetscReal y_momentum;
+} TimeSeriesBoundaryFlux;
+
+typedef struct {
   // fluxes on boundary edges
   struct {
     // per-process numbers of local boundary edges on which fluxes are accumulated
@@ -32,14 +38,10 @@ typedef struct {
     PetscInt *global_flux_md;
     // array of per-boundary offsets in local fluxes array below
     PetscInt *offsets;
+
     // local array of boundary fluxes
     struct {
-      PetscReal water_mass;
-      PetscReal x_momentum;
-      PetscReal y_momentum;
-      PetscReal water_mass_prev;
-      PetscReal x_momentum_prev;
-      PetscReal y_momentum_prev;
+      TimeSeriesBoundaryFlux current, previous;
     } * fluxes;
 
     // last step for which boundary flux time series data was written


### PR DESCRIPTION
Corrects the accumulation of boundary fluxes. The boundary fluxes are now
outputted as an average values over the output time intervals.