### PR TITLE
Use the cell-centered elevation provided in a file for solver

### DIFF
--- a/src/operator_fluxes_hydro_recon_ceed.c
+++ b/src/operator_fluxes_hydro_recon_ceed.c
@@ -118,24 +118,31 @@ static PetscErrorCode CreateCeedInteriorFluxHydroReconSuboperator(const RDyConfi
       g[owned_edge][HR_INTERIOR_NEG_L_OVER_AL] = -edges->lengths[iedge] / cells->areas[l];
       g[owned_edge][HR_INTERIOR_L_OVER_AR]     = edges->lengths[iedge] / cells->areas[r];
 
-      // Use vertex-averaged z for cell bed elevation.  DMPlex's centroid z
-      // (from DMPlexComputeCellGeometryFVM) differs from the vertex average
-      // for non-planar quads, which breaks lake-at-rest consistency with ICs
-      // computed as h = eta - mean(vertex_z).
-      CeedScalar zc_l = 0.0;
-      for (CeedInt v = cells->vertex_offsets[l]; v < cells->vertex_offsets[l + 1]; v++) {
-        zc_l += vertices->points[cells->vertex_ids[v]].X[2];
-      }
-      zc_l /= (CeedScalar)cells->num_vertices[l];
+      if (config.grid.cell_elevation.file[0]) {
+        // use cell-centered z from file if provided
+        g[owned_edge][HR_INTERIOR_ZC_LEFT]  = cells->centroids[l].X[2];
+        g[owned_edge][HR_INTERIOR_ZC_RIGHT] = cells->centroids[r].X[2];
 
-      CeedScalar zc_r = 0.0;
-      for (CeedInt v = cells->vertex_offsets[r]; v < cells->vertex_offsets[r + 1]; v++) {
-        zc_r += vertices->points[cells->vertex_ids[v]].X[2];
-      }
-      zc_r /= (CeedScalar)cells->num_vertices[r];
+      } else {
+        // Use vertex-averaged z for cell bed elevation.  DMPlex's centroid z
+        // (from DMPlexComputeCellGeometryFVM) differs from the vertex average
+        // for non-planar quads, which breaks lake-at-rest consistency with ICs
+        // computed as h = eta - mean(vertex_z).
+        CeedScalar zc_l = 0.0;
+        for (CeedInt v = cells->vertex_offsets[l]; v < cells->vertex_offsets[l + 1]; v++) {
+          zc_l += vertices->points[cells->vertex_ids[v]].X[2];
+        }
+        zc_l /= (CeedScalar)cells->num_vertices[l];
 
-      g[owned_edge][HR_INTERIOR_ZC_LEFT]  = zc_l;
-      g[owned_edge][HR_INTERIOR_ZC_RIGHT] = zc_r;
+        CeedScalar zc_r = 0.0;
+        for (CeedInt v = cells->vertex_offsets[r]; v < cells->vertex_offsets[r + 1]; v++) {
+          zc_r += vertices->points[cells->vertex_ids[v]].X[2];
+        }
+        zc_r /= (CeedScalar)cells->num_vertices[r];
+
+        g[owned_edge][HR_INTERIOR_ZC_LEFT]  = zc_l;
+        g[owned_edge][HR_INTERIOR_ZC_RIGHT] = zc_r;
+      }
 
       owned_edge++;
     }

--- a/src/swe/swe_petsc.c
+++ b/src/swe/swe_petsc.c
@@ -1015,11 +1015,17 @@ PetscErrorCode CreatePetscSWEInteriorFluxHROperator(RDyMesh *mesh, const RDyConf
   RDyVertices *vertices = &mesh->vertices;
   PetscCall(PetscCalloc1(mesh->num_cells, &op->zc));
   for (PetscInt c = 0; c < mesh->num_cells; c++) {
-    PetscReal z_sum = 0.0;
-    for (PetscInt v = cells->vertex_offsets[c]; v < cells->vertex_offsets[c + 1]; v++) {
-      z_sum += vertices->points[cells->vertex_ids[v]].X[2];
+    if (config.grid.cell_elevation.file[0]) {
+      // if cell elevation is provided via the file
+      op->zc[c] = cells->centroids[c].X[2];
+    } else {
+      // otherwise, compute vertex-averaged bed elevation
+      PetscReal z_sum = 0.0;
+      for (PetscInt v = cells->vertex_offsets[c]; v < cells->vertex_offsets[c + 1]; v++) {
+        z_sum += vertices->points[cells->vertex_ids[v]].X[2];
+      }
+      op->zc[c] = z_sum / (PetscReal)cells->num_vertices[c];
     }
-    op->zc[c] = z_sum / (PetscReal)cells->num_vertices[c];
   }
 
   PetscCall(PetscOperatorCreate(op, ApplyInteriorFluxHR, DestroyInteriorFluxHR, petsc_op));


### PR DESCRIPTION
For the hydrostatic reconstruction, instead of computing the cell centered elevation
from the elevation of vertices, use the value provided in the file.