### PR TITLE
Fixes bug due to BS2002

### DIFF
--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -684,9 +684,15 @@ PetscErrorCode CreateCeedEtaVerticesVector(RDyMesh *mesh, CeedVector *eta_vertic
                                           CEED_COPY_VALUES, eta_offset, &eta_restrict));
   if (0) CeedElemRestrictionView(eta_restrict, stdout);
 
-  // create the vector
+  // create the vector and initialize with vertex z-values so that
+  // ComputeDhv returns 0 when no eta operator updates it (WELL_BALANCING_NONE)
   PetscCallCEED(CeedElemRestrictionCreateVector(eta_restrict, eta_vertices, NULL));
-  PetscCallCEED(CeedVectorSetValue(*eta_vertices, 0.0));
+  CeedScalar *eta_array;
+  PetscCallCEED(CeedVectorGetArray(*eta_vertices, CEED_MEM_HOST, &eta_array));
+  for (CeedInt v = 0; v < num_vertices; v++) {
+    eta_array[v * num_comp_eta] = vertices->points[v].X[2];
+  }
+  PetscCallCEED(CeedVectorRestoreArray(*eta_vertices, &eta_array));
 
   // clean up
   PetscCallCEED(CeedElemRestrictionDestroy(&eta_restrict));

--- a/src/operator_fluxes_ceed.c
+++ b/src/operator_fluxes_ceed.c
@@ -687,6 +687,7 @@ PetscErrorCode CreateCeedEtaVerticesVector(RDyMesh *mesh, CeedVector *eta_vertic
   // create the vector and initialize with vertex z-values so that
   // ComputeDhv returns 0 when no eta operator updates it (WELL_BALANCING_NONE)
   PetscCallCEED(CeedElemRestrictionCreateVector(eta_restrict, eta_vertices, NULL));
+  PetscCallCEED(CeedVectorSetValue(*eta_vertices, 0.0));
   CeedScalar *eta_array;
   PetscCallCEED(CeedVectorGetArray(*eta_vertices, CEED_MEM_HOST, &eta_array));
   for (CeedInt v = 0; v < num_vertices; v++) {

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -50,7 +50,8 @@ CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const 
   const CeedScalar(*eta_vert_end)[CEED_Q_VLA] = (const CeedScalar(*)[CEED_Q_VLA])in[4];
   CeedScalar(*cell_L)[CEED_Q_VLA]             = (CeedScalar(*)[CEED_Q_VLA])out[0];
   CeedScalar(*cell_R)[CEED_Q_VLA]             = (CeedScalar(*)[CEED_Q_VLA])out[1];
-  CeedScalar(*courant_num)[CEED_Q_VLA]        = (CeedScalar(*)[CEED_Q_VLA])out[2];
+  CeedScalar(*flux_out)[CEED_Q_VLA]           = (CeedScalar(*)[CEED_Q_VLA])out[2];
+  CeedScalar(*courant_num)[CEED_Q_VLA]        = (CeedScalar(*)[CEED_Q_VLA])out[3];
   const SWEContext context                    = (SWEContext)ctx;
 
   const CeedScalar dt      = context->dtime;
@@ -76,15 +77,17 @@ CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const 
           PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
       }
       for (CeedInt j = 0; j < 3; j++) {
-        cell_L[j][i] = flux[j] * geom[2][i];
-        cell_R[j][i] = flux[j] * geom[3][i];
+        cell_L[j][i]    = flux[j] * geom[2][i];
+        cell_R[j][i]    = flux[j] * geom[3][i];
+        flux_out[j][i]  = flux[j];
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
       courant_num[1][i] = amax * geom[3][i] * dt;
     } else {
       for (CeedInt j = 0; j < 3; j++) {
-        cell_L[j][i] = 0.0;
-        cell_R[j][i] = 0.0;
+        cell_L[j][i]   = 0.0;
+        cell_R[j][i]   = 0.0;
+        flux_out[j][i] = 0.0;
       }
       courant_num[0][i] = 0.0;
       courant_num[1][i] = 0.0;

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -77,9 +77,9 @@ CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const 
           PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
       }
       for (CeedInt j = 0; j < 3; j++) {
-        cell_L[j][i]    = flux[j] * geom[2][i];
-        cell_R[j][i]    = flux[j] * geom[3][i];
-        flux_out[j][i]  = flux[j];
+        cell_L[j][i]   = flux[j] * geom[2][i];
+        cell_R[j][i]   = flux[j] * geom[3][i];
+        flux_out[j][i] = flux[j];
       }
       courant_num[0][i] = -amax * geom[2][i] * dt;
       courant_num[1][i] = amax * geom[3][i] * dt;

--- a/src/swe/swe_fluxes_ceed.h
+++ b/src/swe/swe_fluxes_ceed.h
@@ -74,7 +74,7 @@ CEED_QFUNCTION_HELPER int SWEFlux(void *ctx, CeedInt Q, const CeedScalar *const 
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, geom[0][i], geom[1][i], dhv, flux, &amax);
           break;
         default:
-          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
+          return 1;
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i]   = flux[j] * geom[2][i];
@@ -132,7 +132,7 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Dirichlet(void *ctx, CeedInt Q, const 
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, geom[0][i], geom[1][i], dhv, flux, &amax);
           break;
         default:
-          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
+          return 1;
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i]    = flux[j] * geom[2][i];
@@ -188,7 +188,7 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Reflecting(void *ctx, CeedInt Q, const
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, sn, cn, dhv, flux, &amax);
           break;
         default:
-          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
+          return 1;
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i]    = flux[j] * geom[2][i];
@@ -247,7 +247,7 @@ CEED_QFUNCTION_HELPER int SWEBoundaryFlux_Outflow(void *ctx, CeedInt Q, const Ce
           SWERiemannFlux_Roe(gravity, tiny_h, h_anuga, qL, qR, sn, cn, dhv, flux, &amax);
           break;
         default:
-          PetscCheck(PETSC_FALSE, PETSC_COMM_WORLD, PETSC_ERR_USER, "Unsupported Riemann solver");
+          return 1;
       }
       for (CeedInt j = 0; j < 3; j++) {
         cell_L[j][i]    = flux[j] * geom[2][i];


### PR DESCRIPTION
Instead of assigning `eta` values as zero for the case BS2002 is not selected, the values are set
to the elevation of vertices. This ensures that `dhv` is zero when BS2002 is not used.

Fixes #385 