### PR TITLE
Updates the computation of slope when elevation file is specified

### DIFF
--- a/include/private/rdycoreimpl.h
+++ b/include/private/rdycoreimpl.h
@@ -240,7 +240,7 @@ PETSC_INTERN PetscErrorCode ReadConfigFile(RDy);     // for RDycore driver only!
 PETSC_INTERN PetscErrorCode ReadMMSConfigFile(RDy);  // for MMS driver only!
 PETSC_INTERN PetscErrorCode InitBoundaries(RDy);
 PETSC_INTERN PetscErrorCode InitRegions(RDy);
-PETSC_INTERN PetscErrorCode OverrideCellElevation(RDy);
+PETSC_INTERN PetscErrorCode OverrideCellAttributes(RDy);
 PETSC_INTERN PetscErrorCode OverrideParameters(RDy);
 PETSC_INTERN PetscErrorCode PrintConfig(RDy);
 PETSC_INTERN PetscErrorCode DestroyConfig(RDy);

--- a/src/rdyamr.c
+++ b/src/rdyamr.c
@@ -651,7 +651,7 @@ PetscErrorCode RDyPerformAMR(RDy rdy) {
     PetscCall(RDyMeshOverride2DProjection(&rdy->mesh));
   }
   if (rdy->config.grid.cell_elevation.file[0]) {
-    PetscCall(OverrideCellElevation(rdy));
+    PetscCall(OverrideCellAttributes(rdy));
   }
 
   // initialize the refined solution from existing previous solution

--- a/src/rdymesh.c
+++ b/src/rdymesh.c
@@ -801,6 +801,7 @@ static PetscErrorCode ComputeAdditionalCellAttributes(DM dm, RDyMesh *mesh) {
 
   RDyCells    *cells    = &mesh->cells;
   RDyVertices *vertices = &mesh->vertices;
+  RDyEdges    *edges    = &mesh->edges;
 
   MPI_Comm comm;
   PetscCall(PetscObjectGetComm((PetscObject)dm, &comm));
@@ -855,6 +856,21 @@ static PetscErrorCode ComputeAdditionalCellAttributes(DM dm, RDyMesh *mesh) {
       }
       cells->dz_dx[icell] = cells->dz_dx[icell] / total_area;
       cells->dz_dy[icell] = cells->dz_dy[icell] / total_area;
+    }
+  }
+
+  // save the neighbor IDs for each owned cell
+  for (PetscInt icell = 0; icell < mesh->num_cells; icell++) {
+    if (cells->is_owned[icell]) {
+      for (PetscInt iedge = 0; iedge < cells->num_edges[icell]; iedge++) {
+        PetscInt edge_offset = cells->edge_offsets[icell];
+        PetscInt index       = cells->edge_ids[edge_offset + iedge];
+        PetscInt cell_up     = edges->cell_ids[2 * index];
+        PetscInt cell_dn     = edges->cell_ids[2 * index + 1];
+
+        PetscInt cell_offset                     = cells->neighbor_offsets[icell];
+        cells->neighbor_ids[cell_offset + iedge] = (cell_up == icell) ? cell_dn : cell_up;
+      }
     }
   }
 

--- a/src/rdymms.c
+++ b/src/rdymms.c
@@ -309,7 +309,7 @@ PetscErrorCode RDyMMSSetup(RDy rdy) {
     PetscCall(RDyMeshOverride2DProjection(&rdy->mesh));
   }
   if (rdy->config.grid.cell_elevation.file[0]) {
-    PetscCall(OverrideCellElevation(rdy));
+    PetscCall(OverrideCellAttributes(rdy));
   }
 
   RDyLogDebug(rdy, "Initializing regions...");

