### PR TITLE
Adds upwind Roe Riemann solver for tracers

### DIFF
--- a/driver/tests/sediment/CMakeLists.txt
+++ b/driver/tests/sediment/CMakeLists.txt
@@ -20,6 +20,17 @@ foreach(np 2) # test on 1, 2 processes
 endforeach()
 
 file(COPY
+     ${CMAKE_CURRENT_SOURCE_DIR}/sediment_upwind_mms_conv_study.yaml
+     DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+foreach(np 2) # test on 1, 2 processes
+  foreach(config basic ceed)
+    foreach(lang ${supported_languages})
+      add_test(sediment_upwind_mms_conv_study_${lang}_np_${np}_${config} ${MPIEXEC} ${MPIEXEC_FLAGS} -n ${np} ${mms_${lang}_driver} sediment_upwind_mms_conv_study.yaml ${${config}_args})
+    endforeach()
+  endforeach()
+endforeach()
+
+file(COPY
      ${CMAKE_CURRENT_SOURCE_DIR}/sediment.yaml
      ${MESH_DIR}/DamBreak_grid5x10.exo
      ${CONDITION_DIR}/DamBreak_grid5x10_wetdownstream.ic.${PETSC_ID_TYPE}.bin

--- a/driver/tests/sediment/sediment_upwind_mms_conv_study.yaml
+++ b/driver/tests/sediment/sediment_upwind_mms_conv_study.yaml
@@ -7,7 +7,7 @@ physics:
 numerics:
   spatial : fv
   temporal: euler
-  riemann : upwinded_roe
+  riemann : upwind_roe
 
 # this section contains analytic forms for the method of manufactured solutions
 mms:
@@ -81,7 +81,7 @@ mms:
         Linf: 0.94
       c1:
         L1: 0.93
-        L2: 0.93
+        L2: 0.92
         Linf: 0.95
 
 logging:

--- a/driver/tests/sediment/sediment_upwind_mms_conv_study.yaml
+++ b/driver/tests/sediment/sediment_upwind_mms_conv_study.yaml
@@ -1,0 +1,111 @@
+physics:
+  flow:
+    mode: swe
+  sediment:
+    num_classes: 2
+
+numerics:
+  spatial : fv
+  temporal: euler
+  riemann : upwinded_roe
+
+# this section contains analytic forms for the method of manufactured solutions
+mms:
+  constants: # any single capital letter can be used
+    H: 0.005  # water height scale factor
+    T: 20.0   # time scale
+    U: 0.025  # x-velocity scale factor
+    V: 0.025  # y-velocity scale factor
+    N: 0.01   # manning coefficient scale factor
+    Z: 0.0025 # elevation scale factor
+    C: 0.5   # sediment concentration factor
+
+    K: 0.6283185307179586 # wave number in x and y (pi/5)
+  swe: # functions of x, y, t (non-normalized units)
+    # water height
+    h:    H * (1 + sin(K*x)*sin(K*y)) * exp(t/T)
+    dhdx: H * K * sin(K*y) * cos(K*x) * exp(t/T)
+    dhdy: H * K * sin(K*x) * cos(K*y) * exp(t/T)
+    dhdt: H / T * (1 + sin(K*x)*sin(K*y)) * exp(t/T)
+
+    # x velocity
+    u:     U * cos(K*x) * sin(K*y) * exp(t/T)
+    dudx: -U * K * sin(K*x) * sin(K*y) * exp(t/T)
+    dudy:  U * K * cos(K*x) * cos(K*y) * exp(t/T)
+    dudt:  U / T * cos(K*x) * sin(K*y) * exp(t/T)
+
+    # y velocity
+    v:     V * sin(K*x) * cos(K*y) * exp(t/T)
+    dvdx:  K * V * cos(K*x) * cos(K*y) * exp(t/T)
+    dvdy: -K * V * sin(K*x) * sin(K*y) * exp(t/T)
+    dvdt:  V / T * sin(K*x) * cos(K*y) * exp(t/T)
+
+    # elevation as z(x, y) <-- overwrites mesh z coordinates
+    z:     Z * sin(K*x) * sin(K*y)
+    dzdx:  Z * K * cos(K*x) * sin(K*y)
+    dzdy:  Z * K * sin(K*x) * cos(K*y)
+
+    # Manning coefficient n(x,y)
+    n:     N * (1 + sin(K*x) * sin(K*y))
+
+  sediment: # functions of x, y, t (non-normalized units)
+    c0:    C * (1 + sin(K*x)*sin(K*y)) * exp(t/T)
+    dc0dx: C * K * sin(K*y) * cos(K*x) * exp(t/T)
+    dc0dy: C * K * sin(K*x) * cos(K*y) * exp(t/T)
+    dc0dt: C / T * (1 + sin(K*x)*sin(K*y)) * exp(t/T)
+    c1:    C * (1 + sin(K*x)*sin(K*y)) * exp(-t/T)
+    dc1dx: C * K * sin(K*y) * cos(K*x) * exp(-t/T)
+    dc1dy: C * K * sin(K*x) * cos(K*y) * exp(-t/T)
+    dc1dt: -C / T * (1 + sin(K*x)*sin(K*y)) * exp(-t/T)
+
+  # Convergence study parameters (optional)
+  convergence:
+    num_refinements: 3
+    base_refinement: 1 # <-- start at this refinement level
+    expected_rates: # uses solution names in enabled physics above
+      h:
+        L1: 0.94
+        L2: 0.95
+        Linf: 0.94
+      hu:
+        L1: 0.91
+        L2: 0.93
+        Linf: 0.77
+      hv:
+        L1: 0.91
+        L2: 0.93
+        Linf: 0.77
+      c0:
+        L1: 0.94
+        L2: 0.95
+        Linf: 0.94
+      c1:
+        L1: 0.93
+        L2: 0.93
+        Linf: 0.95
+
+logging:
+  level: none
+
+time:
+  time_step        : 0.01
+  unit             : seconds
+  stop             : 5.00
+  coupling_interval: 0.01
+
+#output:
+#  format: xdmf
+#  output_interval: 500
+
+grid:
+  file: mms_triangles_dx1.exo # z coordinates overwritten by z(x, y) above
+
+# one region represents the whole domain
+regions:
+  - name: domain
+    grid_region_id: 1
+
+boundaries:
+  - name: domain_boundary
+    grid_boundary_id: 1
+

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -107,9 +107,9 @@ typedef enum {
 
 // riemann solvers for horizontal flow
 typedef enum {
-  RIEMANN_ROE = 0,       // Roe solver
+  RIEMANN_ROE = 0,     // Roe solver
   RIEMANN_UPWIND_ROE,  // Upwind Roe solver for tracers
-  RIEMANN_HLLC           // Harten, Lax, van Leer Contact solver
+  RIEMANN_HLLC         // Harten, Lax, van Leer Contact solver
 } RDyNumericsRiemann;
 
 // all numerics parmeters

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -108,7 +108,7 @@ typedef enum {
 // riemann solvers for horizontal flow
 typedef enum {
   RIEMANN_ROE = 0,       // Roe solver
-  RIEMANN_UPWINDED_ROE,  // Upwinded Roe solver for tracers
+  RIEMANN_UPWIND_ROE,  // Upwind Roe solver for tracers
   RIEMANN_HLLC           // Harten, Lax, van Leer Contact solver
 } RDyNumericsRiemann;
 

--- a/include/private/rdyconfigimpl.h
+++ b/include/private/rdyconfigimpl.h
@@ -107,8 +107,9 @@ typedef enum {
 
 // riemann solvers for horizontal flow
 typedef enum {
-  RIEMANN_ROE = 0,  // Roe solver
-  RIEMANN_HLLC      // Harten, Lax, van Leer Contact solver
+  RIEMANN_ROE = 0,       // Roe solver
+  RIEMANN_UPWINDED_ROE,  // Upwinded Roe solver for tracers
+  RIEMANN_HLLC           // Harten, Lax, van Leer Contact solver
 } RDyNumericsRiemann;
 
 // all numerics parmeters

--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -54,7 +54,14 @@ static PetscErrorCode CreateInteriorFluxQFunction(Ceed ceed, const RDyConfig con
     PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEFlux_Roe, SWEFlux_Roe_loc, qf));
     PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
   } else {  // flow + tracers
-    PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerFlux_Roe, TracerFlux_Roe_loc, qf));
+    switch (config.numerics.riemann) {
+      case RIEMANN_ROE:
+        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerFlux_Roe, TracerFlux_Roe_loc, qf));
+        break;
+      case RIEMANN_UPWINDED_ROE:
+        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerFlux_UpwindedRoe, TracerFlux_UpwindedRoe_loc, qf));
+        break;
+    }
     PetscCall(CreateTracerQFunctionContext(ceed, config, &qf_context));
   }
 
