### PR TITLE
Adding an option to enable `clang-tidy`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,11 @@ else()
   set(SYSTEM_LIBRARIES ${PETSc_STATIC_LIBRARIES} PkgConfig::CEED m stdc++)
 endif()
 
+# Gather MPI header paths to help language servers.
+include(extract_mpi_include_directories)
+extract_mpi_include_directories(mpi_dirs)
+include_directories(${mpi_dirs})
+
 if (ENABLE_TESTS)
   include(CTest)
   enable_testing()

--- a/cmake/extract_mpi_include_directories.cmake
+++ b/cmake/extract_mpi_include_directories.cmake
@@ -1,0 +1,16 @@
+# This function, which accepts no arguments, extracts the MPICC_SHOW variable from RDycore's PETSc
+# configuration and parses it into a list of include directories, which it returns in
+# directories. We do this to enable clangd to find mpi.h in more situations.
+include(extract_petsc_variable)
+function(extract_mpi_include_directories directories)
+  extract_petsc_variable("MPICC_SHOW" mpicc_show)
+  string(REPLACE " " ";" candidates ${mpicc_show})
+  foreach(candidate ${candidates})
+    string(FIND ${candidate} "-I" flag_pos)
+    if (NOT ${flag_pos} EQUAL -1)
+      string(SUBSTRING ${candidate} 2 -1 mpi_dir)
+      list(APPEND mpi_dirs ${mpi_dir})
+    endif()
+  endforeach()
+  set(${directories} ${mpi_dirs} PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
Here we add a CMake option that when set (`-DENABLE_TIDY=ON`) runs the `clang-tidy` tool on RDycore. This tool needs some calibration, but it works in its default configuration as long as you extract the proper include directories from our MPI compiler wrappers (which I had done in another branch).

We can add a `.clang-format` file to configure the tool when we figure out what we're doing.