--- a/src/rdysetup.c
+++ b/src/rdysetup.c
@@ -1078,7 +1078,7 @@ static PetscErrorCode InitSolution(RDy rdy) {
 
 // overrides cell centroid elevations with values read from a binary file
 // (e.g., a pit-filled DEM)
-PetscErrorCode OverrideCellElevation(RDy rdy) {
+PetscErrorCode OverrideCellAttributes(RDy rdy) {
   PetscFunctionBegin;
 
   Vec local_elev;
@@ -1088,8 +1088,61 @@ PetscErrorCode OverrideCellElevation(RDy rdy) {
   PetscCall(VecGetArray(local_elev, &elev_ptr));
 
   RDyCells *cells = &rdy->mesh.cells;
+
+  // override the Z value at cell centroids
   for (PetscInt icell = 0; icell < rdy->mesh.num_cells; ++icell) {
     cells->centroids[icell].X[2] = elev_ptr[icell];
+  }
+
+  // the evaluation values typically are provided by D4 or D8 conditioning of the DEM,
+  // recompute dz/dx and dz/dy of owned cells by based on the updated cell centroid elevations
+  // of the neighbors and only use the downhill value
+  for (PetscInt icell = 0; icell < rdy->mesh.num_cells; ++icell) {
+    if (cells->is_owned[icell]) {
+      PetscReal x_cell = cells->centroids[icell].X[0];
+      PetscReal y_cell = cells->centroids[icell].X[1];
+      PetscReal z_cell = cells->centroids[icell].X[2];
+
+      PetscReal max_slope = 0.0;  // steepest downhill slope magnitude found so far (>= 0)
+      PetscReal best_dx = 0.0, best_dy = 0.0, best_dist = 0.0;
+      PetscBool found_downhill = PETSC_FALSE;
+
+      PetscInt cell_offset = cells->neighbor_offsets[icell];
+      for (PetscInt ineighbor = 0; ineighbor < cells->num_edges[icell]; ++ineighbor) {
+        PetscInt neighbor_id = cells->neighbor_ids[cell_offset + ineighbor];
+        if (neighbor_id > -1) {
+          PetscReal x_n = cells->centroids[neighbor_id].X[0];
+          PetscReal y_n = cells->centroids[neighbor_id].X[1];
+          PetscReal z_n = cells->centroids[neighbor_id].X[2];
+
+          PetscReal dx   = x_n - x_cell;
+          PetscReal dy   = y_n - y_cell;
+          PetscReal dist = PetscSqrtReal(dx * dx + dy * dy);
+
+          if (z_n < z_cell && dist > 0.0) {
+            PetscReal slope = (z_cell - z_n) / dist;  // positive downhill slope magnitude
+            if (slope > max_slope) {
+              max_slope      = slope;
+              best_dx        = dx;
+              best_dy        = dy;
+              best_dist      = dist;
+              found_downhill = PETSC_TRUE;
+            }
+          }
+        }
+      }
+
+      if (found_downhill) {
+        // project the steepest downhill slope onto x/y using the true (possibly non-axis-aligned)
+        // displacement vector; sign flipped so the result is uphill-positive, matching
+        // ComputeXYSlopesForTriangle's convention
+        cells->dz_dx[icell] = -max_slope * best_dx / best_dist;
+        cells->dz_dy[icell] = -max_slope * best_dy / best_dist;
+      } else {
+        cells->dz_dx[icell] = 0.0;
+        cells->dz_dy[icell] = 0.0;
+      }
+    }
   }
 
   PetscCall(VecRestoreArray(local_elev, &elev_ptr));
@@ -1508,7 +1561,7 @@ PetscErrorCode RDySetup(RDy rdy) {
     PetscCall(RDyMeshOverride2DProjection(&rdy->mesh));
   }
   if (rdy->config.grid.cell_elevation.file[0]) {
-    PetscCall(OverrideCellElevation(rdy));
+    PetscCall(OverrideCellAttributes(rdy));
   }
   PetscCall(OutputPartitionStatistics(rdy));
 


### PR DESCRIPTION

The cell-centered elevation file is typically specified for D4-conditioned mesh and
includes the elevation values at cell-centers. Given those updated cell centered elevation
values, the slope (dz/dx and dz/dy) are recomputed for each owned cell. For a given cell,
only the steepest decrease in the elevation of it's neighboring cell is used to compute the slope.