@@ -281,7 +288,14 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
         PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Dirichlet_Roe, SWEBoundaryFlux_Dirichlet_Roe_loc, qf));
         PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
       } else {  // flow + tracers
+        switch (config.numerics.riemann) {
+          case RIEMANN_ROE:
         PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_Roe, TracerBoundaryFlux_Dirichlet_Roe_loc, qf));
+            break;
+          case RIEMANN_UPWINDED_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_UpwindedRoe, TracerBoundaryFlux_Dirichlet_UpwindedRoe_loc, qf));
+            break;
+        }
         PetscCall(CreateTracerQFunctionContext(ceed, config, &qf_context));
       }
       break;
@@ -290,7 +304,14 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
         PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Reflecting_Roe, SWEBoundaryFlux_Reflecting_Roe_loc, qf));
         PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
       } else {  // flow + tracers
-        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Reflecting_Roe, TracerBoundaryFlux_Reflecting_Roe_loc, qf));
+        switch (config.numerics.riemann) {
+          case RIEMANN_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Reflecting_Roe, TracerBoundaryFlux_Reflecting_Roe_loc, qf));
+            break;
+          case RIEMANN_UPWINDED_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_UpwindedReflecting_Roe, TracerBoundaryFlux_UpwindedReflecting_Roe_loc, qf));
+            break;
+        }
         PetscCall(CreateTracerQFunctionContext(ceed, config, &qf_context));
       }
       break;

--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -51,8 +51,15 @@ static PetscErrorCode CreateInteriorFluxQFunction(Ceed ceed, const RDyConfig con
 
   CeedQFunctionContext qf_context;
   if (num_tracers == 0) {  // flow only, and SWE is it!
-    PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEFlux_Roe, SWEFlux_Roe_loc, qf));
-    PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+    switch (config.numerics.riemann) {
+      case RIEMANN_ROE:
+        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEFlux_Roe, SWEFlux_Roe_loc, qf));
+        PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+        break;
+      default:
+        PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Only RIEMANN_ROE Riemann solver support for SWE with no tracers");
+        break;
+    }
   } else {  // flow + tracers
     switch (config.numerics.riemann) {
       case RIEMANN_ROE:
@@ -63,6 +70,7 @@ static PetscErrorCode CreateInteriorFluxQFunction(Ceed ceed, const RDyConfig con
         break;
       default:
         PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
+        break;
     }
     PetscCall(CreateTracerQFunctionContext(ceed, config, &qf_context));
   }
@@ -287,8 +295,15 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
   switch (boundary_condition.flow->type) {
     case CONDITION_DIRICHLET:
       if (num_tracers == 0) {  // flow only
-        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Dirichlet_Roe, SWEBoundaryFlux_Dirichlet_Roe_loc, qf));
-        PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+        switch (config.numerics.riemann) {
+          case RIEMANN_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Dirichlet_Roe, SWEBoundaryFlux_Dirichlet_Roe_loc, qf));
+            PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+            break;
+          default:
+            PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Only RIEMANN_ROE Riemann solver support for SWE with no tracers");
+            break;
+        }
       } else {  // flow + tracers
         switch (config.numerics.riemann) {
           case RIEMANN_ROE:
@@ -306,8 +321,15 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
       break;
     case CONDITION_REFLECTING:
       if (num_tracers == 0) {  // flow only
-        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Reflecting_Roe, SWEBoundaryFlux_Reflecting_Roe_loc, qf));
-        PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+        switch (config.numerics.riemann) {
+          case RIEMANN_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Reflecting_Roe, SWEBoundaryFlux_Reflecting_Roe_loc, qf));
+            PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+            break;
+          default:
+            PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Only RIEMANN_ROE Riemann solver support for SWE with no tracers");
+            break;
+        }
       } else {  // flow + tracers
         switch (config.numerics.riemann) {
           case RIEMANN_ROE:
@@ -325,8 +347,15 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
       break;
     case CONDITION_CRITICAL_OUTFLOW:
       if (num_tracers == 0) {  // flow only
-        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Outflow_Roe, SWEBoundaryFlux_Outflow_Roe_loc, qf));
-        PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+        switch (config.numerics.riemann) {
+          case RIEMANN_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, SWEBoundaryFlux_Outflow_Roe, SWEBoundaryFlux_Outflow_Roe_loc, qf));
+            PetscCall(CreateSWEQFunctionContext(ceed, config, &qf_context));
+            break;
+          default:
+            PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Only RIEMANN_ROE Riemann solver support for SWE with no tracers");
+            break;
+        }
       } else {  // flow + tracers
         PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "CONDITION_CRITICAL_OUTFLOW not implemented for tracers");
       }

--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -61,6 +61,8 @@ static PetscErrorCode CreateInteriorFluxQFunction(Ceed ceed, const RDyConfig con
       case RIEMANN_UPWINDED_ROE:
         PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerFlux_UpwindedRoe, TracerFlux_UpwindedRoe_loc, qf));
         break;
+      default:
+        PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
     }
     PetscCall(CreateTracerQFunctionContext(ceed, config, &qf_context));
   }
@@ -295,6 +297,8 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
           case RIEMANN_UPWINDED_ROE:
             PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_UpwindedRoe, TracerBoundaryFlux_Dirichlet_UpwindedRoe_loc, qf));
             break;
+          default:
+            PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
         }
         PetscCall(CreateTracerQFunctionContext(ceed, config, &qf_context));
       }
