### PR TITLE
An attempt at addressing the no-output-on-restart issue.

### DIFF
--- a/src/rdyadvance.c
+++ b/src/rdyadvance.c
@@ -264,7 +264,7 @@ PetscErrorCode RDyAdvance(RDy rdy) {
   // if we're at the start of the simulation, set up monitoring
   PetscInt step;
   PetscCall(TSGetStepNumber(rdy->ts, &step));
-  if (step == 0) {
+  if (step == 0 || (step > 0 && rdy->is_a_restart_run)) {
     PetscCall(CreateOutputDirectory(rdy));
 
     // create a viewer with the proper format for visualization output


### PR DESCRIPTION
@bishtgautam , I think this could address the issue you mentioned. It looks to me like you've already changed the `ctest` logic to use `mv` instead of `cp` as you mention for catching the testing error, but I don't know what it means that these tests haven't been failing.

Closes #317