@@ -311,6 +315,8 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
           case RIEMANN_UPWINDED_ROE:
             PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_UpwindedReflecting_Roe, TracerBoundaryFlux_UpwindedReflecting_Roe_loc, qf));
             break;
+          default:
+            PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
         }
         PetscCall(CreateTracerQFunctionContext(ceed, config, &qf_context));
       }

--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -423,7 +423,7 @@ PetscErrorCode CreateCeedBoundaryFluxSuboperator(const RDyConfig config, RDyMesh
 
   // create vectors (and their supporting restrictions) for the operator
   CeedElemRestriction q_restrict_l, c_restrict_l, restrict_dirichlet, restrict_geom, restrict_flux, restrict_cnum, eta_beg_restrict, eta_end_restrict;
-  CeedVector          geom, flux, flux_accumulated, dirichlet, cnum;
+  CeedVector          geom, flux, dirichlet, cnum;
   {
     CeedInt num_edges = boundary->num_edges;
 

--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -58,8 +58,8 @@ static PetscErrorCode CreateInteriorFluxQFunction(Ceed ceed, const RDyConfig con
       case RIEMANN_ROE:
         PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerFlux_Roe, TracerFlux_Roe_loc, qf));
         break;
-      case RIEMANN_UPWINDED_ROE:
-        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerFlux_UpwindedRoe, TracerFlux_UpwindedRoe_loc, qf));
+      case RIEMANN_UPWIND_ROE:
+        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerFlux_UpwindRoe, TracerFlux_UpwindRoe_loc, qf));
         break;
       default:
         PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
@@ -294,8 +294,8 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
           case RIEMANN_ROE:
         PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_Roe, TracerBoundaryFlux_Dirichlet_Roe_loc, qf));
             break;
-          case RIEMANN_UPWINDED_ROE:
-            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_UpwindedRoe, TracerBoundaryFlux_Dirichlet_UpwindedRoe_loc, qf));
+          case RIEMANN_UPWIND_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_UpwindRoe, TracerBoundaryFlux_Dirichlet_UpwindRoe_loc, qf));
             break;
           default:
             PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
@@ -312,8 +312,8 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
           case RIEMANN_ROE:
             PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Reflecting_Roe, TracerBoundaryFlux_Reflecting_Roe_loc, qf));
             break;
-          case RIEMANN_UPWINDED_ROE:
-            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_UpwindedReflecting_Roe, TracerBoundaryFlux_UpwindedReflecting_Roe_loc, qf));
+          case RIEMANN_UPWIND_ROE:
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_UpwindReflecting_Roe, TracerBoundaryFlux_UpwindReflecting_Roe_loc, qf));
             break;
           default:
             PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");

--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -292,10 +292,11 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
       } else {  // flow + tracers
         switch (config.numerics.riemann) {
           case RIEMANN_ROE:
-        PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_Roe, TracerBoundaryFlux_Dirichlet_Roe_loc, qf));
+            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_Roe, TracerBoundaryFlux_Dirichlet_Roe_loc, qf));
             break;
           case RIEMANN_UPWIND_ROE:
-            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_UpwindRoe, TracerBoundaryFlux_Dirichlet_UpwindRoe_loc, qf));
+            PetscCallCEED(
+                CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Dirichlet_UpwindRoe, TracerBoundaryFlux_Dirichlet_UpwindRoe_loc, qf));
             break;
           default:
             PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
@@ -313,7 +314,8 @@ static PetscErrorCode CreateBoundaryFluxQFunction(Ceed ceed, const RDyConfig con
             PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_Reflecting_Roe, TracerBoundaryFlux_Reflecting_Roe_loc, qf));
             break;
           case RIEMANN_UPWIND_ROE:
-            PetscCallCEED(CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_UpwindReflecting_Roe, TracerBoundaryFlux_UpwindReflecting_Roe_loc, qf));
+            PetscCallCEED(
+                CeedQFunctionCreateInterior(ceed, 1, TracerBoundaryFlux_UpwindReflecting_Roe, TracerBoundaryFlux_UpwindReflecting_Roe_loc, qf));
             break;
           default:
             PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -40,7 +40,7 @@ CEED_QFUNCTION_HELPER CeedScalar ComputeDhv(CeedScalar zv_beg, CeedScalar zv_end
 #define RIEMANN_FLUX_TYPE_DEFINED
 typedef enum {
   RIEMANN_FLUX_ROE,
-  RIEMANN_FLUX_UPWINDED_ROE
+  RIEMANN_FLUX_UPWIND_ROE
 } RiemannFluxType;
 #endif
 

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -40,6 +40,7 @@ CEED_QFUNCTION_HELPER CeedScalar ComputeDhv(CeedScalar zv_beg, CeedScalar zv_end
 #define RIEMANN_FLUX_TYPE_DEFINED
 typedef enum {
   RIEMANN_FLUX_ROE,
+  RIEMANN_FLUX_UPWINDED_ROE
 } RiemannFluxType;
 #endif
 

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -38,10 +38,7 @@ CEED_QFUNCTION_HELPER CeedScalar ComputeDhv(CeedScalar zv_beg, CeedScalar zv_end
 #include "swe_roe_flux_ceed.h"
 #ifndef RIEMANN_FLUX_TYPE_DEFINED
 #define RIEMANN_FLUX_TYPE_DEFINED
-typedef enum {
-  RIEMANN_FLUX_ROE,
-  RIEMANN_FLUX_UPWIND_ROE
-} RiemannFluxType;
+typedef enum { RIEMANN_FLUX_ROE, RIEMANN_FLUX_UPWINDED_ROE } RiemannFluxType;
 #endif
 
 // SWE interior flux operator Q-function

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -75,6 +75,8 @@ CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const 
         case RIEMANN_FLUX_ROE:
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, geom[0][i], geom[1][i], dhv, flux, &amax);
           break;
+        default:
+          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i] = flux[j] * geom[2][i];
@@ -129,6 +131,8 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, const 
         case RIEMANN_FLUX_ROE:
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, geom[0][i], geom[1][i], dhv, flux, &amax);
           break;
+        default:
+          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i]    = flux[j] * geom[2][i];
@@ -183,6 +187,8 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Reflecting(void *ctx, CeedInt Q, const
         case RIEMANN_FLUX_ROE:
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, sn, cn, dhv, flux, &amax);
           break;
+        default:
+          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i]    = flux[j] * geom[2][i];
@@ -240,6 +246,8 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Outflow(void *ctx, CeedInt Q, const Ce
         case RIEMANN_FLUX_ROE:
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, sn, cn, dhv, flux, &amax);
           break;
+        default:
+          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i]    = flux[j] * geom[2][i];

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -38,7 +38,7 @@ CEED_QFUNCTION_HELPER CeedScalar ComputeDhv(CeedScalar zv_beg, CeedScalar zv_end
 #include "swe_roe_flux_ceed.h"
 #ifndef RIEMANN_FLUX_TYPE_DEFINED
 #define RIEMANN_FLUX_TYPE_DEFINED
-typedef enum { RIEMANN_FLUX_ROE, RIEMANN_FLUX_UPWINDED_ROE } RiemannFluxType;
+typedef enum { RIEMANN_FLUX_ROE, RIEMANN_FLUX_UPWIND_ROE } RiemannFluxType;
 #endif
 
 // SWE interior flux operator Q-function

--- a/src/tracer/tracer_fluxes_ceed.h
+++ b/src/tracer/tracer_fluxes_ceed.h
@@ -53,6 +53,9 @@ CEED_QFUNCTION_HELPER int TracerFlux(void *ctx, CeedInt Q, const CeedScalar *con
         case RIEMANN_FLUX_ROE:
           TracerRiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
           break;
+        case RIEMANN_FLUX_UPWINDED_ROE:
+          TracerRiemannFlux_UpwindedRoe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
+          break;
       }
       for (CeedInt j = 0; j < tot_ndof; j++) {
         cell_L[j][i]     = flux[j] * geom[2][i];
@@ -76,6 +79,10 @@ CEED_QFUNCTION_HELPER int TracerFlux(void *ctx, CeedInt Q, const CeedScalar *con
 
 CEED_QFUNCTION(TracerFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   return TracerFlux(ctx, Q, in, out, RIEMANN_FLUX_ROE);
+}
+
+CEED_QFUNCTION(TracerFlux_UpwindedRoe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  return TracerFlux(ctx, Q, in, out, RIEMANN_FLUX_UPWINDED_ROE);
 }
 
 // flow and tracers flux operator Q-function for boundary edges on which dirichlet condition is applied
@@ -110,6 +117,9 @@ CEED_QFUNCTION_HELPER int TracerBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, con
         case RIEMANN_FLUX_ROE:
           TracerRiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
           break;
+        case RIEMANN_FLUX_UPWINDED_ROE:
+          TracerRiemannFlux_UpwindedRoe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
+          break;
       }
       for (CeedInt j = 0; j < tot_ndof; j++) {
         cell_L[j][i]     = flux[j] * geom[2][i];
@@ -130,6 +140,10 @@ CEED_QFUNCTION_HELPER int TracerBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, con
 
 CEED_QFUNCTION(TracerBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   return TracerBoundaryFlux_Dirichlet(ctx, Q, in, out, RIEMANN_FLUX_ROE);
+}
+
+CEED_QFUNCTION(TracerBoundaryFlux_Dirichlet_UpwindedRoe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  return TracerBoundaryFlux_Dirichlet(ctx, Q, in, out, RIEMANN_FLUX_UPWINDED_ROE);
 }
 
 // flow and tracers flux operator Q-function for boundary edges on which reflecting wall condition is applied
@@ -167,6 +181,9 @@ CEED_QFUNCTION_HELPER int TracerBoundaryFlux_Reflecting(void *ctx, CeedInt Q, co
         case RIEMANN_FLUX_ROE:
           TracerRiemannFlux_Roe(gravity, tiny_h, qL, qR, sn, cn, flow_ndof, tracer_ndof, flux, &amax);
           break;
+        case RIEMANN_FLUX_UPWINDED_ROE:
+          TracerRiemannFlux_UpwindedRoe(gravity, tiny_h, qL, qR, sn, cn, flow_ndof, tracer_ndof, flux, &amax);
+          break;
       }
       for (CeedInt j = 0; j < tot_ndof; j++) {
         cell_L[j][i] = flux[j] * geom[2][i];
@@ -184,6 +201,10 @@ CEED_QFUNCTION_HELPER int TracerBoundaryFlux_Reflecting(void *ctx, CeedInt Q, co
 
 CEED_QFUNCTION(TracerBoundaryFlux_Reflecting_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
   return TracerBoundaryFlux_Reflecting(ctx, Q, in, out, RIEMANN_FLUX_ROE);
+}
+
+CEED_QFUNCTION(TracerBoundaryFlux_UpwindedReflecting_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  return TracerBoundaryFlux_Reflecting(ctx, Q, in, out, RIEMANN_FLUX_UPWINDED_ROE);
 }
 
 #pragma GCC diagnostic   pop

--- a/src/tracer/tracer_fluxes_ceed.h
+++ b/src/tracer/tracer_fluxes_ceed.h
@@ -53,8 +53,8 @@ CEED_QFUNCTION_HELPER int TracerFlux(void *ctx, CeedInt Q, const CeedScalar *con
         case RIEMANN_FLUX_ROE:
           TracerRiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
           break;
-        case RIEMANN_FLUX_UPWINDED_ROE:
-          TracerRiemannFlux_UpwindedRoe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
+        case RIEMANN_FLUX_UPWIND_ROE:
+          TracerRiemannFlux_UpwindRoe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
           break;
       }
       for (CeedInt j = 0; j < tot_ndof; j++) {
@@ -81,8 +81,8 @@ CEED_QFUNCTION(TracerFlux_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[
   return TracerFlux(ctx, Q, in, out, RIEMANN_FLUX_ROE);
 }
 
-CEED_QFUNCTION(TracerFlux_UpwindedRoe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
-  return TracerFlux(ctx, Q, in, out, RIEMANN_FLUX_UPWINDED_ROE);
+CEED_QFUNCTION(TracerFlux_UpwindRoe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  return TracerFlux(ctx, Q, in, out, RIEMANN_FLUX_UPWIND_ROE);
 }
 
 // flow and tracers flux operator Q-function for boundary edges on which dirichlet condition is applied
@@ -117,8 +117,8 @@ CEED_QFUNCTION_HELPER int TracerBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, con
         case RIEMANN_FLUX_ROE:
           TracerRiemannFlux_Roe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
           break;
-        case RIEMANN_FLUX_UPWINDED_ROE:
-          TracerRiemannFlux_UpwindedRoe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
+        case RIEMANN_FLUX_UPWIND_ROE:
+          TracerRiemannFlux_UpwindRoe(gravity, tiny_h, qL, qR, geom[0][i], geom[1][i], flow_ndof, tracer_ndof, flux, &amax);
           break;
       }
       for (CeedInt j = 0; j < tot_ndof; j++) {
@@ -142,8 +142,8 @@ CEED_QFUNCTION(TracerBoundaryFlux_Dirichlet_Roe)(void *ctx, CeedInt Q, const Cee
   return TracerBoundaryFlux_Dirichlet(ctx, Q, in, out, RIEMANN_FLUX_ROE);
 }
 
-CEED_QFUNCTION(TracerBoundaryFlux_Dirichlet_UpwindedRoe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
-  return TracerBoundaryFlux_Dirichlet(ctx, Q, in, out, RIEMANN_FLUX_UPWINDED_ROE);
+CEED_QFUNCTION(TracerBoundaryFlux_Dirichlet_UpwindRoe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  return TracerBoundaryFlux_Dirichlet(ctx, Q, in, out, RIEMANN_FLUX_UPWIND_ROE);
 }
 
 // flow and tracers flux operator Q-function for boundary edges on which reflecting wall condition is applied
@@ -181,8 +181,8 @@ CEED_QFUNCTION_HELPER int TracerBoundaryFlux_Reflecting(void *ctx, CeedInt Q, co
         case RIEMANN_FLUX_ROE:
           TracerRiemannFlux_Roe(gravity, tiny_h, qL, qR, sn, cn, flow_ndof, tracer_ndof, flux, &amax);
           break;
-        case RIEMANN_FLUX_UPWINDED_ROE:
-          TracerRiemannFlux_UpwindedRoe(gravity, tiny_h, qL, qR, sn, cn, flow_ndof, tracer_ndof, flux, &amax);
+        case RIEMANN_FLUX_UPWIND_ROE:
+          TracerRiemannFlux_UpwindRoe(gravity, tiny_h, qL, qR, sn, cn, flow_ndof, tracer_ndof, flux, &amax);
           break;
       }
       for (CeedInt j = 0; j < tot_ndof; j++) {
@@ -203,8 +203,8 @@ CEED_QFUNCTION(TracerBoundaryFlux_Reflecting_Roe)(void *ctx, CeedInt Q, const Ce
   return TracerBoundaryFlux_Reflecting(ctx, Q, in, out, RIEMANN_FLUX_ROE);
 }
 
-CEED_QFUNCTION(TracerBoundaryFlux_UpwindedReflecting_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
-  return TracerBoundaryFlux_Reflecting(ctx, Q, in, out, RIEMANN_FLUX_UPWINDED_ROE);
+CEED_QFUNCTION(TracerBoundaryFlux_UpwindReflecting_Roe)(void *ctx, CeedInt Q, const CeedScalar *const in[], CeedScalar *const out[]) {
+  return TracerBoundaryFlux_Reflecting(ctx, Q, in, out, RIEMANN_FLUX_UPWIND_ROE);
 }
 
 #pragma GCC diagnostic   pop

--- a/src/tracer/tracer_petsc.c
+++ b/src/tracer/tracer_petsc.c
@@ -215,8 +215,8 @@ static PetscErrorCode ApplyTracerInteriorFlux(void *context, PetscOperatorFields
     case RIEMANN_ROE:
       PetscCall(ComputeTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
       break;
-    case RIEMANN_UPWINDED_ROE:
-      PetscCall(ComputeUpwindedTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
+    case RIEMANN_UPWIND_ROE:
+      PetscCall(ComputeUpwindTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
       break;
     default:
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Unsupported Riemann solver");
@@ -481,8 +481,8 @@ static PetscErrorCode ApplyTracerBoundaryFlux(void *context, PetscOperatorFields
     case RIEMANN_ROE:
       PetscCall(ComputeTracerRoeFlux(datal, datar, data_edge->sn, data_edge->cn, boundary_fluxes_ptr, data_edge->amax));
       break;
-    case RIEMANN_UPWINDED_ROE:
-      PetscCall(ComputeUpwindedTracerRoeFlux(datal, datar, data_edge->sn, data_edge->cn, boundary_fluxes_ptr, data_edge->amax));
+    case RIEMANN_UPWIND_ROE:
+      PetscCall(ComputeUpwindTracerRoeFlux(datal, datar, data_edge->sn, data_edge->cn, boundary_fluxes_ptr, data_edge->amax));
       break;
     default:
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Unsupported Riemann solver");
@@ -878,8 +878,8 @@ static PetscErrorCode ApplyTracerInteriorFluxHR(void *context, PetscOperatorFiel
     case RIEMANN_ROE:
       PetscCall(ComputeTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
       break;
-    case RIEMANN_UPWINDED_ROE:
-      PetscCall(ComputeUpwindedTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
+    case RIEMANN_UPWIND_ROE:
+      PetscCall(ComputeUpwindTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
       break;
     default:
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Unsupported Riemann solver");

--- a/src/tracer/tracer_petsc.c
+++ b/src/tracer/tracer_petsc.c
@@ -302,6 +302,7 @@ PetscErrorCode CreatePetscTracerInteriorFluxOperator(RDyMesh *mesh, const RDyCon
   TracerInteriorFluxOperator *interior_flux_op;
   PetscCall(PetscCalloc1(1, &interior_flux_op));
   *interior_flux_op = (TracerInteriorFluxOperator){
+      .riemann     = config.numerics.riemann,
       .mesh        = mesh,
       .diagnostics = diagnostics,
       .tiny_h      = config.physics.flow.tiny_h,
@@ -561,6 +562,7 @@ PetscErrorCode CreatePetscTracerBoundaryFluxOperator(RDyMesh *mesh, const RDyCon
   TracerBoundaryFluxOperator *boundary_flux_op;
   PetscCall(PetscCalloc1(1, &boundary_flux_op));
   *boundary_flux_op = (TracerBoundaryFluxOperator){
+      .riemann            = config.numerics.riemann,
       .mesh               = mesh,
       .boundary           = boundary,
       .boundary_condition = boundary_condition,

--- a/src/tracer/tracer_petsc.c
+++ b/src/tracer/tracer_petsc.c
@@ -215,6 +215,9 @@ static PetscErrorCode ApplyTracerInteriorFlux(void *context, PetscOperatorFields
     case RIEMANN_ROE:
       PetscCall(ComputeTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
       break;
+    case RIEMANN_UPWINDED_ROE:
+      PetscCall(ComputeUpwindedTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
+      break;
     default:
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Unsupported Riemann solver");
   }
@@ -476,6 +479,9 @@ static PetscErrorCode ApplyTracerBoundaryFlux(void *context, PetscOperatorFields
   switch (boundary_flux_op->riemann) {
     case RIEMANN_ROE:
       PetscCall(ComputeTracerRoeFlux(datal, datar, data_edge->sn, data_edge->cn, boundary_fluxes_ptr, data_edge->amax));
+      break;
+    case RIEMANN_UPWINDED_ROE:
+      PetscCall(ComputeUpwindedTracerRoeFlux(datal, datar, data_edge->sn, data_edge->cn, boundary_fluxes_ptr, data_edge->amax));
       break;
     default:
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Unsupported Riemann solver");
@@ -869,6 +875,9 @@ static PetscErrorCode ApplyTracerInteriorFluxHR(void *context, PetscOperatorFiel
   switch (op->riemann) {
     case RIEMANN_ROE:
       PetscCall(ComputeTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
+      break;
+    case RIEMANN_UPWINDED_ROE:
+      PetscCall(ComputeUpwindedTracerRoeFlux(datal, datar, sn_vec_int, cn_vec_int, flux_vec_int, amax_vec_int));
       break;
     default:
       PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Unsupported Riemann solver");

--- a/src/tracer/tracer_roe_flux_ceed.h
+++ b/src/tracer/tracer_roe_flux_ceed.h
@@ -108,8 +108,8 @@ CEED_QFUNCTION_HELPER void TracerRiemannFlux_Roe(const CeedScalar gravity, const
 /// computes the flux across an edge using Roe's approximate Riemann solver
 /// for flow, with upwind tracer transport
 CEED_QFUNCTION_HELPER void TracerRiemannFlux_UpwindRoe(const CeedScalar gravity, const CeedScalar tiny_h, TracerState qL, TracerState qR,
-                                                         CeedScalar sn, CeedScalar cn, CeedInt flow_ndof, CeedInt tracer_ndof, CeedScalar flux[],
-                                                         CeedScalar *amax) {
+                                                       CeedScalar sn, CeedScalar cn, CeedInt flow_ndof, CeedInt tracer_ndof, CeedScalar flux[],
+                                                       CeedScalar *amax) {
   const CeedScalar hl = qL.h, hr = qR.h;
   const CeedScalar ul = SafeDiv(qL.hu, hl, hl, tiny_h);
   const CeedScalar vl = SafeDiv(qL.hv, hl, hl, tiny_h);
@@ -156,7 +156,7 @@ CEED_QFUNCTION_HELPER void TracerRiemannFlux_UpwindRoe(const CeedScalar gravity,
   // upwind tracer flux: use Roe h-flux to determine upwind direction
   CeedScalar Fh_num_roe = flux[0];
   for (CeedInt j = 0; j < tracer_ndof; j++) {
-    CeedScalar Cup    = (Fh_num_roe >= 0.0) ? cil[j] : cir[j];
+    CeedScalar Cup      = (Fh_num_roe >= 0.0) ? cil[j] : cir[j];
     flux[flow_ndof + j] = Fh_num_roe * Cup;
   }
 

--- a/src/tracer/tracer_roe_flux_ceed.h
+++ b/src/tracer/tracer_roe_flux_ceed.h
@@ -105,6 +105,65 @@ CEED_QFUNCTION_HELPER void TracerRiemannFlux_Roe(const CeedScalar gravity, const
   *amax = amax_swe;
 }
 
+/// computes the flux across an edge using Roe's approximate Riemann solver
+/// for flow, with upwinded tracer transport
+CEED_QFUNCTION_HELPER void TracerRiemannFlux_UpwindedRoe(const CeedScalar gravity, const CeedScalar tiny_h, TracerState qL, TracerState qR,
+                                                         CeedScalar sn, CeedScalar cn, CeedInt flow_ndof, CeedInt tracer_ndof, CeedScalar flux[],
+                                                         CeedScalar *amax) {
+  const CeedScalar hl = qL.h, hr = qR.h;
+  const CeedScalar ul = SafeDiv(qL.hu, hl, hl, tiny_h);
+  const CeedScalar vl = SafeDiv(qL.hv, hl, hl, tiny_h);
+  CeedScalar       cil[MAX_NUM_TRACERS], cir[MAX_NUM_TRACERS];
+  for (CeedInt j = 0; j < tracer_ndof; ++j) {
+    cil[j] = SafeDiv(qL.hci[j], hl, hl, tiny_h);
+    cir[j] = SafeDiv(qR.hci[j], hr, hl, tiny_h);
+  }
+  const CeedScalar ur = SafeDiv(qR.hu, hr, hr, tiny_h);
+  const CeedScalar vr = SafeDiv(qR.hv, hr, hr, tiny_h);
+
+  // compute the eigenspectrum for the shallow water equations
+  CeedScalar A_swe[3], R_swe[3][3], dW_swe[3], amax_swe;
+  ComputeSWEEigenspectrum_Roe(hl, ul, vl, hr, ur, vr, sn, cn, gravity, A_swe, R_swe, dW_swe, &amax_swe);
+
+  CeedScalar uperpl = ul * cn + vl * sn;
+  CeedScalar uperpr = ur * cn + vr * sn;
+
+  CeedScalar FL[MAX_NUM_FIELD_COMPONENTS] = {0};
+  CeedScalar FR[MAX_NUM_FIELD_COMPONENTS] = {0};
+
+  // compute interface fluxes
+  FL[0] = uperpl * hl;
+  FL[1] = ul * uperpl * hl + 0.5 * gravity * hl * hl * cn;
+  FL[2] = vl * uperpl * hl + 0.5 * gravity * hl * hl * sn;
+
+  FR[0] = uperpr * hr;
+  FR[1] = ur * uperpr * hr + 0.5 * gravity * hr * hr * cn;
+  FR[2] = vr * uperpr * hr + 0.5 * gravity * hr * hr * sn;
+
+  for (CeedInt j = 0; j < tracer_ndof; j++) {
+    FL[j + 3] = hl * uperpl * cil[j];
+    FR[j + 3] = hr * uperpr * cir[j];
+  }
+
+  // compute Roe flux for flow components
+  for (CeedInt dof1 = 0; dof1 < flow_ndof; dof1++) {
+    flux[dof1] = 0.5 * (FL[dof1] + FR[dof1]);
+    for (CeedInt dof2 = 0; dof2 < flow_ndof; dof2++) {
+      flux[dof1] -= 0.5 * R_swe[dof1][dof2] * A_swe[dof2] * dW_swe[dof2];
+    }
+  }
+
+  // upwinded tracer flux: use Roe h-flux to determine upwind direction
+  CeedScalar Fh_num_roe = flux[0];
+  for (CeedInt j = 0; j < tracer_ndof; j++) {
+    CeedScalar Cup    = (Fh_num_roe >= 0.0) ? cil[j] : cir[j];
+    flux[flow_ndof + j] = Fh_num_roe * Cup;
+  }
+
+  // max wave speed
+  *amax = amax_swe;
+}
+
 #pragma GCC diagnostic   pop
 #pragma clang diagnostic pop
 

--- a/src/tracer/tracer_roe_flux_ceed.h
+++ b/src/tracer/tracer_roe_flux_ceed.h
@@ -106,8 +106,8 @@ CEED_QFUNCTION_HELPER void TracerRiemannFlux_Roe(const CeedScalar gravity, const
 }
 
 /// computes the flux across an edge using Roe's approximate Riemann solver
-/// for flow, with upwinded tracer transport
-CEED_QFUNCTION_HELPER void TracerRiemannFlux_UpwindedRoe(const CeedScalar gravity, const CeedScalar tiny_h, TracerState qL, TracerState qR,
+/// for flow, with upwind tracer transport
+CEED_QFUNCTION_HELPER void TracerRiemannFlux_UpwindRoe(const CeedScalar gravity, const CeedScalar tiny_h, TracerState qL, TracerState qR,
                                                          CeedScalar sn, CeedScalar cn, CeedInt flow_ndof, CeedInt tracer_ndof, CeedScalar flux[],
                                                          CeedScalar *amax) {
   const CeedScalar hl = qL.h, hr = qR.h;
@@ -153,7 +153,7 @@ CEED_QFUNCTION_HELPER void TracerRiemannFlux_UpwindedRoe(const CeedScalar gravit
     }
   }
 
-  // upwinded tracer flux: use Roe h-flux to determine upwind direction
+  // upwind tracer flux: use Roe h-flux to determine upwind direction
   CeedScalar Fh_num_roe = flux[0];
   for (CeedInt j = 0; j < tracer_ndof; j++) {
     CeedScalar Cup    = (Fh_num_roe >= 0.0) ? cil[j] : cir[j];

--- a/src/tracer/tracer_roe_flux_petsc.h
+++ b/src/tracer/tracer_roe_flux_petsc.h
@@ -117,4 +117,94 @@ static PetscErrorCode ComputeTracerRoeFlux(TracerRiemannStateData *datal, Tracer
 
   PetscFunctionReturn(PETSC_SUCCESS);
 }
+
+/// @brief Computes the flux for SWE and tracerss across the edge using Roe Riemann solve. The tracer flux is upwinded.
+/// @param [in] *datal A TracerRiemannStateData for values left of the edges
+/// @param [in] *datar A TracerRiemannStateData for values right of the edges
+/// @param [in] sn array containing sines of the angles between edges and y-axis
+/// @param [in] cn array containing cosines of the angles between edges and y-axis
+/// @param [out] fij array containing fluxes through edges
+/// @param [out] amax array storing maximum courant number on edges
+/// @return 0 on success, or a non-zero error code on failure
+static PetscErrorCode ComputeUpwindedTracerRoeFlux(TracerRiemannStateData *datal, TracerRiemannStateData *datar, const PetscReal *sn, const PetscReal *cn,
+                                           PetscReal *fij, PetscReal *amax) {
+  PetscFunctionBeginUser;
+
+  PetscReal *hl  = datal->h;
+  PetscReal *ul  = datal->u;
+  PetscReal *vl  = datal->v;
+  PetscReal *cil = datal->ci;
+
+  PetscReal *hr  = datar->h;
+  PetscReal *ur  = datar->u;
+  PetscReal *vr  = datar->v;
+  PetscReal *cir = datar->ci;
+
+  PetscAssert(datal->num_states == datar->num_states, PETSC_COMM_WORLD, PETSC_ERR_ARG_SIZ, "Size of data left and right of edges is not the same!");
+
+  PetscInt num_states    = datal->num_states;
+  PetscInt flow_ncomp    = datal->num_flow_comp;
+  PetscInt tracers_ncomp = datal->num_tracers_comp;
+  PetscInt soln_ncomp    = flow_ncomp + tracers_ncomp;
+
+  PetscInt ci_index_offset;
+
+  PetscReal A[MAX_NUM_FIELD_COMPONENTS]  = {0};
+  PetscReal FL[MAX_NUM_FIELD_COMPONENTS] = {0};
+  PetscReal FR[MAX_NUM_FIELD_COMPONENTS] = {0};
+
+  for (PetscInt i = 0; i < num_states; ++i) {
+    // compute the eigenspectrum for the shallow water equations
+    PetscReal A_swe[3], R_swe[3][3], dW_swe[3], amax_swe;
+    ComputeSWERoeEigenspectrum(hl[i], ul[i], vl[i], hr[i], ur[i], vr[i], sn[i], cn[i], A_swe, R_swe, dW_swe, &amax_swe);
+
+    PetscReal uperpl = ul[i] * cn[i] + vl[i] * sn[i];
+    PetscReal uperpr = ur[i] * cn[i] + vr[i] * sn[i];
+
+    A[0] = A_swe[0];
+    A[1] = A_swe[1];
+    A[2] = A_swe[2];
+    for (PetscInt j = 0; j < tracers_ncomp; j++) {
+      A[j + 3] = A[1];
+    }
+
+    // compute interface fluxes
+    FL[0] = uperpl * hl[i];
+    FL[1] = ul[i] * uperpl * hl[i] + 0.5 * GRAVITY * hl[i] * hl[i] * cn[i];
+    FL[2] = vl[i] * uperpl * hl[i] + 0.5 * GRAVITY * hl[i] * hl[i] * sn[i];
+
+    FR[0] = uperpr * hr[i];
+    FR[1] = ur[i] * uperpr * hr[i] + 0.5 * GRAVITY * hr[i] * hr[i] * cn[i];
+    FR[2] = vr[i] * uperpr * hr[i] + 0.5 * GRAVITY * hr[i] * hr[i] * sn[i];
+
+    ci_index_offset = i * tracers_ncomp;
+    for (PetscInt j = 0; j < tracers_ncomp; j++) {
+      FL[j + 3] = hl[i] * uperpl * cil[ci_index_offset + j];
+      FR[j + 3] = hr[i] * uperpr * cir[ci_index_offset + j];
+    }
+
+    PetscReal Fh_num_roe = 0.5 * (FL[0] + FR[0])
+                         - 0.5 * (R_swe[0][0] * A_swe[0] * dW_swe[0] + R_swe[0][1] * A_swe[1] * dW_swe[1] +
+                                  R_swe[0][2] * A_swe[2] * dW_swe[2]);
+
+    for (PetscInt dof1 = 0; dof1 < 3; dof1++) {
+      PetscReal Fnum = 0.5 * (FL[dof1] + FR[dof1])
+                     - 0.5 * (R_swe[dof1][0] * A_swe[0] * dW_swe[0] + R_swe[dof1][1] * A_swe[1] * dW_swe[1] +
+                              R_swe[dof1][2] * A_swe[2] * dW_swe[2]);
+      fij[soln_ncomp * i + dof1] = Fnum;
+    }
+
+    for (PetscInt j = 0; j < tracers_ncomp; j++) {
+      PetscReal cL  = cil[ci_index_offset + j];
+      PetscReal cR  = cir[ci_index_offset + j];
+      PetscReal Cup = (Fh_num_roe >= 0.0) ? cL : cR;
+      fij[soln_ncomp * i + (3 + j)] = Fh_num_roe * Cup;
+    }
+
+    amax[i] = amax_swe;
+  }
+
+  PetscFunctionReturn(PETSC_SUCCESS);
+}
+
 #endif

--- a/src/tracer/tracer_roe_flux_petsc.h
+++ b/src/tracer/tracer_roe_flux_petsc.h
@@ -118,7 +118,7 @@ static PetscErrorCode ComputeTracerRoeFlux(TracerRiemannStateData *datal, Tracer
   PetscFunctionReturn(PETSC_SUCCESS);
 }
 
-/// @brief Computes the flux for SWE and tracerss across the edge using Roe Riemann solve. The tracer flux is upwinded.
+/// @brief Computes the flux for SWE and tracerss across the edge using Roe Riemann solve. The tracer flux is upwind.
 /// @param [in] *datal A TracerRiemannStateData for values left of the edges
 /// @param [in] *datar A TracerRiemannStateData for values right of the edges
 /// @param [in] sn array containing sines of the angles between edges and y-axis
@@ -126,7 +126,7 @@ static PetscErrorCode ComputeTracerRoeFlux(TracerRiemannStateData *datal, Tracer
 /// @param [out] fij array containing fluxes through edges
 /// @param [out] amax array storing maximum courant number on edges
 /// @return 0 on success, or a non-zero error code on failure
-static PetscErrorCode ComputeUpwindedTracerRoeFlux(TracerRiemannStateData *datal, TracerRiemannStateData *datar, const PetscReal *sn, const PetscReal *cn,
+static PetscErrorCode ComputeUpwindTracerRoeFlux(TracerRiemannStateData *datal, TracerRiemannStateData *datar, const PetscReal *sn, const PetscReal *cn,
                                            PetscReal *fij, PetscReal *amax) {
   PetscFunctionBeginUser;
 

--- a/src/tracer/tracer_roe_flux_petsc.h
+++ b/src/tracer/tracer_roe_flux_petsc.h
@@ -126,8 +126,8 @@ static PetscErrorCode ComputeTracerRoeFlux(TracerRiemannStateData *datal, Tracer
 /// @param [out] fij array containing fluxes through edges
 /// @param [out] amax array storing maximum courant number on edges
 /// @return 0 on success, or a non-zero error code on failure
-static PetscErrorCode ComputeUpwindTracerRoeFlux(TracerRiemannStateData *datal, TracerRiemannStateData *datar, const PetscReal *sn, const PetscReal *cn,
-                                           PetscReal *fij, PetscReal *amax) {
+static PetscErrorCode ComputeUpwindTracerRoeFlux(TracerRiemannStateData *datal, TracerRiemannStateData *datar, const PetscReal *sn,
+                                                 const PetscReal *cn, PetscReal *fij, PetscReal *amax) {
   PetscFunctionBeginUser;
 
   PetscReal *hl  = datal->h;
@@ -183,21 +183,19 @@ static PetscErrorCode ComputeUpwindTracerRoeFlux(TracerRiemannStateData *datal, 
       FR[j + 3] = hr[i] * uperpr * cir[ci_index_offset + j];
     }
 
-    PetscReal Fh_num_roe = 0.5 * (FL[0] + FR[0])
-                         - 0.5 * (R_swe[0][0] * A_swe[0] * dW_swe[0] + R_swe[0][1] * A_swe[1] * dW_swe[1] +
-                                  R_swe[0][2] * A_swe[2] * dW_swe[2]);
+    PetscReal Fh_num_roe =
+        0.5 * (FL[0] + FR[0]) - 0.5 * (R_swe[0][0] * A_swe[0] * dW_swe[0] + R_swe[0][1] * A_swe[1] * dW_swe[1] + R_swe[0][2] * A_swe[2] * dW_swe[2]);
 
     for (PetscInt dof1 = 0; dof1 < 3; dof1++) {
-      PetscReal Fnum = 0.5 * (FL[dof1] + FR[dof1])
-                     - 0.5 * (R_swe[dof1][0] * A_swe[0] * dW_swe[0] + R_swe[dof1][1] * A_swe[1] * dW_swe[1] +
-                              R_swe[dof1][2] * A_swe[2] * dW_swe[2]);
+      PetscReal Fnum = 0.5 * (FL[dof1] + FR[dof1]) -
+                       0.5 * (R_swe[dof1][0] * A_swe[0] * dW_swe[0] + R_swe[dof1][1] * A_swe[1] * dW_swe[1] + R_swe[dof1][2] * A_swe[2] * dW_swe[2]);
       fij[soln_ncomp * i + dof1] = Fnum;
     }
 
     for (PetscInt j = 0; j < tracers_ncomp; j++) {
-      PetscReal cL  = cil[ci_index_offset + j];
-      PetscReal cR  = cir[ci_index_offset + j];
-      PetscReal Cup = (Fh_num_roe >= 0.0) ? cL : cR;
+      PetscReal cL                  = cil[ci_index_offset + j];
+      PetscReal cR                  = cir[ci_index_offset + j];
+      PetscReal Cup                 = (Fh_num_roe >= 0.0) ? cL : cR;
       fij[soln_ncomp * i + (3 + j)] = Fh_num_roe * Cup;
     }
 

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -122,8 +122,9 @@ static const cyaml_strval_t numerics_temporal_types[] = {
 
 // mapping of strings to numerics riemann solver types
 static const cyaml_strval_t numerics_riemann_types[] = {
-    {"roe",  RIEMANN_ROE },
-    {"hllc", RIEMANN_HLLC},
+    {"roe",           RIEMANN_ROE },
+    {"upwinded_roe",  RIEMANN_UPWINDED_ROE },
+    {"hllc",          RIEMANN_HLLC},
 };
 
 // mapping of numerics fields to members of RDyNumericsSection
@@ -926,8 +927,8 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
   if (config->numerics.temporal == TEMPORAL_BEULER) {
     PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "The backward euler temporal method (BEULER) is not implemented.");
   }
-  if (config->numerics.riemann != RIEMANN_ROE) {
-    PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Only the roe riemann solver (ROE) is currently implemented.");
+  if (config->numerics.riemann != RIEMANN_ROE && config->numerics.riemann != RIEMANN_UPWINDED_ROE) {
+    PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Only the roe riemann solver (ROE) and upwinded roe riemann solver (UPWINDED_ROE) are currently implemented.");
   }
 
   PetscCheck(strlen(config->grid.file), comm, PETSC_ERR_USER, "grid.file not specified!");

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -928,7 +928,8 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
     PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "The backward euler temporal method (BEULER) is not implemented.");
   }
   if (config->numerics.riemann != RIEMANN_ROE && config->numerics.riemann != RIEMANN_UPWIND_ROE) {
-    PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Only the roe riemann solver (ROE) and upwind roe riemann solver (UPWIND_ROE) are currently implemented.");
+    PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER,
+               "Only the roe riemann solver (ROE) and upwinded roe riemann solver (UPWIND_ROE) are currently implemented.");
   }
 
   PetscCheck(strlen(config->grid.file), comm, PETSC_ERR_USER, "grid.file not specified!");

--- a/src/yaml_input.c
+++ b/src/yaml_input.c
@@ -123,7 +123,7 @@ static const cyaml_strval_t numerics_temporal_types[] = {
 // mapping of strings to numerics riemann solver types
 static const cyaml_strval_t numerics_riemann_types[] = {
     {"roe",           RIEMANN_ROE },
-    {"upwinded_roe",  RIEMANN_UPWINDED_ROE },
+    {"upwind_roe",  RIEMANN_UPWIND_ROE },
     {"hllc",          RIEMANN_HLLC},
 };
 
@@ -927,8 +927,8 @@ static PetscErrorCode ValidateConfig(MPI_Comm comm, RDyConfig *config, PetscBool
   if (config->numerics.temporal == TEMPORAL_BEULER) {
     PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "The backward euler temporal method (BEULER) is not implemented.");
   }
-  if (config->numerics.riemann != RIEMANN_ROE && config->numerics.riemann != RIEMANN_UPWINDED_ROE) {
-    PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Only the roe riemann solver (ROE) and upwinded roe riemann solver (UPWINDED_ROE) are currently implemented.");
+  if (config->numerics.riemann != RIEMANN_ROE && config->numerics.riemann != RIEMANN_UPWIND_ROE) {
+    PetscCheck(PETSC_FALSE, comm, PETSC_ERR_USER, "Only the roe riemann solver (ROE) and upwind roe riemann solver (UPWIND_ROE) are currently implemented.");
   }
 
   PetscCheck(strlen(config->grid.file), comm, PETSC_ERR_USER, "grid.file not specified!");


### PR DESCRIPTION
- This PR implements the upwind Roe Riemann solver that Dongyu implemented in his branch.
- The upwind Roe Riemann solver is implemented for PETSc and CEED version
- An MMS test for the upwind solver is added
   - The test is based on the existing MMS solver with default Roe Riemann solver
   - The L2 error tolerance for the upwind Roe solver is slightly lower (0.92) than for the default solver (0.93).